### PR TITLE
fix(ci): configure git identity for annotated tag creation

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -33,6 +33,11 @@ jobs:
             exit 1
           fi
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Create and push annotated tag
         run: |
           TAG="${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary
- `release-tag` 工作流在创建 annotated tag 时因缺少 git 身份配置而失败
- 在 `git tag -a` 之前增加 `git config user.name/email` 步骤，使用 `github-actions[bot]` 标准身份

## Context
v1.2.6 发版时 release-tag workflow 失败（exit code 128），已手动补创 tag。此 PR 确保后续发版不再出现此问题。

Made with [Cursor](https://cursor.com)