### PR TITLE
fix(backend): clean up failed 3MF temp files

### DIFF
--- a/core/src/geo/three_mf_writer.cpp
+++ b/core/src/geo/three_mf_writer.cpp
@@ -4,7 +4,11 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
+#include <random>
+#include <system_error>
+#include <utility>
 
 namespace ChromaPrint3D::detail {
 
@@ -16,6 +20,71 @@ bool HasMetadataKey(const std::vector<ThreeMfMetadataEntry>& metadata, const std
     return std::any_of(metadata.begin(), metadata.end(),
                        [&](const ThreeMfMetadataEntry& entry) { return entry.name == key; });
 }
+
+std::string RandomHex(std::size_t byte_count) {
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::random_device rd;
+    std::string out;
+    out.reserve(byte_count * 2);
+    for (std::size_t i = 0; i < byte_count; ++i) {
+        const auto value = static_cast<unsigned char>(rd());
+        out.push_back(kHex[(value >> 4U) & 0x0F]);
+        out.push_back(kHex[value & 0x0F]);
+    }
+    return out;
+}
+
+std::filesystem::path MakeAtomicTempPath(const std::filesystem::path& final_path) {
+    const auto dir           = final_path.parent_path();
+    const auto filename_base = final_path.filename().string();
+    for (int attempt = 0; attempt < 16; ++attempt) {
+        auto candidate = dir / (filename_base + ".tmp-" + RandomHex(8));
+        std::error_code ec;
+        if (!std::filesystem::exists(candidate, ec) && !ec) { return candidate; }
+    }
+    throw IOError("Failed to allocate temporary output path for " + final_path.string());
+}
+
+class PendingAtomicFile {
+public:
+    explicit PendingAtomicFile(std::filesystem::path path) : path_(std::move(path)) {}
+
+    ~PendingAtomicFile() { Cleanup(); }
+
+    PendingAtomicFile(const PendingAtomicFile&)            = delete;
+    PendingAtomicFile& operator=(const PendingAtomicFile&) = delete;
+
+    const std::filesystem::path& path() const { return path_; }
+
+    void CommitTo(const std::filesystem::path& final_path) {
+        std::error_code ec;
+#if defined(_WIN32)
+        if (std::filesystem::exists(final_path, ec) && !ec) {
+            std::filesystem::remove(final_path, ec);
+            if (ec) {
+                throw IOError("Failed to replace existing output file " + final_path.string() +
+                              ": " + ec.message());
+            }
+        }
+#endif
+        std::filesystem::rename(path_, final_path, ec);
+        if (ec) {
+            throw IOError("Failed to move temp output file into place for " + final_path.string() +
+                          ": " + ec.message());
+        }
+        path_.clear();
+    }
+
+private:
+    void Cleanup() noexcept {
+        if (path_.empty()) return;
+        std::error_code ec;
+        std::filesystem::remove(path_, ec);
+        path_.clear();
+    }
+
+    std::filesystem::path path_;
+};
 
 } // namespace
 
@@ -97,15 +166,48 @@ ThreeMfWriter::WriteToBuffer(const std::vector<ThreeMfInputObject>& objects) con
     return zip_bytes;
 }
 
+void WriteFileAtomically(const std::filesystem::path& final_path,
+                         const std::function<void(const std::filesystem::path&)>& writer) {
+    if (final_path.empty()) { throw InputError("output path is empty"); }
+
+    const auto dir = final_path.parent_path();
+    if (!dir.empty()) {
+        std::error_code ec;
+        std::filesystem::create_directories(dir, ec);
+        if (ec) {
+            throw IOError("Failed to create output directory " + dir.string() + ": " +
+                          ec.message());
+        }
+    }
+
+    PendingAtomicFile pending(MakeAtomicTempPath(final_path));
+    writer(pending.path());
+    pending.CommitTo(final_path);
+}
+
+void WriteBufferToFileAtomically(const std::filesystem::path& final_path,
+                                 const std::vector<uint8_t>& bytes) {
+    WriteFileAtomically(final_path, [&](const std::filesystem::path& temp_path) {
+        std::ofstream out(temp_path, std::ios::binary | std::ios::trunc);
+        if (!out.is_open()) {
+            throw IOError("Cannot open file for writing: " + temp_path.string());
+        }
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+        if (!out.good()) { throw IOError("Cannot write to " + final_path.string()); }
+    });
+}
+
 void ThreeMfWriter::WriteToFile(const std::string& path,
                                 const std::vector<ThreeMfInputObject>& objects) const {
     if (path.empty()) { throw InputError("3MF output path is empty"); }
 
     ThreeMfDocument document = BuildDocument(objects);
     OpcPartSet part_set      = BuildOpcPartSet(document);
-
-    StreamingZipWriter zip(path, options_);
-    WriteAllEntries(zip, part_set, document);
+    WriteFileAtomically(path, [&](const std::filesystem::path& temp_path) {
+        StreamingZipWriter zip(temp_path.string(), options_);
+        WriteAllEntries(zip, part_set, document);
+    });
 }
 
 } // namespace ChromaPrint3D::detail

--- a/core/src/geo/three_mf_writer.h
+++ b/core/src/geo/three_mf_writer.h
@@ -3,6 +3,7 @@
 #include "three_mf_ir.h"
 
 #include <cstdint>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
@@ -57,6 +58,14 @@ OpcPartSet BuildOpcPartSet(const ThreeMfDocument& document);
 
 // Generate external objects model XML (mesh data only, Bambu namespaces, empty build).
 std::string BuildObjectsModelXml(const std::vector<ThreeMfMeshResource>& resources);
+
+// Atomically replace the target file by first writing a sibling temporary file.
+void WriteFileAtomically(const std::filesystem::path& final_path,
+                         const std::function<void(const std::filesystem::path&)>& writer);
+
+// Convenience wrapper for atomically writing an in-memory buffer to disk.
+void WriteBufferToFileAtomically(const std::filesystem::path& final_path,
+                                 const std::vector<uint8_t>& bytes);
 
 // Streaming mesh XML serialization (implemented in three_mf_opc.cpp).
 // Writes XML in chunks to the sink callback, avoiding full XML materialization.

--- a/core/src/pipeline/pipeline.cpp
+++ b/core/src/pipeline/pipeline.cpp
@@ -9,12 +9,12 @@
 #include "chromaprint3d/recipe_map.h"
 #include "chromaprint3d/print_profile.h"
 #include "chromaprint3d/error.h"
+#include "geo/three_mf_writer.h"
 
 #include <spdlog/spdlog.h>
 
 #include <atomic>
 #include <filesystem>
-#include <fstream>
 #include <optional>
 #include <set>
 #include <string>
@@ -379,13 +379,7 @@ ConvertResult ConvertRaster(const ConvertRasterRequest& request, ProgressCallbac
     const bool file_only = !request.output_3mf_path.empty() && request.output_3mf_file_only;
 
     auto write_buffer_to_file = [&](const std::vector<uint8_t>& buf) {
-        auto dir = std::filesystem::path(request.output_3mf_path).parent_path();
-        if (!dir.empty()) { std::filesystem::create_directories(dir); }
-        std::ofstream ofs(request.output_3mf_path, std::ios::binary);
-        if (ofs) {
-            ofs.write(reinterpret_cast<const char*>(buf.data()),
-                      static_cast<std::streamsize>(buf.size()));
-        }
+        detail::WriteBufferToFileAtomically(request.output_3mf_path, buf);
     };
 
     if (has_transparent) {

--- a/core/src/pipeline/vector_pipeline.cpp
+++ b/core/src/pipeline/vector_pipeline.cpp
@@ -8,11 +8,11 @@
 #include "chromaprint3d/color_db.h"
 #include "chromaprint3d/print_profile.h"
 #include "chromaprint3d/error.h"
+#include "geo/three_mf_writer.h"
 
 #include <spdlog/spdlog.h>
 
 #include <filesystem>
-#include <fstream>
 #include <cmath>
 #include <optional>
 
@@ -247,12 +247,7 @@ ConvertResult ConvertVector(const ConvertVectorRequest& request, ProgressCallbac
     const bool file_only = !request.output_3mf_path.empty() && request.output_3mf_file_only;
 
     auto write_buffer_to_file = [&](const std::vector<uint8_t>& buf) {
-        auto dir = std::filesystem::path(request.output_3mf_path).parent_path();
-        if (!dir.empty()) { std::filesystem::create_directories(dir); }
-        std::ofstream ofs(request.output_3mf_path, std::ios::binary);
-        if (!ofs) { throw IOError("Cannot write to " + request.output_3mf_path); }
-        ofs.write(reinterpret_cast<const char*>(buf.data()),
-                  static_cast<std::streamsize>(buf.size()));
+        detail::WriteBufferToFileAtomically(request.output_3mf_path, buf);
         spdlog::info("Wrote 3MF to {}", request.output_3mf_path);
     };
 

--- a/core/tests/test_3mf_writer.cpp
+++ b/core/tests/test_3mf_writer.cpp
@@ -6,13 +6,13 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdio>
-#include <cstdlib>
+#include <filesystem>
 #include <fstream>
-#include <unistd.h>
 #include <memory>
+#include <random>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #if defined(CHROMAPRINT3D_HAS_ZLIB)
@@ -24,6 +24,29 @@ using namespace ChromaPrint3D;
 namespace {
 
 constexpr uint32_t kZipLocalFileHeaderSignature = 0x04034B50u;
+
+std::string RandomHex(std::size_t byte_count) {
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::random_device rd;
+    std::string out;
+    out.reserve(byte_count * 2);
+    for (std::size_t i = 0; i < byte_count; ++i) {
+        const auto value = static_cast<unsigned char>(rd());
+        out.push_back(kHex[(value >> 4U) & 0x0F]);
+        out.push_back(kHex[value & 0x0F]);
+    }
+    return out;
+}
+
+std::filesystem::path CreateUniqueTempDir() {
+    auto dir = std::filesystem::temp_directory_path() / ("chromaprint3d_test_" + RandomHex(8));
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+bool IsDirectoryEmpty(const std::filesystem::path& dir) {
+    return std::filesystem::directory_iterator(dir) == std::filesystem::directory_iterator{};
+}
 
 uint16_t ReadU16(const std::vector<uint8_t>& bytes, std::size_t offset) {
     if (offset + 1 >= bytes.size()) { throw std::runtime_error("ReadU16 out of range"); }
@@ -334,12 +357,9 @@ TEST(ThreeMfWriter, WriteToFileMatchesWriteToBuffer) {
     std::vector<uint8_t> buffer = writer.WriteToBuffer({object});
     ASSERT_FALSE(buffer.empty());
 
-    char tmp_template[] = "/tmp/chromaprint3d_test_XXXXXX.3mf";
-    int fd              = mkstemps(tmp_template, 4);
-    ASSERT_NE(fd, -1);
-    close(fd);
-    std::string tmp_path(tmp_template);
-    writer.WriteToFile(tmp_path, {object});
+    const auto temp_dir = CreateUniqueTempDir();
+    const auto tmp_path = temp_dir / "writer-output.3mf";
+    writer.WriteToFile(tmp_path.string(), {object});
 
     std::ifstream ifs(tmp_path, std::ios::binary | std::ios::ate);
     ASSERT_TRUE(ifs.is_open());
@@ -348,10 +368,35 @@ TEST(ThreeMfWriter, WriteToFileMatchesWriteToBuffer) {
     std::vector<uint8_t> file_bytes(file_size);
     ifs.read(reinterpret_cast<char*>(file_bytes.data()), static_cast<std::streamsize>(file_size));
     ifs.close();
-    std::remove(tmp_path.c_str());
+    std::error_code ec;
+    std::filesystem::remove_all(temp_dir, ec);
 
     ASSERT_EQ(buffer.size(), file_bytes.size());
     EXPECT_EQ(buffer, file_bytes);
+}
+
+TEST(ThreeMfWriter, AtomicWriteRemovesTempFileOnFailure) {
+    const auto temp_dir   = CreateUniqueTempDir();
+    const auto final_path = temp_dir / "failed-output.3mf";
+
+    try {
+        detail::WriteFileAtomically(final_path, [&](const std::filesystem::path& temp_path) {
+            std::ofstream out(temp_path, std::ios::binary | std::ios::trunc);
+            if (!out.is_open()) {
+                throw IOError("Cannot open file for writing: " + temp_path.string());
+            }
+            out.write("partial", 7);
+            out.flush();
+            throw IOError("simulated write failure");
+        });
+        FAIL() << "expected atomic write helper to propagate writer failure";
+    } catch (const IOError& e) { EXPECT_EQ(std::string(e.what()), "simulated write failure"); }
+
+    EXPECT_FALSE(std::filesystem::exists(final_path));
+    EXPECT_TRUE(IsDirectoryEmpty(temp_dir));
+
+    std::error_code ec;
+    std::filesystem::remove_all(temp_dir, ec);
 }
 
 TEST(ThreeMfWriter, DeflateModeFallsBackToStoreOnCompressionFailure) {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -367,6 +367,8 @@ server {
 > - 后端 `--max-pixels`（默认 `16777216`）限制的是**解码后像素数**，与文件大小限制独立；仅放宽 Nginx 限制并不能避免后端 `413 image_too_large`。
 > - Web 部署若要“限制更紧”，请同时下调后端 `--max-upload-mb`/`--max-pixels` 与 Nginx `client_max_body_size`。
 > - `--max-result-mb` 现在仅追踪内存中的制品大小（preview、mask、layer previews）。3MF 结果已自动落盘到 `data_dir/tmp/results/`，不计入内存预算。因此该值可以比旧版本大幅降低（如 64MB），同时容纳更多已完成任务。
+> - 失败或中断的 3MF 导出会主动回收未提交的临时文件；服务启动时也会清扫 `data_dir/tmp/results/` 与 fallback 结果目录中的历史残留，避免旧的半写入文件持续占满 `tmpfs`。
+> - 如需排查结果目录占用，可执行 `docker exec chromaprint3d du -sh /app/data/tmp/results` 查看总量，再用 `docker exec chromaprint3d ls -lhS /app/data/tmp/results | head -30` 定位最大文件。
 
 ### 2.5 配置防火墙
 

--- a/web/backend/src/infrastructure/spillable_artifact.cpp
+++ b/web/backend/src/infrastructure/spillable_artifact.cpp
@@ -7,6 +7,22 @@
 
 namespace chromaprint3d::backend {
 
+namespace {
+
+void RemoveTrackedFile(std::filesystem::path& path, const char* owner) noexcept {
+    if (path.empty()) return;
+
+    std::error_code ec;
+    if (std::filesystem::remove(path, ec)) {
+        spdlog::debug("{}: removed temp file {}", owner, path.string());
+    } else if (ec) {
+        spdlog::warn("{}: failed to remove {}: {}", owner, path.string(), ec.message());
+    }
+    path.clear();
+}
+
+} // namespace
+
 SpillableArtifact::~SpillableArtifact() { Cleanup(); }
 
 SpillableArtifact::SpillableArtifact(SpillableArtifact&& other) noexcept
@@ -34,15 +50,34 @@ SpillableArtifact SpillableArtifact::FromFile(std::filesystem::path path, std::s
 }
 
 void SpillableArtifact::Cleanup() noexcept {
-    if (path_.empty()) return;
-    std::error_code ec;
-    if (std::filesystem::remove(path_, ec)) {
-        spdlog::debug("SpillableArtifact: removed temp file {}", path_.string());
-    } else if (ec) {
-        spdlog::warn("SpillableArtifact: failed to remove {}: {}", path_.string(), ec.message());
-    }
-    path_.clear();
+    RemoveTrackedFile(path_, "SpillableArtifact");
     size_ = 0;
 }
+
+PendingArtifactFile::PendingArtifactFile(std::filesystem::path path) : path_(std::move(path)) {}
+
+PendingArtifactFile::~PendingArtifactFile() { Cleanup(); }
+
+PendingArtifactFile::PendingArtifactFile(PendingArtifactFile&& other) noexcept
+    : path_(std::move(other.path_)) {
+    other.path_.clear();
+}
+
+PendingArtifactFile& PendingArtifactFile::operator=(PendingArtifactFile&& other) noexcept {
+    if (this != &other) {
+        Cleanup();
+        path_ = std::move(other.path_);
+        other.path_.clear();
+    }
+    return *this;
+}
+
+SpillableArtifact PendingArtifactFile::Commit(std::size_t size) {
+    SpillableArtifact artifact = SpillableArtifact::FromFile(std::move(path_), size);
+    path_.clear();
+    return artifact;
+}
+
+void PendingArtifactFile::Cleanup() noexcept { RemoveTrackedFile(path_, "PendingArtifactFile"); }
 
 } // namespace chromaprint3d::backend

--- a/web/backend/src/infrastructure/spillable_artifact.h
+++ b/web/backend/src/infrastructure/spillable_artifact.h
@@ -34,4 +34,30 @@ private:
     std::size_t size_ = 0;
 };
 
+/// RAII guard for a temp file that has been created but not yet committed into a SpillableArtifact.
+/// Deletes the file on destruction unless Commit() transfers ownership.
+class PendingArtifactFile {
+public:
+    PendingArtifactFile() = default;
+    explicit PendingArtifactFile(std::filesystem::path path);
+    ~PendingArtifactFile();
+
+    PendingArtifactFile(PendingArtifactFile&& other) noexcept;
+    PendingArtifactFile& operator=(PendingArtifactFile&& other) noexcept;
+
+    PendingArtifactFile(const PendingArtifactFile&)            = delete;
+    PendingArtifactFile& operator=(const PendingArtifactFile&) = delete;
+
+    bool has_path() const { return !path_.empty(); }
+
+    const std::filesystem::path& path() const { return path_; }
+
+    SpillableArtifact Commit(std::size_t size);
+
+private:
+    void Cleanup() noexcept;
+
+    std::filesystem::path path_;
+};
+
 } // namespace chromaprint3d::backend

--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -72,9 +72,16 @@ const char* TaskStatusToString(RuntimeTaskStatus status) {
 
 namespace {
 
-bool TryPrepareTempDir(const std::filesystem::path& dir) {
+bool CleanupTempDirRoot(const std::filesystem::path& dir) {
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
+    return !ec;
+}
+
+bool TryPrepareTempDir(const std::filesystem::path& dir) {
+    if (!CleanupTempDirRoot(dir)) return false;
+
+    std::error_code ec;
     std::filesystem::create_directories(dir, ec);
     if (ec) return false;
     std::filesystem::permissions(dir, std::filesystem::perms::owner_all,
@@ -82,10 +89,15 @@ bool TryPrepareTempDir(const std::filesystem::path& dir) {
     return !ec;
 }
 
+bool SamePath(const std::filesystem::path& a, const std::filesystem::path& b) {
+    return a.lexically_normal() == b.lexically_normal();
+}
+
 constexpr std::size_t kVectorSvgSpillThresholdBytes = 2 * 1024 * 1024;
 
 SpillableArtifact SpillSvgToFile(const std::filesystem::path& path, const std::string& svg) {
-    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    PendingArtifactFile pending(path);
+    std::ofstream out(pending.path(), std::ios::binary | std::ios::trunc);
     if (!out.is_open()) {
         throw std::runtime_error("failed to open svg spill file: " + path.string());
     }
@@ -99,7 +111,7 @@ SpillableArtifact SpillSvgToFile(const std::filesystem::path& path, const std::s
         throw std::runtime_error("failed to persist full svg payload to spill file: " +
                                  path.string());
     }
-    return SpillableArtifact::FromFile(path, written_size);
+    return pending.Commit(written_size);
 }
 
 } // namespace
@@ -111,6 +123,10 @@ TaskRuntime::TaskRuntime(std::int64_t worker_count, std::int64_t max_queue,
       max_total_result_bytes_(max_total_result_bytes) {
     auto primary  = std::filesystem::path(data_dir) / "tmp" / "results";
     auto fallback = std::filesystem::temp_directory_path() / "chromaprint3d_results";
+
+    if (!SamePath(primary, fallback) && !CleanupTempDirRoot(fallback)) {
+        spdlog::warn("TaskRuntime: failed to clean stale fallback temp dir {}", fallback.string());
+    }
 
     if (TryPrepareTempDir(primary)) {
         temp_dir_ = primary;
@@ -152,6 +168,7 @@ SubmitResult TaskRuntime::SubmitConvertRaster(const std::string& owner,
                               auto temp_path               = temp_dir_ / (id + "_model.3mf");
                               request.output_3mf_path      = temp_path.string();
                               request.output_3mf_file_only = true;
+                              PendingArtifactFile pending_3mf(temp_path);
 
                               ChromaPrint3D::ProgressCallback progress_cb =
                                   [this, id](ChromaPrint3D::ConvertStage stage, float progress) {
@@ -163,8 +180,9 @@ SubmitResult TaskRuntime::SubmitConvertRaster(const std::string& owner,
                                       });
                                   };
 
-                              auto result    = ChromaPrint3D::ConvertRaster(request, progress_cb);
-                              auto file_size = std::filesystem::file_size(temp_path);
+                              auto result      = ChromaPrint3D::ConvertRaster(request, progress_cb);
+                              auto file_size   = std::filesystem::file_size(temp_path);
+                              auto spilled_3mf = pending_3mf.Commit(file_size);
 
                               UpdateTaskRecord(id, [&](TaskRecord& rec) {
                                   auto* cp = std::get_if<ConvertTaskPayload>(&rec.snapshot.payload);
@@ -172,8 +190,7 @@ SubmitResult TaskRuntime::SubmitConvertRaster(const std::string& owner,
                                   cp->result          = std::move(result);
                                   cp->progress        = 1.0f;
                                   cp->has_3mf_on_disk = true;
-                                  rec.spilled_3mf =
-                                      SpillableArtifact::FromFile(temp_path, file_size);
+                                  rec.spilled_3mf     = std::move(spilled_3mf);
                               });
                           });
 }
@@ -189,6 +206,7 @@ SubmitResult TaskRuntime::SubmitConvertVector(const std::string& owner,
                               auto temp_path               = temp_dir_ / (id + "_model.3mf");
                               request.output_3mf_path      = temp_path.string();
                               request.output_3mf_file_only = true;
+                              PendingArtifactFile pending_3mf(temp_path);
 
                               ChromaPrint3D::ProgressCallback progress_cb =
                                   [this, id](ChromaPrint3D::ConvertStage stage, float progress) {
@@ -200,8 +218,9 @@ SubmitResult TaskRuntime::SubmitConvertVector(const std::string& owner,
                                       });
                                   };
 
-                              auto result    = ChromaPrint3D::ConvertVector(request, progress_cb);
-                              auto file_size = std::filesystem::file_size(temp_path);
+                              auto result      = ChromaPrint3D::ConvertVector(request, progress_cb);
+                              auto file_size   = std::filesystem::file_size(temp_path);
+                              auto spilled_3mf = pending_3mf.Commit(file_size);
 
                               UpdateTaskRecord(id, [&](TaskRecord& rec) {
                                   auto* cp = std::get_if<ConvertTaskPayload>(&rec.snapshot.payload);
@@ -209,8 +228,7 @@ SubmitResult TaskRuntime::SubmitConvertVector(const std::string& owner,
                                   cp->result          = std::move(result);
                                   cp->progress        = 1.0f;
                                   cp->has_3mf_on_disk = true;
-                                  rec.spilled_3mf =
-                                      SpillableArtifact::FromFile(temp_path, file_size);
+                                  rec.spilled_3mf     = std::move(spilled_3mf);
                               });
                           });
 }


### PR DESCRIPTION
## Summary
- guard pending backend artifacts and atomically publish finished 3MF outputs so failed exports no longer leave orphaned or half-written result files
- add regression coverage for atomic write cleanup and document result-directory troubleshooting/behavior in deployment docs

## Test plan
- [x] `cmake -S . -B build-pr -DCHROMAPRINT3D_BUILD_TESTS=ON -DCHROMAPRINT3D_BUILD_INFER=OFF`
- [x] `cmake --build build-pr --target chromaprint3d_tests chromaprint3d_server -j 4`
- [x] `ctest --test-dir build-pr --output-on-failure -R "ThreeMfWriter"`


Made with [Cursor](https://cursor.com)