### PR TITLE
fix(backend): use WHOLE_ARCHIVE to preserve Drogon controller registration

### DIFF
--- a/web/backend/CMakeLists.txt
+++ b/web/backend/CMakeLists.txt
@@ -80,4 +80,5 @@ target_link_libraries(chromaprint3d_backend PUBLIC
 
 add_executable(chromaprint3d_server server_main.cpp)
 
-target_link_libraries(chromaprint3d_server PRIVATE chromaprint3d_backend)
+target_link_libraries(chromaprint3d_server PRIVATE
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,chromaprint3d_backend>)


### PR DESCRIPTION
## Summary

- `chromaprint3d_backend` 是 STATIC 库，链接器在构建 `chromaprint3d_server` 时丢弃了 `api_v1_controller.o`（因为 `server_main.cpp` 未直接引用 `ApiV1Controller`），导致 Drogon 的静态自注册机制失效，所有 API 路由返回 404
- 使用 CMake 3.24+ 的 `$<LINK_LIBRARY:WHOLE_ARCHIVE,...>` 强制包含静态库中所有 object 文件，恢复控制器路由注册

## Test plan

- [x] `nm` 确认修复前二进制无 `ApiV1Controller` 符号，修复后存在
- [x] `curl http://localhost:8080/api/v1/health` 修复前返回 Drogon 404，修复后返回正常 JSON
- [x] 前端 `npm run dev` + 后端 `--port 8080` 联调，health check 通过，服务器状态显示在线

Made with [Cursor](https://cursor.com)