### PR TITLE
feat: version update notification for web and Electron clients

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -402,6 +402,7 @@ cd web/frontend
 # 建议新建 .env.production.local（该文件默认不进 Git）
 cat > .env.production.local <<'EOF'
 VITE_API_BASE=https://api.chromaprint3d.com:9443
+VITE_UPDATE_MANIFEST_URL=https://chromaprint3d.com/version-manifest.json
 VITE_SITE_ICP_NUMBER=京ICP备12345678号-1
 VITE_SITE_ICP_URL=https://beian.miit.gov.cn/
 VITE_SITE_PUBLIC_SECURITY_RECORD_NUMBER=京公网安备11010502000001号
@@ -422,6 +423,7 @@ npm run build
 >   working-directory: web/frontend
 >   env:
 >     VITE_API_BASE: https://api.chromaprint3d.com:9443
+>     VITE_UPDATE_MANIFEST_URL: https://chromaprint3d.com/version-manifest.json
 >   run: |
 >     npm ci
 >     npm run build
@@ -496,6 +498,13 @@ server {
     location = /index.html {
         add_header Cache-Control "no-store, must-revalidate";
         try_files $uri =404;
+    }
+
+    # 版本更新 manifest（供跨域的自部署实例和 Electron 检查新版本）
+    location = /version-manifest.json {
+        add_header Access-Control-Allow-Origin  "*" always;
+        add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+        add_header Cache-Control "public, max-age=300";
     }
 
     # SPA 路由回退
@@ -684,6 +693,8 @@ docker run -d -p 8080:8080 neroued/chromaprint3d:latest
 ```
 
 访问 `http://localhost:8080` 即可使用，无需配置 `--cors-origin`。
+
+如需启用版本更新提醒，可在构建前端时设置 `VITE_UPDATE_MANIFEST_URL` 环境变量，指向官方 manifest 文件（如 `https://chromaprint3d.com/version-manifest.json`）。未设置时更新检查功能不会激活。
 
 ### Docker 镜像标签说明
 

--- a/scripts/deploy_split.sh
+++ b/scripts/deploy_split.sh
@@ -73,9 +73,17 @@ if [[ "$WEB_INSTALL_DEPS" == "1" ]]; then
 fi
 
 info "Building web frontend..."
+BUILD_ENV=()
 if [[ -n "${VITE_API_BASE:-}" ]]; then
     info "Using VITE_API_BASE=$VITE_API_BASE"
-    (cd "$ROOT_DIR/web/frontend" && VITE_API_BASE="$VITE_API_BASE" npm run build)
+    BUILD_ENV+=(VITE_API_BASE="$VITE_API_BASE")
+fi
+if [[ -n "${VITE_UPDATE_MANIFEST_URL:-}" ]]; then
+    info "Using VITE_UPDATE_MANIFEST_URL=$VITE_UPDATE_MANIFEST_URL"
+    BUILD_ENV+=(VITE_UPDATE_MANIFEST_URL="$VITE_UPDATE_MANIFEST_URL")
+fi
+if (( ${#BUILD_ENV[@]} > 0 )); then
+    (cd "$ROOT_DIR/web/frontend" && env "${BUILD_ENV[@]}" npm run build)
 else
     (cd "$ROOT_DIR/web/frontend" && npm run build)
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# Usage: ./scripts/release.sh <new_version>
+# Usage: ./scripts/release.sh <new_version> [changelog]
 #   e.g. ./scripts/release.sh 1.2.6
+#   e.g. ./scripts/release.sh 1.3.0 "- New feature A\n- Bug fix B"
 #
 # Creates a release branch + PR. After the PR is merged, the
 # release-tag.yml workflow auto-creates the git tag, which triggers
@@ -11,7 +12,8 @@
 #   1. Validate version format and prerequisites
 #   2. Create release/v<version> branch from origin/master
 #   3. Update version in CMakeLists.txt, web/frontend/package.json, web/electron/package.json
-#   4. Commit, push branch, and open PR via gh
+#   4. Generate web/frontend/public/version-manifest.json
+#   5. Commit, push branch, and open PR via gh
 
 set -euo pipefail
 
@@ -23,7 +25,8 @@ info() { echo "==> $*"; }
 # ---------- Args ----------
 
 VERSION="${1:-}"
-[[ -z "$VERSION" ]] && die "Usage: $0 <version>  (e.g. 1.2.0)"
+CHANGELOG="${2:-}"
+[[ -z "$VERSION" ]] && die "Usage: $0 <version> [changelog]  (e.g. 1.2.0)"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "Version must be MAJOR.MINOR.PATCH (got: $VERSION)"
 
 TAG="v${VERSION}"
@@ -97,10 +100,23 @@ grep -q "VERSION ${VERSION}" "$ROOT/CMakeLists.txt" || die "Failed to update CMa
 grep -q "\"version\": \"${VERSION}\"" "$ROOT/web/frontend/package.json" || die "Failed to update package.json"
 grep -q "\"version\": \"${VERSION}\"" "$ROOT/web/electron/package.json" || die "Failed to update electron package.json"
 
+# ---------- 2b. Generate version manifest ----------
+
+info "Generating version-manifest.json..."
+mkdir -p "$ROOT/web/frontend/public"
+cat > "$ROOT/web/frontend/public/version-manifest.json" <<MANIFEST
+{
+  "version": "${VERSION}",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v${VERSION}",
+  "changelog": "${CHANGELOG}",
+  "published_at": "$(date -u +%Y-%m-%d)"
+}
+MANIFEST
+
 # ---------- 3. Commit, push, create PR ----------
 
 info "Committing version bump..."
-git add CMakeLists.txt web/frontend/package.json web/electron/package.json
+git add CMakeLists.txt web/frontend/package.json web/electron/package.json web/frontend/public/version-manifest.json
 git commit -m "release: v${VERSION}"
 
 info "Pushing branch $RELEASE_BRANCH..."
@@ -116,6 +132,7 @@ Bumps version to \`${VERSION}\` in:
 - \`CMakeLists.txt\`
 - \`web/frontend/package.json\`
 - \`web/electron/package.json\`
+- \`web/frontend/public/version-manifest.json\`
 
 After this PR is merged, the \`release-tag\` workflow will automatically
 create tag \`${TAG}\` and trigger the full release pipeline.")

--- a/version-manifest.example.json
+++ b/version-manifest.example.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.3.0",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.3.0",
+  "changelog": "- New feature A\n- Bug fix B",
+  "published_at": "2026-03-15"
+}

--- a/web/frontend/.env.production
+++ b/web/frontend/.env.production
@@ -18,3 +18,10 @@ VITE_API_BASE=
 # Optional: browser footer public security filing information.
 # VITE_SITE_PUBLIC_SECURITY_RECORD_NUMBER=京公网安备11010502000001号
 # VITE_SITE_PUBLIC_SECURITY_RECORD_URL=https://beian.mps.gov.cn/
+
+# Optional: version update manifest URL.
+# When set, the frontend checks this URL on startup for new versions
+# and shows a non-intrusive banner if an update is available.
+# Leave empty to disable update checking.
+# Example: VITE_UPDATE_MANIFEST_URL=https://chromaprint3d.com/version-manifest.json
+VITE_UPDATE_MANIFEST_URL=

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -33,9 +33,12 @@ import Calibration8ColorPanel from './components/Calibration8ColorPanel.vue'
 import MattingPanel from './components/MattingPanel.vue'
 import VectorizePanel from './components/VectorizePanel.vue'
 import ColorDBUploadSection from './components/calibration/ColorDBUploadSection.vue'
+import UpdateBanner from './components/UpdateBanner.vue'
+import CheckUpdateLink from './components/CheckUpdateLink.vue'
 import { darkThemeOverrides, lightThemeOverrides } from './theme'
 import { useAppStore } from './stores/app'
 import { useAppLifecycle } from './composables/feature/useAppLifecycle'
+import { useUpdateChecker } from './composables/feature/useUpdateChecker'
 import { isElectronRuntime } from './runtime/platform'
 import {
   getSiteIcpNumber,
@@ -82,6 +85,9 @@ if (activeTab.value === 'calibration' || activeTab.value === 'calibration-8color
 }
 
 useAppLifecycle()
+
+const { initOnce: initUpdateChecker } = useUpdateChecker()
+initUpdateChecker()
 
 function handleColorDBUpdated() {
   appStore.refreshColorDBs()
@@ -144,6 +150,7 @@ function toggleLocale() {
 
         <NLayoutContent class="app-shell__content">
           <div class="app-shell__content-inner">
+            <UpdateBanner />
             <div class="app-shell__announce">
               <div class="app-shell__announce-inner">
                 <span class="app-shell__announce-text">
@@ -292,6 +299,7 @@ function toggleLocale() {
             <NText depth="3" class="app-shell__meta-text">
               ChromaPrint3D{{ serverVersion ? ` v${serverVersion}` : '' }}
             </NText>
+            <CheckUpdateLink />
             <NText depth="3" class="app-shell__meta-text">
               Multi-color 3D Print Image Processor
             </NText>

--- a/web/frontend/src/components/CheckUpdateLink.vue
+++ b/web/frontend/src/components/CheckUpdateLink.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { NText, useMessage } from 'naive-ui'
+import { useUpdateChecker } from '../composables/feature/useUpdateChecker'
+
+const { t } = useI18n()
+const message = useMessage()
+const { checking, checkForUpdate, hasUpdate } = useUpdateChecker()
+
+async function handleClick() {
+  const found = await checkForUpdate()
+  if (!found && !hasUpdate.value) {
+    message.success(t('app.update.upToDate'))
+  }
+}
+</script>
+
+<template>
+  <span class="check-update-link" @click="handleClick">
+    <NText depth="3" class="app-shell__meta-text check-update-link__text">
+      {{ checking ? t('app.update.checking') : t('app.update.checkForUpdate') }}
+    </NText>
+  </span>
+</template>
+
+<style scoped>
+.check-update-link {
+  cursor: pointer;
+}
+
+.check-update-link__text:hover {
+  text-decoration: underline;
+}
+</style>

--- a/web/frontend/src/components/UpdateBanner.vue
+++ b/web/frontend/src/components/UpdateBanner.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NAlert, NButton, NSpace, NText } from 'naive-ui'
+import { useUpdateChecker } from '../composables/feature/useUpdateChecker'
+
+const { t } = useI18n()
+const { latestVersion, changelog, downloadUrl, showBanner, dismiss } = useUpdateChecker()
+
+const changelogLines = computed(() => {
+  const raw = changelog.value
+  if (!raw) return []
+  return raw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+})
+</script>
+
+<template>
+  <div v-if="showBanner" class="update-banner">
+    <NAlert type="info" closable @close="dismiss">
+      <template #header>
+        {{ t('app.update.newVersionAvailable', { version: latestVersion }) }}
+      </template>
+      <NSpace vertical :size="8">
+        <ul v-if="changelogLines.length" class="update-banner__changelog">
+          <li v-for="(line, i) in changelogLines" :key="i">
+            <NText depth="2">{{ line.replace(/^[-·•]\s*/, '') }}</NText>
+          </li>
+        </ul>
+        <NSpace :size="12">
+          <NButton
+            v-if="downloadUrl"
+            tag="a"
+            :href="downloadUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            type="info"
+            size="small"
+          >
+            {{ t('app.update.download') }}
+          </NButton>
+        </NSpace>
+      </NSpace>
+    </NAlert>
+  </div>
+</template>
+
+<style scoped>
+.update-banner {
+  margin-bottom: 12px;
+}
+
+.update-banner__changelog {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.update-banner__changelog li {
+  margin: 2px 0;
+}
+</style>

--- a/web/frontend/src/composables/feature/useUpdateChecker.ts
+++ b/web/frontend/src/composables/feature/useUpdateChecker.ts
@@ -1,0 +1,147 @@
+import { ref, computed, readonly } from 'vue'
+import { useAppStore } from '../../stores/app'
+import { isElectronRuntime } from '../../runtime/platform'
+
+export type VersionManifest = {
+  version: string
+  download_url: string
+  changelog: string
+  published_at: string
+}
+
+const DISMISS_KEY = 'chromaprint3d-update-dismissed'
+const FETCH_TIMEOUT_MS = 5000
+
+function getManifestUrl(): string {
+  const electronUrl = window.electron?.env?.updateManifestUrl
+  if (electronUrl?.trim()) return electronUrl.trim()
+  const envUrl = import.meta.env.VITE_UPDATE_MANIFEST_URL
+  return typeof envUrl === 'string' ? envUrl.trim() : ''
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  const len = Math.max(pa.length, pb.length)
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0
+    const nb = pb[i] ?? 0
+    if (na !== nb) return na - nb
+  }
+  return 0
+}
+
+function isValidManifest(data: unknown): data is VersionManifest {
+  if (typeof data !== 'object' || data === null) return false
+  const obj = data as Record<string, unknown>
+  return typeof obj.version === 'string' && /^\d+\.\d+\.\d+/.test(obj.version)
+}
+
+function isDismissedForVersion(version: string): boolean {
+  try {
+    return sessionStorage.getItem(DISMISS_KEY) === version
+  } catch {
+    return false
+  }
+}
+
+function setDismissedVersion(version: string) {
+  try {
+    sessionStorage.setItem(DISMISS_KEY, version)
+  } catch {
+    // ignore
+  }
+}
+
+const hasUpdate = ref(false)
+const latestVersion = ref('')
+const changelog = ref('')
+const downloadUrl = ref('')
+const checking = ref(false)
+const dismissed = ref(false)
+
+let initialized = false
+
+export function useUpdateChecker() {
+  const appStore = useAppStore()
+
+  const currentVersion = computed(() => {
+    if (isElectronRuntime()) return __APP_VERSION__
+    return appStore.serverVersion || __APP_VERSION__
+  })
+
+  const showBanner = computed(() => hasUpdate.value && !dismissed.value)
+
+  async function fetchManifest(): Promise<VersionManifest | null> {
+    const url = getManifestUrl()
+    if (!url) return null
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    try {
+      const resp = await fetch(url, { signal: controller.signal, cache: 'no-cache' })
+      if (!resp.ok) return null
+      const data: unknown = await resp.json()
+      if (!isValidManifest(data)) return null
+      return data
+    } catch {
+      return null
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  async function checkForUpdate(): Promise<boolean> {
+    if (checking.value) return false
+    checking.value = true
+    try {
+      const manifest = await fetchManifest()
+      if (!manifest) return false
+
+      const current = currentVersion.value
+      if (!current) return false
+
+      if (compareVersions(manifest.version, current) > 0) {
+        latestVersion.value = manifest.version
+        changelog.value = manifest.changelog ?? ''
+        downloadUrl.value = manifest.download_url ?? ''
+        hasUpdate.value = true
+        dismissed.value = isDismissedForVersion(manifest.version)
+        return true
+      }
+
+      hasUpdate.value = false
+      return false
+    } catch {
+      return false
+    } finally {
+      checking.value = false
+    }
+  }
+
+  function dismiss() {
+    dismissed.value = true
+    if (latestVersion.value) {
+      setDismissedVersion(latestVersion.value)
+    }
+  }
+
+  function initOnce() {
+    if (initialized) return
+    initialized = true
+    void checkForUpdate()
+  }
+
+  return {
+    hasUpdate: readonly(hasUpdate),
+    latestVersion: readonly(latestVersion),
+    changelog: readonly(changelog),
+    downloadUrl: readonly(downloadUrl),
+    checking: readonly(checking),
+    showBanner,
+    currentVersion,
+    checkForUpdate,
+    dismiss,
+    initOnce,
+  }
+}

--- a/web/frontend/src/electron.d.ts
+++ b/web/frontend/src/electron.d.ts
@@ -1,10 +1,12 @@
 export {}
 
 declare global {
+  const __APP_VERSION__: string
   type ElectronEnvApi = {
     apiBase?: string
     uploadMaxMb?: number
     uploadMaxPixels?: number
+    updateManifestUrl?: string
   }
 
   type ElectronStorageApi = {

--- a/web/frontend/src/locales/en.ts
+++ b/web/frontend/src/locales/en.ts
@@ -53,6 +53,14 @@ export default {
       makerWorldLink: 'MakerWorld',
       makerWorldSuffix: '',
     },
+    update: {
+      newVersionAvailable: 'New version {version} is available',
+      changelog: 'Changelog',
+      download: 'Download',
+      checkForUpdate: 'Check for updates',
+      checking: 'Checking...',
+      upToDate: 'You are up to date',
+    },
   },
 
   convert: {

--- a/web/frontend/src/locales/zh-CN.ts
+++ b/web/frontend/src/locales/zh-CN.ts
@@ -83,6 +83,14 @@ export default {
       makerWorldLink: 'MakerWorld',
       makerWorldSuffix: '上查看我的打印作品',
     },
+    update: {
+      newVersionAvailable: '新版本 {version} 已发布',
+      changelog: '更新内容',
+      download: '前往下载',
+      checkForUpdate: '检查更新',
+      checking: '正在检查...',
+      upToDate: '已是最新版本',
+    },
   },
 
   convert: {

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import pkg from './package.json' with { type: 'json' }
 
 const frontendTarget = (process.env.CHROMAPRINT3D_FRONTEND_TARGET ?? '').trim().toLowerCase()
 const isElectronTarget = frontendTarget === 'electron'
@@ -7,6 +8,9 @@ const isElectronTarget = frontendTarget === 'electron'
 export default defineConfig({
   base: isElectronTarget ? './' : '/',
   plugins: [vue()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary

- 新增版本更新提醒功能：前端启动时从可配置的远程 manifest URL 检查新版本，并以顶部横幅形式展示更新信息（版本号、更新日志、下载链接）
- 页脚新增"检查更新"手动入口，支持用户主动触发检查
- 检查失败时静默处理，不影响用户体验；横幅支持关闭（sessionStorage 持久化）
- `release.sh` 脚本新增自动生成 `version-manifest.json`，下载链接默认指向 GitHub Release 页面
- 更新部署文档与脚本，支持分体部署场景下的 manifest URL 配置与 Nginx CORS 设置

## Changes

| 文件 | 说明 |
|---|---|
| `version-manifest.example.json` | manifest 格式示例 |
| `web/frontend/vite.config.ts` | 注入 `__APP_VERSION__` 构建常量 |
| `web/frontend/.env.production` | 新增 `VITE_UPDATE_MANIFEST_URL` 占位 |
| `web/frontend/src/composables/feature/useUpdateChecker.ts` | 核心逻辑：fetch manifest、semver 比较、状态管理 |
| `web/frontend/src/components/UpdateBanner.vue` | 更新通知横幅组件 |
| `web/frontend/src/components/CheckUpdateLink.vue` | 页脚"检查更新"入口 |
| `web/frontend/src/App.vue` | 集成横幅组件与检查入口 |
| `web/frontend/src/locales/zh-CN.ts` / `en.ts` | i18n 翻译 key |
| `web/frontend/src/electron.d.ts` | 类型声明扩展 |
| `scripts/release.sh` | 自动生成 manifest 文件 |
| `scripts/deploy_split.sh` | 支持传递 `VITE_UPDATE_MANIFEST_URL` 环境变量 |
| `docs/deployment.md` | 补充 manifest URL 配置、Nginx CORS、单机部署说明 |

## Test plan

- [ ] 设置 `VITE_UPDATE_MANIFEST_URL` 指向一个包含更高版本号的 manifest 文件，启动前端验证横幅出现
- [ ] 点击横幅关闭按钮，刷新页面确认横幅不再出现（同 session）
- [ ] 点击页脚"检查更新"链接，验证手动触发检查正常工作
- [ ] 不设置 `VITE_UPDATE_MANIFEST_URL`（或设为空），确认无更新检查行为
- [ ] 将 manifest URL 设为不可达地址，确认无报错、无横幅
- [ ] 运行 `scripts/release.sh 9.9.9 "test changelog"` 验证 manifest 自动生成


Made with [Cursor](https://cursor.com)