### PR TITLE
docs: complete build dependencies and align Docker build env with CI

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -11,9 +11,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         ca-certificates \
         curl \
+        ccache \
         libopencv-dev \
         libpotrace-dev \
         uuid-dev \
+        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \

--- a/docs/build.md
+++ b/docs/build.md
@@ -20,23 +20,42 @@ git submodule update --init --recursive
 
 ### 2.1 环境要求
 
+**必需：**
+
 | 依赖 | 最低版本 | 说明 |
 |---|---|---|
 | CMake | 3.25 | 构建系统 |
 | C++ 编译器 | C++20 | 推荐 `g++-13` 或更高 |
 | OpenCV | 4.5+ | 图像处理依赖 |
-| zlib | 1.2+ | 3MF ZIP Deflate 压缩后端（可选，缺失时回退 Store） |
+| Potrace | — | 矢量化后端（neroued_vectorizer 依赖） |
+| uuid 库 | — | UUID 生成（Drogon 依赖） |
+| pkg-config | — | 库发现工具 |
 | Node.js | 22+ | 前端构建 |
-| Python | 3.10+ | 建模管线（可选） |
+
+**推荐：**
+
+| 依赖 | 说明 |
+|---|---|
+| Ninja | 更快的构建后端，CI 和 Docker 构建均使用 |
+| ccache | 编译缓存，显著加速增量编译 |
+| clang-format 18 | CI 强制检查 C++ 格式，建议本地安装以便提交前自检 |
+
+**可选：**
+
+| 依赖 | 说明 |
+|---|---|
+| zlib 1.2+ | 3MF ZIP Deflate 压缩后端（缺失时回退 Store） |
+| Python 3.10+ | 建模管线 |
 
 ### 2.2 安装系统依赖（示例）
 
 ```bash
 # Ubuntu / Debian
-sudo apt install libopencv-dev zlib1g-dev
+sudo apt install build-essential g++-13 cmake ninja-build pkg-config ccache \
+    libopencv-dev libpotrace-dev uuid-dev zlib1g-dev
 
 # macOS
-brew install opencv zlib
+brew install cmake ninja ccache opencv potrace ossp-uuid zlib
 ```
 
 ### 2.3 构建 C++ 核心与应用
@@ -164,4 +183,7 @@ Electron 开发启动命令与调试流程见 [docs/development.md](development.
 - CMake 版本过低：升级到 3.25+
 - C++20 报错：确认使用 `g++-13` 或更高
 - 前端构建失败：确认 Node.js 版本满足 `22+`
+- 链接报 `potrace` 符号缺失：安装 `libpotrace-dev`（Ubuntu）或 `potrace`（macOS）
+- 链接报 `uuid` 符号缺失：安装 `uuid-dev`（Ubuntu）或 `ossp-uuid`（macOS）
+- PR 格式检查失败：安装 `clang-format-18` 并在提交前执行 `clang-format -i <修改的文件>`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,6 +120,18 @@ curl -s http://127.0.0.1:8080/api/v1/vectorize/defaults
 ctest --test-dir build --output-on-failure
 ```
 
+### 3.5 C++ 格式检查
+
+CI 会对所有变更的 C++ 文件执行 `clang-format-18` 格式检查（见 `.clang-format` 配置），未通过时 PR 会被阻止合并。建议在本地提交前对修改的文件运行格式化：
+
+```bash
+# 安装（Ubuntu / Debian）
+sudo apt install clang-format-18
+
+# 对修改的文件执行格式化
+clang-format -i <修改的文件>
+```
+
 ## 4. Electron 本地开发
 
 Electron 主进程会自动拉起后端（要求后端二进制已构建完成）。


### PR DESCRIPTION
## Summary

- **docs/build.md**: 环境要求表拆分为必需/推荐/可选三级，补全 potrace、uuid、pkg-config、ninja、ccache、clang-format 18；Ubuntu/macOS 安装命令与 CI 和 Dockerfile.build 对齐；排障部分新增 potrace/uuid 链接失败和 clang-format 检查失败条目
- **Dockerfile.build**: 添加 `zlib1g-dev`（支持 3MF Deflate 压缩，与 CI 一致）和 `ccache`（加速增量编译）
- **docs/development.md**: 新增 3.5 节 C++ 格式检查说明，告知开发者 CI 强制 clang-format-18 检查及本地使用方式

## Test plan

- [ ] 确认 docs/build.md 中 Ubuntu 安装命令可在干净环境执行
- [ ] 确认 Dockerfile.build 可正常 `docker build -f Dockerfile.build`
- [ ] 确认文档链接和格式渲染正常


Made with [Cursor](https://cursor.com)