### PR TITLE
fix: stabilize vectorize SVG artifact delivery

### DIFF
--- a/.cursor/rules/git-branch-pr-policy.mdc
+++ b/.cursor/rules/git-branch-pr-policy.mdc
@@ -1,0 +1,34 @@
+---
+description: 禁止直接提交到 master，必须走分支 + PR
+alwaysApply: true
+---
+
+# Git 提交与合并规范
+
+## 强制要求
+
+- **禁止**在 `master` 分支直接提交代码并推送。
+- 所有代码改动必须在独立分支完成，并通过 Pull Request 合并到 `master`。
+- 分支未提交 PR 前，不得视为“已完成”。
+
+## 标准流程
+
+1. 同步基线：`git fetch origin`，基于最新 `origin/master` 创建分支。
+2. 分支开发：在功能分支完成修改与验证。
+3. 推送分支：`git push -u origin <branch>`。
+4. 创建 PR：说明变更、验证结果、风险与回滚方案。
+5. 合并条件：CI 通过 + Code Review 通过后再合并。
+
+## 分支命名建议
+
+- `feat/<topic>`
+- `fix/<topic>`
+- `refactor/<topic>`
+- `docs/<topic>`
+- `chore/<topic>`
+- `release/vX.Y.Z`
+
+## 异常场景
+
+- 仅在紧急故障且仓库维护者明确授权时，才允许绕过该规范。
+- 事后必须补齐复盘记录与后续 PR 同步。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 - 前后端联动大型修改必须执行端到端闭环检查：[.cursor/rules/end-to-end-change-checklist.mdc](.cursor/rules/end-to-end-change-checklist.mdc)
 - 前端验证必须与 CI 一致（`npm run format:check` / `lint` / `test` / `build`）：[.cursor/rules/frontend-layer-boundary.mdc](.cursor/rules/frontend-layer-boundary.mdc)
 - 前端 i18n 国际化规范（禁止硬编码文案、翻译 key 同步、locale 格式化）：[.cursor/rules/frontend-i18n.mdc](.cursor/rules/frontend-i18n.mdc)
+- Git 提交流程强制规范（禁止直提 `master`，必须分支 + PR）：[.cursor/rules/git-branch-pr-policy.mdc](.cursor/rules/git-branch-pr-policy.mdc)
 
 ## 标准工作流（建议）
 
@@ -82,9 +83,9 @@
 | 用户可见前端行为变化 | [README.md](README.md)、[docs/development.md](docs/development.md)、[docs/agents/web/frontend/README.md](docs/agents/web/frontend/README.md) |
 | 模块入口或职责边界变化 | [docs/agents/README.md](docs/agents/README.md) 与对应模块索引 |
 
-## PR 检查建议
+## PR 检查要求
 
-建议使用仓库 PR 模板中的协作清单，确保每次改动都覆盖：
+每次提交都应使用仓库 PR 模板中的协作清单，确保覆盖：
 
 - 代码验证
 - 文档同步

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -872,11 +872,12 @@ json ServerFacade::TaskToJson(const TaskSnapshot& task) {
     j["num_shapes"] = 0;
     j["svg_size"]   = 0;
     if (vp && task.status == RuntimeTaskStatus::Completed) {
-        j["width"]      = vp->width;
-        j["height"]     = vp->height;
-        j["num_shapes"] = vp->num_shapes;
-        j["svg_size"]   = vp->svg_content.size();
-        j["timing"]     = {
+        const auto svg_size = vp->svg_bytes > 0 ? vp->svg_bytes : vp->svg_content.size();
+        j["width"]          = vp->width;
+        j["height"]         = vp->height;
+        j["num_shapes"]     = vp->num_shapes;
+        j["svg_size"]       = svg_size;
+        j["timing"]         = {
             {"decode_ms", vp->decode_ms},
             {"vectorize_ms", vp->vectorize_ms},
             {"pipeline_ms", vp->pipeline_ms},

--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstring>
+#include <fstream>
 #include <stdexcept>
 
 namespace {
@@ -79,6 +80,26 @@ bool TryPrepareTempDir(const std::filesystem::path& dir) {
     std::filesystem::permissions(dir, std::filesystem::perms::owner_all,
                                  std::filesystem::perm_options::replace, ec);
     return !ec;
+}
+
+constexpr std::size_t kVectorSvgSpillThresholdBytes = 2 * 1024 * 1024;
+
+SpillableArtifact SpillSvgToFile(const std::filesystem::path& path, const std::string& svg) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+        throw std::runtime_error("failed to open svg spill file: " + path.string());
+    }
+
+    out.write(svg.data(), static_cast<std::streamsize>(svg.size()));
+    out.close();
+
+    std::error_code ec;
+    const auto written_size = std::filesystem::file_size(path, ec);
+    if (ec || written_size != svg.size()) {
+        throw std::runtime_error("failed to persist full svg payload to spill file: " +
+                                 path.string());
+    }
+    return SpillableArtifact::FromFile(path, written_size);
 }
 
 } // namespace
@@ -298,24 +319,44 @@ SubmitResult TaskRuntime::SubmitVectorize(const std::string& owner,
             }
             auto t1                     = Clock::now();
             const std::size_t svg_bytes = result.svg_content.size();
+            const int out_width         = result.width;
+            const int out_height        = result.height;
+            const int out_shapes        = result.num_shapes;
+            std::string svg_content     = std::move(result.svg_content);
+
+            std::optional<SpillableArtifact> spilled_svg;
+            if (svg_bytes >= kVectorSvgSpillThresholdBytes) {
+                auto spill_path = temp_dir_ / (id + "_vectorized.svg");
+                spilled_svg     = SpillSvgToFile(spill_path, svg_content);
+            }
+            const bool has_svg_on_disk = spilled_svg.has_value();
 
             auto ms = [](auto d) { return std::chrono::duration<double, std::milli>(d).count(); };
 
-            UpdateTaskPayload(id, [&](TaskPayload& p) {
-                auto* vp = std::get_if<VectorizeTaskPayload>(&p);
+            UpdateTaskRecord(id, [&, svg_bytes, svg_content = std::move(svg_content),
+                                  spilled_svg = std::move(spilled_svg)](TaskRecord& rec) mutable {
+                auto* vp = std::get_if<VectorizeTaskPayload>(&rec.snapshot.payload);
                 if (!vp) return;
                 vp->decode_ms    = 0;
                 vp->vectorize_ms = ms(t1 - t0);
                 vp->pipeline_ms  = ms(t1 - t0);
-                vp->svg_content  = std::move(result.svg_content);
-                vp->width        = result.width;
-                vp->height       = result.height;
-                vp->num_shapes   = result.num_shapes;
+                vp->svg_bytes    = svg_bytes;
+                vp->width        = out_width;
+                vp->height       = out_height;
+                vp->num_shapes   = out_shapes;
+                if (spilled_svg.has_value()) {
+                    vp->svg_content.clear();
+                    vp->has_svg_on_disk = true;
+                    rec.spilled_svg     = std::move(*spilled_svg);
+                } else {
+                    vp->svg_content     = std::move(svg_content);
+                    vp->has_svg_on_disk = false;
+                }
             });
             spdlog::info(
                 "Vectorize task core completed: task_id={}, vectorize_ms={:.2f}, width={}, "
-                "height={}, num_shapes={}, svg_bytes={}",
-                id, ms(t1 - t0), result.width, result.height, result.num_shapes, svg_bytes);
+                "height={}, num_shapes={}, svg_bytes={}, spilled_svg={}",
+                id, ms(t1 - t0), out_width, out_height, out_shapes, svg_bytes, has_svg_on_disk);
         });
 }
 
@@ -583,8 +624,17 @@ std::optional<TaskArtifact> TaskRuntime::LoadArtifact(const std::string& owner,
 
     if (auto vp = std::get_if<VectorizeTaskPayload>(&t.payload)) {
         if (artifact == "svg") {
-            std::vector<uint8_t> svg(vp->svg_content.begin(), vp->svg_content.end());
             std::string filename = vp->image_name.empty() ? "result.svg" : vp->image_name + ".svg";
+            if (rec.spilled_svg.has_file()) {
+                return TaskArtifact{
+                    {}, rec.spilled_svg.path(), "image/svg+xml", std::move(filename)};
+            }
+            if (vp->svg_content.empty()) {
+                status_code = 404;
+                message     = "SVG result not available";
+                return std::nullopt;
+            }
+            std::vector<uint8_t> svg(vp->svg_content.begin(), vp->svg_content.end());
             return TaskArtifact{std::move(svg), {}, "image/svg+xml", std::move(filename)};
         }
     }
@@ -740,13 +790,14 @@ void TaskRuntime::MarkCompleted(const std::string& id) {
         ElapsedMs(it->second.snapshot.created_at, it->second.snapshot.completed_at);
 
     if (auto* vp = std::get_if<VectorizeTaskPayload>(&it->second.snapshot.payload)) {
+        const std::size_t svg_bytes = vp->svg_bytes > 0 ? vp->svg_bytes : vp->svg_content.size();
         spdlog::info(
             "Task completed: id={}, kind={}, owner={}, elapsed_ms={:.2f}, vectorize_ms={:.2f}, "
-            "pipeline_ms={:.2f}, width={}, height={}, num_shapes={}, svg_bytes={}, "
+            "pipeline_ms={:.2f}, width={}, height={}, num_shapes={}, svg_bytes={}, spilled_svg={}, "
             "artifact_bytes={}",
             id, TaskKindToString(it->second.snapshot.kind), OwnerTag(it->second.snapshot.owner),
             elapsed, vp->vectorize_ms, vp->pipeline_ms, vp->width, vp->height, vp->num_shapes,
-            vp->svg_content.size(), it->second.artifact_bytes);
+            svg_bytes, it->second.spilled_svg.has_file(), it->second.artifact_bytes);
     } else {
         spdlog::debug(
             "Task completed: id={}, kind={}, owner={}, elapsed_ms={:.2f}, artifact_bytes={}", id,

--- a/web/backend/src/infrastructure/task_runtime.h
+++ b/web/backend/src/infrastructure/task_runtime.h
@@ -71,9 +71,11 @@ struct VectorizeTaskPayload {
     double pipeline_ms  = 0;
 
     std::string svg_content;
-    int width      = 0;
-    int height     = 0;
-    int num_shapes = 0;
+    std::size_t svg_bytes = 0;
+    bool has_svg_on_disk  = false;
+    int width             = 0;
+    int height            = 0;
+    int num_shapes        = 0;
 };
 
 using TaskPayload = std::variant<ConvertTaskPayload, MattingTaskPayload, VectorizeTaskPayload>;
@@ -157,6 +159,7 @@ private:
         TaskSnapshot snapshot;
         std::size_t artifact_bytes = 0;
         SpillableArtifact spilled_3mf;
+        SpillableArtifact spilled_svg;
     };
 
     struct QueueEntry {


### PR DESCRIPTION
## Summary
- Fixes a vectorize delivery-path issue where large SVG artifacts were returned as in-memory response bodies, which could trigger Drogon/Trantor write callback fatals (`no writing but write callback called`) even though vectorization itself completed successfully.
- Spills large vectorized SVG payloads to temp files and serves them via file response; keeps task metadata (`svg_size`) accurate even when in-memory SVG content is cleared.
- Adds a repository-level always-apply policy rule that forbids direct commits/pushes to `master` and requires branch + PR workflow, and links this rule from `AGENTS.md`.

## Test plan
- [x] Build backend target successfully: `cmake --build build --target chromaprint3d_server --parallel 4`
- [ ] Reproduce vectorize requests with large SVG outputs and verify no `TcpConnectionImpl.cc` fatal occurs during artifact download
- [ ] Verify `/api/v1/tasks/{id}` reports correct `svg_size` for both in-memory and spilled SVG cases
- [ ] Verify policy rule is present in `.cursor/rules/git-branch-pr-policy.mdc` and referenced by `AGENTS.md`


Made with [Cursor](https://cursor.com)