### PR TITLE
fix(eval): MSVC cross-platform compatibility for eval module

### DIFF
--- a/eval/src/benchmark.cpp
+++ b/eval/src/benchmark.cpp
@@ -344,14 +344,22 @@ namespace eval {
 std::string GitShortHash() {
     std::array<char, 128> buf;
     std::string result = "unknown";
-    FILE* pipe         = popen("git rev-parse --short HEAD 2>/dev/null", "r");
+#if defined(_WIN32)
+    FILE* pipe = _popen("git rev-parse --short HEAD 2>NUL", "r");
+#else
+    FILE* pipe = popen("git rev-parse --short HEAD 2>/dev/null", "r");
+#endif
     if (pipe) {
         if (std::fgets(buf.data(), static_cast<int>(buf.size()), pipe)) {
             result = buf.data();
             while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
                 result.pop_back();
         }
+#if defined(_WIN32)
+        _pclose(pipe);
+#else
         pclose(pipe);
+#endif
     }
     return result;
 }
@@ -360,7 +368,11 @@ std::string CurrentTimestamp() {
     auto now  = std::chrono::system_clock::now();
     auto time = std::chrono::system_clock::to_time_t(now);
     std::tm tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &time);
+#else
     localtime_r(&time, &tm);
+#endif
     char buf[64];
     std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", &tm);
     return buf;
@@ -370,7 +382,11 @@ std::string MakeRunId() {
     auto now  = std::chrono::system_clock::now();
     auto time = std::chrono::system_clock::to_time_t(now);
     std::tm tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &time);
+#else
     localtime_r(&time, &tm);
+#endif
     char buf[64];
     std::strftime(buf, sizeof(buf), "%Y%m%d_%H%M%S", &tm);
     return std::string(buf) + "_" + GitShortHash();

--- a/eval/src/path_metrics.cpp
+++ b/eval/src/path_metrics.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <numbers>
 #include <map>
 #include <memory>
 #include <numeric>
@@ -233,7 +234,7 @@ PathMetricsResult ComputePathMetrics(const std::string& svg_content, int width, 
         net_areas.push_back(net);
 
         if (total_perim > 0) {
-            double circ = 4.0 * M_PI * net / (total_perim * total_perim);
+            double circ = 4.0 * std::numbers::pi * net / (total_perim * total_perim);
             circularities.push_back(circ);
             if (circ < sliver_threshold && net > 1.0) r.sliver_count++;
         }

--- a/eval/src/vectorize_eval.cpp
+++ b/eval/src/vectorize_eval.cpp
@@ -500,7 +500,7 @@ VectorizeMetrics EvaluateImage(const std::string& image_path, const EvalConfig& 
 std::vector<ImageResult> EvaluateBatch(const Manifest& manifest, const EvalConfig& config) {
     std::vector<ImageResult> results(manifest.images.size());
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && _OPENMP >= 200805
     int prev_levels = omp_get_max_active_levels();
     omp_set_max_active_levels(1);
 #endif
@@ -510,7 +510,7 @@ std::vector<ImageResult> EvaluateBatch(const Manifest& manifest, const EvalConfi
         results[i] = EvaluateSingleEntry(manifest.images[i], config);
     }
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && _OPENMP >= 200805
     omp_set_max_active_levels(prev_levels);
 #endif
 


### PR DESCRIPTION
## Summary
- `path_metrics.cpp`: `M_PI` → `std::numbers::pi`（C++20），MSVC 默认不定义 `M_PI`
- `benchmark.cpp`: `popen`/`pclose` → `_popen`/`_pclose`，`localtime_r` → `localtime_s`（Windows 分支）
- `vectorize_eval.cpp`: `omp_set_max_active_levels` 限定 `_OPENMP >= 200805`（OpenMP 3.0+），MSVC 仅支持 OpenMP 2.0

## Context
v1.2.6 release 的 Windows CI 构建因这三个 POSIX-only API 失败。修复后需要重新打 tag 触发 release。

Made with [Cursor](https://cursor.com)