### PR TITLE
fix(ci): use PAT in release-tag workflow to trigger release pipeline

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # A PAT is required so that the tag push triggers the Release
+          # workflow.  Tags pushed with the default GITHUB_TOKEN do not
+          # fire further workflow runs (GitHub security policy).
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Extract version from branch name
         id: version


### PR DESCRIPTION
## Summary

- `release-tag.yml` 使用默认 `GITHUB_TOKEN` 推送 tag 时，不会触发后续的 `release.yml` 工作流（GitHub 安全策略限制）
- 改为使用 `secrets.RELEASE_PAT`（Personal Access Token），若未配置则回退到 `github.token`

## 背景

v1.2.7 发版时 `release-tag.yml` 首次成功创建 tag，但 `release.yml` 未被触发，需手动重推 tag。此修复确保后续发版自动化链路完整。

## 需要的操作

合并此 PR 后，需要配置仓库 secret `RELEASE_PAT`：

1. 前往 https://github.com/settings/tokens → **Fine-grained tokens** → Generate new token
2. 仅授权 `Neroued/ChromaPrint3D` 仓库，权限选择 **Contents: Read and write**
3. 前往仓库 Settings → Secrets and variables → Actions → New repository secret
4. Name: `RELEASE_PAT`，Value: 刚生成的 token

未配置 `RELEASE_PAT` 前，行为与现有一致（回退到 `github.token`），不会破坏现有流程。

## Test plan

- [ ] 合并后配置 `RELEASE_PAT` secret
- [ ] 下次发版时验证 release-tag → release 自动触发链路

Made with [Cursor](https://cursor.com)