### PR TITLE
release: v1.2.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ChromaPrint3D VERSION 1.2.5 LANGUAGES CXX)
+project(ChromaPrint3D VERSION 1.2.6 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "description": "ChromaPrint3D - Multi-color 3D printing image processor",
   "author": "neroued <neroued@gmail.com>",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d-web",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Web frontend for ChromaPrint3D — multi-color 3D print image processor",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Release v1.2.6

Bumps version to `1.2.6` in:
- `CMakeLists.txt`
- `web/frontend/package.json`
- `web/electron/package.json`

After this PR is merged, the `release-tag` workflow will automatically
create tag `v1.2.6` and trigger the full release pipeline.