### PR TITLE
feat: 矢量化流水线质量优化——亚像素边界修正与贝塞尔拟合修复

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources(chromaprint3d PRIVATE
     src/imgproc/boundary_graph.cpp
     src/imgproc/contour_assembly.cpp
     src/imgproc/curve_fitting.cpp
+    src/imgproc/subpixel_refine.cpp
     src/imgproc/thin_line_vectorizer.cpp
     src/imgproc/vectorize_potrace_pipeline.cpp
     src/imgproc/vectorizer.cpp

--- a/core/include/chromaprint3d/vectorizer.h
+++ b/core/include/chromaprint3d/vectorizer.h
@@ -41,6 +41,10 @@ struct VectorizerConfig {
     float max_merge_color_dist =
         200.0f; ///< Max LAB ΔE² for small-region merging (higher = merge more aggressively).
 
+    // ── Subpixel boundary refinement ────────────────────────────────────────
+    bool enable_subpixel_refine     = true; ///< Gradient-guided sub-pixel boundary refinement.
+    float subpixel_max_displacement = 0.7f; ///< Max normal displacement for sub-pixel refine (px).
+
     // ── Thin-line enhancement ───────────────────────────────────────────────
     float thin_line_max_radius =
         2.5f; ///< Distance-transform radius threshold for thin-line extraction.

--- a/core/src/imgproc/contour_assembly.cpp
+++ b/core/src/imgproc/contour_assembly.cpp
@@ -203,12 +203,59 @@ std::vector<std::vector<Vec2f>> ChainEdgesIntoLoops(const BoundaryGraph& graph,
     return loops;
 }
 
+// Remove near-collinear interior points to clean up residual zigzag
+// from the crack grid after subpixel refinement.
+void DecimateNearCollinear(std::vector<Vec2f>& pts, float epsilon) {
+    constexpr int kMinPoints = 6;
+    constexpr int kMaxPasses = 3;
+    const float eps_sq       = epsilon * epsilon;
+
+    for (int pass = 0; pass < kMaxPasses; ++pass) {
+        int n = static_cast<int>(pts.size());
+        if (n <= kMinPoints) break;
+
+        std::vector<bool> remove(static_cast<size_t>(n), false);
+        bool prev_removed = false;
+        int count         = 0;
+
+        for (int i = 0; i < n; ++i) {
+            if (prev_removed) {
+                prev_removed = false;
+                continue;
+            }
+            int prev        = ((i - 1) % n + n) % n;
+            int next        = (i + 1) % n;
+            Vec2f ab        = pts[static_cast<size_t>(next)] - pts[static_cast<size_t>(prev)];
+            float ab_len_sq = ab.LengthSquared();
+            if (ab_len_sq < 1e-12f) continue;
+            Vec2f ap      = pts[static_cast<size_t>(i)] - pts[static_cast<size_t>(prev)];
+            float cross   = ap.x * ab.y - ap.y * ab.x;
+            float dist_sq = (cross * cross) / ab_len_sq;
+
+            if (dist_sq < eps_sq && (n - count) > kMinPoints) {
+                remove[static_cast<size_t>(i)] = true;
+                prev_removed                   = true;
+                ++count;
+            }
+        }
+
+        if (count == 0) break;
+
+        std::vector<Vec2f> result;
+        result.reserve(static_cast<size_t>(n - count));
+        for (int i = 0; i < n; ++i) {
+            if (!remove[static_cast<size_t>(i)]) result.push_back(pts[static_cast<size_t>(i)]);
+        }
+        pts = std::move(result);
+    }
+}
+
 void SmoothClosedLoop(std::vector<Vec2f>& pts, float max_displacement, int iterations) {
     if (pts.size() < 5) return;
-    const int n                       = static_cast<int>(pts.size());
-    const std::vector<Vec2f> original = pts;
+    const int n = static_cast<int>(pts.size());
 
     for (int iter = 0; iter < iterations; ++iter) {
+        std::vector<Vec2f> prev_pts = pts;
         std::vector<Vec2f> smoothed(n);
         for (int i = 0; i < n; ++i) {
             int im2 = ((i - 2) % n + n) % n;
@@ -220,10 +267,10 @@ void SmoothClosedLoop(std::vector<Vec2f>& pts, float max_displacement, int itera
                 (1.0f / 16.0f);
         }
         for (int i = 0; i < n; ++i) {
-            Vec2f delta = smoothed[i] - original[i];
+            Vec2f delta = smoothed[i] - prev_pts[i];
             float dist  = delta.Length();
             if (dist > max_displacement) {
-                smoothed[i] = original[i] + delta * (max_displacement / dist);
+                smoothed[i] = prev_pts[i] + delta * (max_displacement / dist);
             }
         }
         pts = std::move(smoothed);
@@ -257,9 +304,13 @@ std::vector<VectorizedShape> AssembleContoursFromGraph(const BoundaryGraph& grap
             continue;
         }
 
+        constexpr float kDecimateEpsilon       = 0.15f;
         constexpr float kSmoothMaxDisplacement = 0.5f;
         constexpr int kSmoothIterations        = 2;
-        for (auto& lp : loops) { SmoothClosedLoop(lp, kSmoothMaxDisplacement, kSmoothIterations); }
+        for (auto& lp : loops) {
+            DecimateNearCollinear(lp, kDecimateEpsilon);
+            SmoothClosedLoop(lp, kSmoothMaxDisplacement, kSmoothIterations);
+        }
 
         // Classify loops as outer (CCW, positive area) or hole (CW, negative area)
         struct ClassifiedLoop {

--- a/core/src/imgproc/contour_assembly.cpp
+++ b/core/src/imgproc/contour_assembly.cpp
@@ -257,7 +257,7 @@ std::vector<VectorizedShape> AssembleContoursFromGraph(const BoundaryGraph& grap
             continue;
         }
 
-        constexpr float kSmoothMaxDisplacement = 0.8f;
+        constexpr float kSmoothMaxDisplacement = 0.5f;
         constexpr int kSmoothIterations        = 2;
         for (auto& lp : loops) { SmoothClosedLoop(lp, kSmoothMaxDisplacement, kSmoothIterations); }
 

--- a/core/src/imgproc/curve_fitting.cpp
+++ b/core/src/imgproc/curve_fitting.cpp
@@ -116,10 +116,10 @@ CubicBezier FitSingleBezier(const std::vector<Vec2f>& pts, const std::vector<flo
 
     float seg_len = (p3 - p0).Length();
     float eps     = seg_len * 1e-4f;
-    if (alpha1 < eps || alpha2 > -eps) {
+    if (alpha1 < eps || alpha2 < eps) {
         float dist = seg_len / 3.0f;
         alpha1     = dist;
-        alpha2     = -dist;
+        alpha2     = dist;
     }
 
     return {p0, p0 + tan_left * alpha1, p3 + tan_right * alpha2, p3};

--- a/core/src/imgproc/curve_fitting.h
+++ b/core/src/imgproc/curve_fitting.h
@@ -15,7 +15,7 @@ struct CurveFitConfig {
     int max_recursion_depth          = 8;
     int reparameterize_iterations    = 3;
     float corner_angle_threshold_deg = 135.0f;
-    int corner_neighbor_k            = 3;
+    int corner_neighbor_k            = 6;
 };
 
 /// Detect corner indices in a polyline based on angle threshold.

--- a/core/src/imgproc/subpixel_refine.cpp
+++ b/core/src/imgproc/subpixel_refine.cpp
@@ -1,0 +1,163 @@
+#include "imgproc/subpixel_refine.h"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <vector>
+
+namespace ChromaPrint3D::detail {
+
+namespace {
+
+cv::Vec3f BilinearSampleLab(const cv::Mat& lab, float fx, float fy) {
+    const int max_c = lab.cols - 1;
+    const int max_r = lab.rows - 1;
+
+    int x0  = static_cast<int>(std::floor(fx));
+    int y0  = static_cast<int>(std::floor(fy));
+    float u = fx - static_cast<float>(x0);
+    float v = fy - static_cast<float>(y0);
+
+    x0     = std::clamp(x0, 0, max_c);
+    y0     = std::clamp(y0, 0, max_r);
+    int x1 = std::min(x0 + 1, max_c);
+    int y1 = std::min(y0 + 1, max_r);
+
+    const cv::Vec3f& p00 = lab.at<cv::Vec3f>(y0, x0);
+    const cv::Vec3f& p01 = lab.at<cv::Vec3f>(y0, x1);
+    const cv::Vec3f& p10 = lab.at<cv::Vec3f>(y1, x0);
+    const cv::Vec3f& p11 = lab.at<cv::Vec3f>(y1, x1);
+
+    float w00 = (1.0f - u) * (1.0f - v);
+    float w01 = u * (1.0f - v);
+    float w10 = (1.0f - u) * v;
+    float w11 = u * v;
+
+    return p00 * w00 + p01 * w01 + p10 * w10 + p11 * w11;
+}
+
+float LabDeltaE(const cv::Vec3f& a, const cv::Vec3f& b) {
+    float dL = a[0] - b[0];
+    float da = a[1] - b[1];
+    float db = a[2] - b[2];
+    return std::sqrt(dL * dL + da * da + db * db);
+}
+
+} // namespace
+
+void RefineEdgesSubpixel(BoundaryGraph& graph, const cv::Mat& lab,
+                         const SubpixelRefineConfig& cfg) {
+    if (lab.empty() || lab.type() != CV_32FC3 || graph.edges.empty()) {
+        spdlog::debug("RefineEdgesSubpixel skipped: lab_empty={}, edges={}", lab.empty(),
+                      graph.edges.size());
+        return;
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+
+    const int num_samples = std::max(3, cfg.num_samples | 1); // ensure odd
+    const float range     = std::max(0.1f, cfg.sample_range);
+    const float step      = 2.0f * range / static_cast<float>(num_samples - 1);
+    const float max_disp  = std::max(0.0f, cfg.max_displacement);
+    const float min_grad  = std::max(0.0f, cfg.min_gradient);
+    const int tw          = std::max(1, cfg.tangent_window);
+
+    std::vector<float> offsets(static_cast<size_t>(num_samples));
+    for (int j = 0; j < num_samples; ++j) {
+        offsets[static_cast<size_t>(j)] = -range + static_cast<float>(j) * step;
+    }
+
+    const int num_grads = num_samples - 1;
+    std::vector<float> grad_centers(static_cast<size_t>(num_grads));
+    for (int j = 0; j < num_grads; ++j) {
+        grad_centers[static_cast<size_t>(j)] =
+            0.5f * (offsets[static_cast<size_t>(j)] + offsets[static_cast<size_t>(j + 1)]);
+    }
+
+    int total_points  = 0;
+    int shifted_count = 0;
+    int skipped_short = 0;
+
+    std::vector<cv::Vec3f> samples(static_cast<size_t>(num_samples));
+    std::vector<float> grads(static_cast<size_t>(num_grads));
+
+    for (auto& edge : graph.edges) {
+        const int n = static_cast<int>(edge.points.size());
+        if (n < 5) {
+            ++skipped_short;
+            continue;
+        }
+
+        for (int i = 1; i < n - 1; ++i) {
+            ++total_points;
+            const Vec2f& p = edge.points[static_cast<size_t>(i)];
+
+            // 1. Local tangent from neighbour window
+            int k         = std::min(tw, std::min(i, n - 1 - i));
+            Vec2f ahead   = edge.points[static_cast<size_t>(i + k)];
+            Vec2f behind  = edge.points[static_cast<size_t>(i - k)];
+            Vec2f tangent = ahead - behind;
+            float tlen    = tangent.Length();
+            if (tlen < 1e-6f) continue;
+            tangent = tangent / tlen;
+
+            // 2. Normal (90-deg CCW rotation of tangent)
+            Vec2f normal{-tangent.y, tangent.x};
+
+            // 3. Sample LAB image along normal
+            for (int j = 0; j < num_samples; ++j) {
+                float t                         = offsets[static_cast<size_t>(j)];
+                float sx                        = p.x + normal.x * t;
+                float sy                        = p.y + normal.y * t;
+                samples[static_cast<size_t>(j)] = BilinearSampleLab(lab, sx, sy);
+            }
+
+            // 4. Gradient profile (deltaE between consecutive samples)
+            int max_j    = 0;
+            float max_gv = 0.0f;
+            for (int j = 0; j < num_grads; ++j) {
+                float g = LabDeltaE(samples[static_cast<size_t>(j)],
+                                    samples[static_cast<size_t>(j + 1)]) /
+                          step;
+                grads[static_cast<size_t>(j)] = g;
+                if (g > max_gv) {
+                    max_gv = g;
+                    max_j  = j;
+                }
+            }
+
+            if (max_gv < min_grad) continue;
+
+            // 5. Parabolic interpolation around the peak
+            float peak_t = grad_centers[static_cast<size_t>(max_j)];
+            if (max_j > 0 && max_j < num_grads - 1) {
+                float a     = grads[static_cast<size_t>(max_j - 1)];
+                float b     = grads[static_cast<size_t>(max_j)];
+                float c     = grads[static_cast<size_t>(max_j + 1)];
+                float denom = a - 2.0f * b + c;
+                if (std::abs(denom) > 1e-6f) {
+                    float delta = 0.5f * (a - c) / denom;
+                    peak_t += delta * step;
+                }
+            }
+
+            // 6. Clamp and apply displacement
+            peak_t = std::clamp(peak_t, -max_disp, max_disp);
+            if (std::abs(peak_t) < 1e-4f) continue;
+
+            edge.points[static_cast<size_t>(i)] =
+                Vec2f{p.x + normal.x * peak_t, p.y + normal.y * peak_t};
+            ++shifted_count;
+        }
+    }
+
+    const auto elapsed_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+    spdlog::info("RefineEdgesSubpixel done: edges={}, total_pts={}, shifted={}, skipped_short={}, "
+                 "elapsed_ms={:.2f}",
+                 graph.edges.size(), total_points, shifted_count, skipped_short, elapsed_ms);
+}
+
+} // namespace ChromaPrint3D::detail

--- a/core/src/imgproc/subpixel_refine.h
+++ b/core/src/imgproc/subpixel_refine.h
@@ -1,0 +1,33 @@
+#pragma once
+
+/// \file subpixel_refine.h
+/// \brief Gradient-guided sub-pixel boundary refinement for BoundaryGraph edges.
+///
+/// After BuildBoundaryGraph produces crack-grid chains at integer coordinates,
+/// this pass shifts each interior point along its local normal to the position
+/// of maximum colour gradient in the original (unsmoothed) LAB image, recovering
+/// sub-pixel edge locations and eliminating the staircase artefact.
+
+#include "imgproc/boundary_graph.h"
+
+#include <opencv2/core.hpp>
+
+namespace ChromaPrint3D::detail {
+
+struct SubpixelRefineConfig {
+    float max_displacement = 0.7f; ///< Max shift along the normal (pixels).
+    int tangent_window     = 5;    ///< Neighbour radius for tangent estimation (points).
+    int num_samples        = 9;    ///< Sampling points along the normal.
+    float sample_range     = 1.0f; ///< Sampling half-range along the normal (pixels).
+    float min_gradient     = 3.0f; ///< Minimum gradient peak to apply a shift (LAB deltaE/px).
+};
+
+/// Refine BoundaryGraph edge points to sub-pixel positions using colour gradients.
+///
+/// Junction nodes (first/last point of each edge) are kept fixed to preserve
+/// the multi-label topology.  The \p lab image should be the **original
+/// unsmoothed** LAB image (CV_32FC3) so that gradients are sharp.
+void RefineEdgesSubpixel(BoundaryGraph& graph, const cv::Mat& lab,
+                         const SubpixelRefineConfig& cfg = {});
+
+} // namespace ChromaPrint3D::detail

--- a/core/src/imgproc/vectorize_potrace_pipeline.cpp
+++ b/core/src/imgproc/vectorize_potrace_pipeline.cpp
@@ -6,6 +6,7 @@
 #include "imgproc/contour_assembly.h"
 #include "imgproc/coverage_guard.h"
 #include "imgproc/curve_fitting.h"
+#include "imgproc/subpixel_refine.h"
 #include "imgproc/potrace_adapter.h"
 #include "imgproc/thin_line_vectorizer.h"
 #include "imgproc/svg_writer.h"
@@ -540,6 +541,14 @@ VectorizerResult VectorizePotracePipeline(const cv::Mat& bgr, const VectorizerCo
         auto boundary_graph = BuildBoundaryGraph(seg.labels);
         spdlog::debug("BoundaryGraph built: nodes={}, edges={}", boundary_graph.nodes.size(),
                       boundary_graph.edges.size());
+
+        if (cfg.enable_subpixel_refine) {
+            cv::Mat refine_lab = unsmoothed.empty() ? BgrToLab(working) : BgrToLab(unsmoothed);
+            SubpixelRefineConfig sp_cfg;
+            sp_cfg.max_displacement = cfg.subpixel_max_displacement;
+            RefineEdgesSubpixel(boundary_graph, refine_lab, sp_cfg);
+        }
+
         CurveFitConfig fit_cfg;
         fit_cfg.error_threshold            = std::clamp(cfg.curve_fit_error, 0.05f, 10.0f);
         fit_cfg.corner_angle_threshold_deg = std::clamp(cfg.corner_angle_threshold, 60.0f, 179.0f);

--- a/core/src/imgproc/vectorize_potrace_pipeline.cpp
+++ b/core/src/imgproc/vectorize_potrace_pipeline.cpp
@@ -511,8 +511,11 @@ VectorizerResult VectorizePotracePipeline(const cv::Mat& bgr, const VectorizerCo
         spdlog::debug("Vectorize transparent mask applied: transparent_pixels={}", transparent_px);
     }
 
-    if (multicolor && cfg.refine_passes > 0 && !unsmoothed.empty() && !seg.centers_lab.empty()) {
-        cv::Mat unsmoothed_lab = BgrToLab(unsmoothed);
+    cv::Mat unsmoothed_lab;
+    if (multicolor && !unsmoothed.empty()) { unsmoothed_lab = BgrToLab(unsmoothed); }
+
+    if (multicolor && cfg.refine_passes > 0 && !unsmoothed_lab.empty() &&
+        !seg.centers_lab.empty()) {
         RefineLabelsBoundary(seg.labels, unsmoothed_lab, seg.centers_lab, cfg.refine_passes);
         spdlog::info("Vectorize label refinement applied: passes={}", cfg.refine_passes);
     }
@@ -543,7 +546,8 @@ VectorizerResult VectorizePotracePipeline(const cv::Mat& bgr, const VectorizerCo
                       boundary_graph.edges.size());
 
         if (cfg.enable_subpixel_refine) {
-            cv::Mat refine_lab = unsmoothed.empty() ? BgrToLab(working) : BgrToLab(unsmoothed);
+            const cv::Mat& refine_lab =
+                unsmoothed_lab.empty() ? (unsmoothed_lab = BgrToLab(working)) : unsmoothed_lab;
             SubpixelRefineConfig sp_cfg;
             sp_cfg.max_displacement = cfg.subpixel_max_displacement;
             RefineEdgesSubpixel(boundary_graph, refine_lab, sp_cfg);


### PR DESCRIPTION
## Summary

- **亚像素边界修正**：新增 `RefineEdgesSubpixel` 步骤，在 `BuildBoundaryGraph` 之后利用原始 LAB 图像的颜色梯度，将 crack grid 整数坐标边界点沿法线偏移到真实边缘的亚像素位置，从根本上消除阶梯锯齿
- **Schneider 贝塞尔拟合 alpha2 符号修复**：`FitSingleBezier` 回退条件 `alpha2>-eps` 对正常正值几乎总为真，导致算法绕过最小二乘最优解并反复递归分裂产生大量近线性微段；修正为 `alpha2<eps` 且回退值为正
- **轮廓后处理优化**：新增 `DecimateNearCollinear` 清除残余共线点；修复 `SmoothClosedLoop` 多迭代夹紧失效；消除流水线中重复的 `BgrToLab` 计算

## Changes (8 files, +276 -11)

| File | Change |
|------|--------|
| `core/src/imgproc/subpixel_refine.h/.cpp` | 新增梯度引导亚像素修正模块 |
| `core/src/imgproc/curve_fitting.cpp` | 修复 alpha2 符号 bug |
| `core/src/imgproc/curve_fitting.h` | corner_neighbor_k 3→6 |
| `core/src/imgproc/contour_assembly.cpp` | 新增 DecimateNearCollinear、修复 SmoothClosedLoop |
| `core/src/imgproc/vectorize_potrace_pipeline.cpp` | 集成亚像素修正、BgrToLab 去重 |
| `core/include/chromaprint3d/vectorizer.h` | 新增 subpixel refine 配置字段 |
| `core/CMakeLists.txt` | 添加 subpixel_refine.cpp |

## Test plan

- [ ] 用多色图片（>=3 色）运行 `raster_to_svg`，确认 SVG 边缘平滑度显著改善
- [ ] 对比修改前后 SVG 的 Bezier 段数，验证 Schneider 修复后段数大幅减少
- [ ] 二值模式（num_colors=2）回归测试，确认 Potrace 路径不受影响
- [ ] 边缘情况：极小图片（<100px）、纯色图片、高对比度线条图


Made with [Cursor](https://cursor.com)