### PR TITLE
release: v1.2.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ChromaPrint3D VERSION 1.2.6 LANGUAGES CXX)
+project(ChromaPrint3D VERSION 1.2.7 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "private": true,
   "description": "ChromaPrint3D - Multi-color 3D printing image processor",
   "author": "neroued <neroued@gmail.com>",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d-web",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Web frontend for ChromaPrint3D — multi-color 3D print image processor",
   "type": "module",
   "license": "Apache-2.0",

--- a/web/frontend/public/version-manifest.json
+++ b/web/frontend/public/version-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.2.7",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.7",
+  "changelog": "- 新增版本更新通知（Web 和 Electron 客户端）\n- 矢量化模块迁移至 neroued_vectorizer 子模块\n- 更新 neroued_vectorizer 子模块至 v0.1.1",
+  "published_at": "2026-03-17"
+}


### PR DESCRIPTION
## Release v1.2.7

Bumps version to `1.2.7` in:
- `CMakeLists.txt`
- `web/frontend/package.json`
- `web/electron/package.json`
- `web/frontend/public/version-manifest.json`

After this PR is merged, the `release-tag` workflow will automatically
create tag `v1.2.7` and trigger the full release pipeline.