### PR TITLE
fix: unify cluster_count default to 0 (auto-detect)

### DIFF
--- a/apps/raster_to_3mf.cpp
+++ b/apps/raster_to_3mf.cpp
@@ -26,7 +26,7 @@ struct Options {
 
     ColorSpace color_space           = ColorSpace::Lab;
     int k_candidates                 = 1;
-    int cluster_count                = 64;
+    int cluster_count                = 0;
     PrintMode print_mode             = PrintMode::Mode0p08x5;
     bool flip_y                      = true;
     NozzleSize nozzle_size           = NozzleSize::N04;
@@ -59,7 +59,7 @@ void PrintUsage(const char* exe) {
         "  --mode 0.08x5|0.04x10   Target print mode (default 0.08x5)\n"
         "  --color-space lab|rgb   Match in Lab or RGB (default lab)\n"
         "  --k N               Top-k candidates (default 1)\n"
-        "  --clusters N        Cluster count for color matching (default 4096, <=1 disable)\n"
+        "  --clusters N        Cluster count (0=auto-detect, 1=per-pixel, >=2=manual; default 0)\n"
         "  --model-pack PATH   Phase A model package json\n"
         "  --model-enable 0|1  Enable model fallback when model pack is provided (default 1)\n"
         "  --model-only 0|1    Match by model only (requires --model-pack, default 0)\n"

--- a/core/include/chromaprint3d/pipeline.h
+++ b/core/include/chromaprint3d/pipeline.h
@@ -57,13 +57,13 @@ struct ConvertRasterRequest {
     ColorSpace color_space       = ColorSpace::Lab;       ///< Color space used for matching.
     int k_candidates             = 1; ///< Number of candidate colors to consider per pixel.
     ClusterMethod cluster_method = ClusterMethod::KMeans; ///< Non-dither clustering method.
-    int cluster_count            = 64;                    ///< K-Means cluster count.
-    int slic_target_superpixels  = 256;                   ///< SLIC target superpixel count.
-    float slic_compactness       = 10.0f;                 ///< SLIC compactness weight (> 0).
-    int slic_iterations          = 10;                    ///< SLIC refinement iterations.
-    float slic_min_region_ratio  = 0.25f;                 ///< SLIC small-region merge ratio [0, 1].
-    DitherMethod dither          = DitherMethod::None;    ///< Dithering method for matching.
-    float dither_strength        = 0.8f;                  ///< Dither intensity [0, 1].
+    int cluster_count            = 0;     ///< 0 = auto-detect, 1 = per-pixel, >= 2 = manual.
+    int slic_target_superpixels  = 256;   ///< SLIC target superpixel count.
+    float slic_compactness       = 10.0f; ///< SLIC compactness weight (> 0).
+    int slic_iterations          = 10;    ///< SLIC refinement iterations.
+    float slic_min_region_ratio  = 0.25f; ///< SLIC small-region merge ratio [0, 1].
+    DitherMethod dither          = DitherMethod::None; ///< Dithering method for matching.
+    float dither_strength        = 0.8f;               ///< Dither intensity [0, 1].
     std::vector<std::string> allowed_channel_keys; ///< Allowed channel filters (empty = use all;
                                                    ///< "color|material" format).
 

--- a/core/include/chromaprint3d/recipe_map.h
+++ b/core/include/chromaprint3d/recipe_map.h
@@ -37,13 +37,13 @@ struct MatchConfig {
     int k_candidates             = 1; ///< k <= 1 uses single nearest neighbour.
     ColorSpace color_space       = ColorSpace::Lab;
     ClusterMethod cluster_method = ClusterMethod::KMeans; ///< Non-dither clustering method.
-    int cluster_count            = 64;                    ///< K-Means clusters; <= 1 per-pixel.
-    int slic_target_superpixels  = 256;                   ///< SLIC target superpixel count.
-    float slic_compactness       = 10.0f;                 ///< SLIC compactness weight (> 0).
-    int slic_iterations          = 10;                    ///< SLIC refinement iterations.
-    float slic_min_region_ratio  = 0.25f;                 ///< Small-region merge ratio [0, 1].
-    DitherMethod dither          = DitherMethod::None;    ///< Dithering method.
-    float dither_strength        = 0.8f;                  ///< Dither intensity [0, 1].
+    int cluster_count            = 0;     ///< 0 = auto-detect, 1 = per-pixel, >= 2 = manual.
+    int slic_target_superpixels  = 256;   ///< SLIC target superpixel count.
+    float slic_compactness       = 10.0f; ///< SLIC compactness weight (> 0).
+    int slic_iterations          = 10;    ///< SLIC refinement iterations.
+    float slic_min_region_ratio  = 0.25f; ///< Small-region merge ratio [0, 1].
+    DitherMethod dither          = DitherMethod::None; ///< Dithering method.
+    float dither_strength        = 0.8f;               ///< Dither intensity [0, 1].
 };
 
 /// Per-pixel recipe map: for every pixel stores which channel to use at each

--- a/docs/development.md
+++ b/docs/development.md
@@ -203,7 +203,10 @@ npm run dev
 ### 5.5 Raster 匹配参数说明
 
 - `cluster_method`：`kmeans`（默认）或 `slic`
-- `kmeans` 路径参数：`cluster_count`
+- `kmeans` 路径参数：`cluster_count`（默认 `0`）
+  - `0`：自动检测最优聚类数
+  - `1`：逐像素匹配（不聚类）
+  - `>= 2`：手动指定聚类数
 - `slic` 路径参数：`slic_target_superpixels`、`slic_compactness`、`slic_iterations`、`slic_min_region_ratio`
 - 互斥规则：当 `cluster_method=slic` 时，后端会强制 `dither=none`
 


### PR DESCRIPTION
## Summary

- 将 `cluster_count` 默认值从 `64`（手动）统一改为 `0`（自动检测），覆盖 C++ core 结构体、CLI 工具、后端 API 和前端初始化全链路
- 修复前端首次加载时聚类模式显示"自动"但实际参数为 64 的不一致问题，导致转换结果不展示自动检测颜色数
- 修正 CLI `--clusters` 帮助文本中错误的默认值（`4096` -> `0`），补充值语义说明
- 同步更新 `docs/development.md` 中 `cluster_count` 参数文档

## 变更文件

| 文件 | 变更 |
|------|------|
| `core/include/chromaprint3d/pipeline.h` | `ConvertRasterRequest::cluster_count` 默认值 64 → 0 |
| `core/include/chromaprint3d/recipe_map.h` | `MatchConfig::cluster_count` 默认值 64 → 0 |
| `apps/raster_to_3mf.cpp` | CLI 默认值 64 → 0，修正帮助文本 |
| `docs/development.md` | 补充 `cluster_count` 值语义文档 |

## Test plan

- [ ] 前端首次加载叠色模型界面，确认聚类模式为"自动"且转换后结果展示"X 色 (自动检测)"
- [ ] 切换手动/自动模式后转换，确认行为与首次加载一致
- [ ] CLI `raster_to_3mf` 不指定 `--clusters` 时确认日志输出 `auto` 模式
- [ ] CLI 指定 `--clusters 32` 时确认按手动 32 色聚类

Made with [Cursor](https://cursor.com)