### PR TITLE
fix: harden 3MF file write robustness and add diagnostic logging

### DIFF
--- a/core/src/geo/bambu_metadata.cpp
+++ b/core/src/geo/bambu_metadata.cpp
@@ -97,14 +97,19 @@ std::vector<std::string> ReadFilamentColours(const std::string& preset_json_path
     if (preset_json_path.empty()) return result;
 
     std::ifstream ifs(preset_json_path);
-    if (!ifs.is_open()) return result;
+    if (!ifs.is_open()) {
+        spdlog::warn("ReadFilamentColours: cannot open {}", preset_json_path);
+        return result;
+    }
 
     try {
         auto j = nlohmann::json::parse(ifs);
         if (j.contains("filament_colour") && j["filament_colour"].is_array()) {
             for (const auto& c : j["filament_colour"]) { result.push_back(c.get<std::string>()); }
         }
-    } catch (...) {}
+    } catch (const std::exception& e) {
+        spdlog::warn("ReadFilamentColours: parse error for {}: {}", preset_json_path, e.what());
+    }
     return result;
 }
 

--- a/core/src/geo/export_3mf.cpp
+++ b/core/src/geo/export_3mf.cpp
@@ -58,8 +58,15 @@ std::vector<Mesh> BuildMeshes(const ModelIR& model_ir, const BuildMeshConfig& cf
 #pragma omp parallel for schedule(dynamic)
     for (int i = 0; i < n; ++i) {
         const VoxelGrid& grid = model_ir.voxel_grids[static_cast<std::size_t>(i)];
-        if (grid.width <= 0 || grid.height <= 0 || grid.num_layers <= 0) { continue; }
-        if (grid.ooc.empty()) { continue; }
+        if (grid.width <= 0 || grid.height <= 0 || grid.num_layers <= 0) {
+            spdlog::warn("BuildMeshes: grid {} skipped (dimensions {}x{}x{})", i, grid.width,
+                         grid.height, grid.num_layers);
+            continue;
+        }
+        if (grid.ooc.empty()) {
+            spdlog::warn("BuildMeshes: grid {} skipped (empty voxel data)", i);
+            continue;
+        }
 
         BuildMeshConfig per_grid = cfg;
         if (apply_gap) {
@@ -223,8 +230,14 @@ BuildWriterObjects(const std::vector<Mesh>& meshes,
                    const std::function<std::string(std::size_t)>& color_fn) {
     std::vector<detail::ThreeMfInputObject> objects;
     objects.reserve(meshes.size());
+    std::size_t skipped = 0;
     for (std::size_t i = 0; i < meshes.size(); ++i) {
-        if (meshes[i].vertices.empty() || meshes[i].indices.empty()) { continue; }
+        if (meshes[i].vertices.empty() || meshes[i].indices.empty()) {
+            spdlog::warn("BuildWriterObjects: mesh {} ('{}') skipped (vertices={}, indices={})", i,
+                         name_fn(i), meshes[i].vertices.size(), meshes[i].indices.size());
+            ++skipped;
+            continue;
+        }
         detail::ThreeMfInputObject object;
         object.name              = name_fn(i);
         object.display_color_hex = color_fn(i);
@@ -232,6 +245,8 @@ BuildWriterObjects(const std::vector<Mesh>& meshes,
         object.transform         = detail::ThreeMfTransform::Identity();
         objects.push_back(std::move(object));
     }
+    spdlog::info("BuildWriterObjects: {} mesh(es) in, {} object(s) out, {} skipped", meshes.size(),
+                 objects.size(), skipped);
     return objects;
 }
 
@@ -248,8 +263,15 @@ BuildWriterObjectsAndSlots(const std::vector<Mesh>& meshes,
     WriterObjectsAndSlots result;
     result.objects.reserve(meshes.size());
     result.slots.reserve(meshes.size());
+    std::size_t skipped = 0;
     for (std::size_t i = 0; i < meshes.size(); ++i) {
-        if (meshes[i].vertices.empty() || meshes[i].indices.empty()) { continue; }
+        if (meshes[i].vertices.empty() || meshes[i].indices.empty()) {
+            spdlog::warn("BuildWriterObjectsAndSlots: mesh {} ('{}') skipped (vertices={}, "
+                         "indices={})",
+                         i, name_fn(i), meshes[i].vertices.size(), meshes[i].indices.size());
+            ++skipped;
+            continue;
+        }
         detail::ThreeMfInputObject object;
         object.name              = name_fn(i);
         object.display_color_hex = color_fn(i);
@@ -258,11 +280,22 @@ BuildWriterObjectsAndSlots(const std::vector<Mesh>& meshes,
         result.objects.push_back(std::move(object));
         result.slots.push_back(slot_fn(i));
     }
+    spdlog::info("BuildWriterObjectsAndSlots: {} mesh(es) in, {} object(s) out, {} skipped",
+                 meshes.size(), result.objects.size(), skipped);
     return result;
 }
 
-void EnsureNonEmptyGeometry(const std::vector<detail::ThreeMfInputObject>& objects) {
-    if (objects.empty()) { throw InputError("No geometry to export"); }
+void EnsureNonEmptyGeometry(const std::vector<detail::ThreeMfInputObject>& objects,
+                            std::size_t total_input_meshes = 0) {
+    if (objects.empty()) {
+        std::string msg = "No geometry to export";
+        if (total_input_meshes > 0) {
+            msg += " (all " + std::to_string(total_input_meshes) +
+                   " input mesh(es) were empty or filtered)";
+        }
+        spdlog::error("EnsureNonEmptyGeometry: {}", msg);
+        throw InputError(msg);
+    }
 }
 
 detail::ThreeMfWriter BuildWriter(const SlicerPreset* preset, std::vector<int> slots,
@@ -317,7 +350,7 @@ void Export3mf(const std::string& path, const ModelIR& model_ir, const BuildMesh
             }
             return {};
         });
-    EnsureNonEmptyGeometry(objects);
+    EnsureNonEmptyGeometry(objects, meshes.size());
 
     detail::ThreeMfWriter writer(DefaultWriterOptions());
     writer.WriteToFile(path, objects);
@@ -342,7 +375,7 @@ std::vector<uint8_t> Export3mfToBuffer(const ModelIR& model_ir, const BuildMeshC
             }
             return {};
         });
-    EnsureNonEmptyGeometry(objects);
+    EnsureNonEmptyGeometry(objects, meshes.size());
 
     detail::ThreeMfWriter writer(DefaultWriterOptions());
     std::vector<uint8_t> buffer = writer.WriteToBuffer(objects);
@@ -372,7 +405,7 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
             }
             return {};
         });
-    EnsureNonEmptyGeometry(objects);
+    EnsureNonEmptyGeometry(objects, mutable_meshes.size());
 
     detail::ThreeMfWriter writer(DefaultWriterOptions());
     std::vector<uint8_t> buffer = writer.WriteToBuffer(objects);
@@ -397,7 +430,7 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
             if (i < palette.size()) return palette[i].hex_color;
             return {};
         });
-    EnsureNonEmptyGeometry(objects);
+    EnsureNonEmptyGeometry(objects, mutable_meshes.size());
 
     detail::ThreeMfWriter writer(DefaultWriterOptions());
     std::vector<uint8_t> buffer = writer.WriteToBuffer(objects);
@@ -434,7 +467,7 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
             if (base_layers > 0 && base_channel_idx >= 0) return base_channel_idx + 1;
             return static_cast<int>(i) + 1;
         });
-    EnsureNonEmptyGeometry(result.objects);
+    EnsureNonEmptyGeometry(result.objects, mutable_meshes.size());
 
     std::vector<uint8_t> buffer =
         WriteObjectsToBuffer(result.objects, &preset, std::move(result.slots), model_name);
@@ -467,7 +500,7 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
             return {};
         },
         [&](std::size_t i) -> int { return slots[i]; });
-    EnsureNonEmptyGeometry(result.objects);
+    EnsureNonEmptyGeometry(result.objects, mutable_meshes.size());
 
     std::vector<uint8_t> buffer =
         WriteObjectsToBuffer(result.objects, &preset, std::move(result.slots), model_name);
@@ -503,7 +536,7 @@ std::vector<uint8_t> Export3mfToBuffer(const ModelIR& model_ir, const BuildMeshC
             if (has_base && base_channel_idx >= 0) return base_channel_idx + 1;
             return static_cast<int>(i) + 1;
         });
-    EnsureNonEmptyGeometry(result.objects);
+    EnsureNonEmptyGeometry(result.objects, meshes.size());
 
     std::vector<uint8_t> buffer =
         WriteObjectsToBuffer(result.objects, &preset, std::move(result.slots), model_ir.name);
@@ -533,7 +566,7 @@ void Export3mfToFile(const std::string& path, const ModelIR& model_ir, const Bui
             }
             return {};
         });
-    EnsureNonEmptyGeometry(objects);
+    EnsureNonEmptyGeometry(objects, meshes.size());
     WriteObjectsToFile(path, objects);
     spdlog::info("Export3mfToFile: written {} object(s) to {}", objects.size(), path);
 }
@@ -565,7 +598,7 @@ void Export3mfToFile(const std::string& path, const ModelIR& model_ir, const Bui
             if (has_base && base_channel_idx >= 0) return base_channel_idx + 1;
             return static_cast<int>(i) + 1;
         });
-    EnsureNonEmptyGeometry(result.objects);
+    EnsureNonEmptyGeometry(result.objects, meshes.size());
     WriteObjectsToFile(path, result.objects, &preset, std::move(result.slots), model_ir.name);
     spdlog::info("Export3mfToFile (with preset): written {} object(s) to {}", result.objects.size(),
                  path);
@@ -593,7 +626,7 @@ void Export3mfFromMeshesToFile(const std::string& path, const std::vector<Mesh>&
             }
             return {};
         });
-    EnsureNonEmptyGeometry(objects);
+    EnsureNonEmptyGeometry(objects, mutable_meshes.size());
     WriteObjectsToFile(path, objects);
     spdlog::info("Export3mfFromMeshesToFile: written {} object(s) to {}", objects.size(), path);
 }
@@ -627,7 +660,7 @@ void Export3mfFromMeshesToFile(const std::string& path, const std::vector<Mesh>&
             if (base_layers > 0 && base_channel_idx >= 0) return base_channel_idx + 1;
             return static_cast<int>(i) + 1;
         });
-    EnsureNonEmptyGeometry(result.objects);
+    EnsureNonEmptyGeometry(result.objects, mutable_meshes.size());
     WriteObjectsToFile(path, result.objects, &preset, std::move(result.slots), model_name);
     spdlog::info("Export3mfFromMeshesToFile (with preset): written {} object(s) to {}",
                  result.objects.size(), path);

--- a/core/src/geo/geo.cpp
+++ b/core/src/geo/geo.cpp
@@ -185,7 +185,11 @@ Mesh Mesh::Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg) {
     const int width  = voxel_grid.width;
     const int height = voxel_grid.height;
     const int layers = voxel_grid.num_layers;
-    if (width <= 0 || height <= 0 || layers <= 0) { return mesh; }
+    if (width <= 0 || height <= 0 || layers <= 0) {
+        spdlog::debug("Mesh::Build: returning empty mesh (dimensions {}x{}x{})", width, height,
+                      layers);
+        return mesh;
+    }
     if (cfg.pixel_mm <= 0.0f || cfg.layer_height_mm <= 0.0f) {
         throw InputError("BuildMeshConfig values must be positive");
     }
@@ -342,8 +346,13 @@ Mesh Mesh::Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg) {
         }
     }
 
-    spdlog::debug("Mesh::Build: ch={}, vertices={}, triangles={}", voxel_grid.channel_idx,
-                  mesh.vertices.size(), mesh.indices.size());
+    if (mesh.vertices.empty() || mesh.indices.empty()) {
+        spdlog::warn("Mesh::Build: ch={} produced empty mesh (vertices={}, triangles={})",
+                     voxel_grid.channel_idx, mesh.vertices.size(), mesh.indices.size());
+    } else {
+        spdlog::debug("Mesh::Build: ch={}, vertices={}, triangles={}", voxel_grid.channel_idx,
+                      mesh.vertices.size(), mesh.indices.size());
+    }
     return mesh;
 }
 

--- a/core/src/geo/three_mf_extensions.cpp
+++ b/core/src/geo/three_mf_extensions.cpp
@@ -127,13 +127,23 @@ public:
         document.mesh_resources.clear();
         document.build_items.clear();
 
-        std::size_t dropped_degenerate = 0;
+        std::size_t dropped_degenerate  = 0;
+        std::size_t meshes_dropped_full = 0;
         for (std::size_t i = 0; i < objects.size(); ++i) {
             const auto& in = objects[i];
-            if (!in.mesh) { continue; }
+            if (!in.mesh) {
+                spdlog::warn("CoreModelExtension: object {} ('{}') has null mesh pointer", i,
+                             in.name);
+                continue;
+            }
             const Mesh& mesh               = *in.mesh;
             const std::size_t vertex_count = mesh.vertices.size();
-            if (vertex_count == 0 || mesh.indices.empty()) { continue; }
+            if (vertex_count == 0 || mesh.indices.empty()) {
+                spdlog::warn("CoreModelExtension: object {} ('{}') skipped (vertices={}, "
+                             "triangles={})",
+                             i, in.name, vertex_count, mesh.indices.size());
+                continue;
+            }
             if (vertex_count > static_cast<std::size_t>(std::numeric_limits<uint32_t>::max())) {
                 throw InputError("Mesh vertex count exceeds 3MF uint32 limit");
             }
@@ -172,7 +182,13 @@ public:
             }
             mesh_resource.valid_triangle_count = valid_count;
 
-            if (valid_count == 0) { continue; }
+            if (valid_count == 0) {
+                spdlog::warn("CoreModelExtension: object {} ('{}') dropped, all {} triangle(s) "
+                             "degenerate",
+                             i, in.name, mesh.indices.size());
+                ++meshes_dropped_full;
+                continue;
+            }
 
             if (document.base_material_group_id.has_value() && i < document.base_materials.size()) {
                 mesh_resource.object_property = ThreeMfObjectProperty{
@@ -187,9 +203,10 @@ public:
             });
         }
 
-        if (dropped_degenerate > 0) {
-            spdlog::warn("3MF export dropped {} degenerate triangle(s)", dropped_degenerate);
-        }
+        spdlog::info("CoreModelExtension: {} object(s) in, {} mesh(es) accepted, {} dropped "
+                     "(fully degenerate), {} degenerate triangle(s) filtered",
+                     objects.size(), document.mesh_resources.size(), meshes_dropped_full,
+                     dropped_degenerate);
     }
 };
 

--- a/core/src/geo/three_mf_writer.cpp
+++ b/core/src/geo/three_mf_writer.cpp
@@ -2,6 +2,8 @@
 
 #include "chromaprint3d/error.h"
 
+#include <spdlog/spdlog.h>
+
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
@@ -163,6 +165,20 @@ ThreeMfWriter::WriteToBuffer(const std::vector<ThreeMfInputObject>& objects) con
     std::vector<uint8_t> zip_bytes;
     StreamingZipWriter zip(zip_bytes, options_);
     WriteAllEntries(zip, part_set, document);
+
+    constexpr std::size_t kMinZipSize = 22;
+    if (zip_bytes.size() < kMinZipSize) {
+        spdlog::error("WriteToBuffer: generated buffer too small ({} bytes), expected >= {}",
+                      zip_bytes.size(), kMinZipSize);
+        throw IOError("Generated 3MF buffer is too small (" + std::to_string(zip_bytes.size()) +
+                      " bytes), likely corrupt");
+    }
+    if (zip_bytes.size() >= 4 && !(zip_bytes[0] == 0x50 && zip_bytes[1] == 0x4B &&
+                                   zip_bytes[2] == 0x03 && zip_bytes[3] == 0x04)) {
+        spdlog::error("WriteToBuffer: generated buffer missing ZIP magic bytes (PK\\x03\\x04)");
+        throw IOError("Generated 3MF buffer has invalid ZIP header, likely corrupt");
+    }
+
     return zip_bytes;
 }
 
@@ -170,11 +186,15 @@ void WriteFileAtomically(const std::filesystem::path& final_path,
                          const std::function<void(const std::filesystem::path&)>& writer) {
     if (final_path.empty()) { throw InputError("output path is empty"); }
 
+    spdlog::debug("WriteFileAtomically: target={}", final_path.string());
+
     const auto dir = final_path.parent_path();
     if (!dir.empty()) {
         std::error_code ec;
         std::filesystem::create_directories(dir, ec);
         if (ec) {
+            spdlog::error("WriteFileAtomically: failed to create directory {}: {}", dir.string(),
+                          ec.message());
             throw IOError("Failed to create output directory " + dir.string() + ": " +
                           ec.message());
         }
@@ -187,15 +207,48 @@ void WriteFileAtomically(const std::filesystem::path& final_path,
 
 void WriteBufferToFileAtomically(const std::filesystem::path& final_path,
                                  const std::vector<uint8_t>& bytes) {
+    spdlog::info("WriteBufferToFileAtomically: path={}, bytes={}", final_path.string(),
+                 bytes.size());
+
     WriteFileAtomically(final_path, [&](const std::filesystem::path& temp_path) {
         std::ofstream out(temp_path, std::ios::binary | std::ios::trunc);
         if (!out.is_open()) {
+            spdlog::error("WriteBufferToFileAtomically: cannot open temp file {}",
+                          temp_path.string());
             throw IOError("Cannot open file for writing: " + temp_path.string());
         }
         out.write(reinterpret_cast<const char*>(bytes.data()),
                   static_cast<std::streamsize>(bytes.size()));
-        if (!out.good()) { throw IOError("Cannot write to " + final_path.string()); }
+        if (!out.good()) {
+            spdlog::error("WriteBufferToFileAtomically: write failed for {}", final_path.string());
+            throw IOError("Cannot write to " + final_path.string());
+        }
+        out.close();
+        if (out.fail()) {
+            spdlog::error("WriteBufferToFileAtomically: close/flush failed for {}",
+                          temp_path.string());
+            throw IOError("Failed to flush/close output file: " + temp_path.string());
+        }
+
+        std::error_code ec;
+        auto actual_size = std::filesystem::file_size(temp_path, ec);
+        if (ec) {
+            spdlog::error("WriteBufferToFileAtomically: cannot stat temp file {}: {}",
+                          temp_path.string(), ec.message());
+            throw IOError("Cannot verify temp file size: " + temp_path.string() + ": " +
+                          ec.message());
+        }
+        if (actual_size != bytes.size()) {
+            spdlog::error(
+                "WriteBufferToFileAtomically: size mismatch for {}: expected={}, actual={}",
+                temp_path.string(), bytes.size(), actual_size);
+            throw IOError("File size mismatch after write: expected " +
+                          std::to_string(bytes.size()) + " but got " + std::to_string(actual_size));
+        }
     });
+
+    spdlog::info("WriteBufferToFileAtomically: written {} bytes to {}", bytes.size(),
+                 final_path.string());
 }
 
 void ThreeMfWriter::WriteToFile(const std::string& path,

--- a/core/src/pipeline/pipeline.cpp
+++ b/core/src/pipeline/pipeline.cpp
@@ -502,6 +502,7 @@ ConvertResult ConvertRaster(const ConvertRasterRequest& request, ProgressCallbac
 
     if (!request.output_3mf_path.empty() && !result.model_3mf.empty()) {
         detail::WriteBufferToFileAtomically(request.output_3mf_path, result.model_3mf);
+        spdlog::info("Wrote 3MF to {}", request.output_3mf_path);
         if (request.output_3mf_file_only) {
             result.model_3mf.clear();
             result.model_3mf.shrink_to_fit();
@@ -509,9 +510,11 @@ ConvertResult ConvertRaster(const ConvertRasterRequest& request, ProgressCallbac
     }
     if (!request.preview_path.empty() && !result.preview_png.empty()) {
         detail::WriteBufferToFileAtomically(request.preview_path, result.preview_png);
+        spdlog::info("Wrote preview to {}", request.preview_path);
     }
     if (!request.source_mask_path.empty() && !result.source_mask_png.empty()) {
         detail::WriteBufferToFileAtomically(request.source_mask_path, result.source_mask_png);
+        spdlog::info("Wrote source mask to {}", request.source_mask_path);
     }
 
     return result;

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -935,7 +935,26 @@ ServiceResult ServerFacade::DownloadBoardModel(const std::string& board_id, Task
     constexpr const char* kModelContentType =
         "application/vnd.ms-package.3dmanufacturing-3dmodel+xml";
     if (board->has_file_backed_model()) {
-        out = TaskArtifact{{}, board->model_3mf_path, kModelContentType, std::move(filename)};
+        const auto& fpath = board->model_3mf_path;
+        std::error_code ec;
+        bool exists      = std::filesystem::exists(fpath, ec);
+        auto actual_size = exists ? std::filesystem::file_size(fpath, ec) : 0ULL;
+        spdlog::info("DownloadBoardModel: board={}, path={}, exists={}, actual_size={}, "
+                     "expected_size={}",
+                     board_id, fpath.string(), exists, actual_size, board->expected_file_size);
+        if (!exists) {
+            spdlog::error("DownloadBoardModel: file missing for board {}: {}", board_id,
+                          fpath.string());
+            return ServiceResult::Error(404, "not_found", "Board model file missing from disk");
+        }
+        if (board->expected_file_size > 0 && actual_size != board->expected_file_size) {
+            spdlog::error("DownloadBoardModel: file size mismatch for board {}: expected={}, "
+                          "actual={}",
+                          board_id, board->expected_file_size, actual_size);
+            return ServiceResult::Error(500, "corrupt_file",
+                                        "Board model file is incomplete or corrupt");
+        }
+        out = TaskArtifact{{}, fpath, kModelContentType, std::move(filename)};
         return ServiceResult::Success(200, json::object());
     }
     if (board->model_3mf.empty()) {

--- a/web/backend/src/infrastructure/board_runtime_cache.cpp
+++ b/web/backend/src/infrastructure/board_runtime_cache.cpp
@@ -3,6 +3,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include <filesystem>
 #include <fstream>
 #include <system_error>
 
@@ -15,24 +16,47 @@ std::optional<SpillableArtifact> WriteBoardModelFile(const std::filesystem::path
     if (temp_dir.empty() || model_3mf.empty()) return std::nullopt;
 
     auto file_path = temp_dir / (board_id + "_calibration_board.3mf");
+    spdlog::info("WriteBoardModelFile: board={}, path={}, bytes={}", board_id, file_path.string(),
+                 model_3mf.size());
     {
         std::ofstream out(file_path, std::ios::binary | std::ios::trunc);
-        if (!out) {
-            spdlog::warn("BoardRuntimeCache: cannot open temp file for board {}: {}", board_id,
-                         file_path.string());
+        if (!out.is_open()) {
+            spdlog::error("WriteBoardModelFile: cannot open temp file for board {}: {}", board_id,
+                          file_path.string());
             return std::nullopt;
         }
         out.write(reinterpret_cast<const char*>(model_3mf.data()),
                   static_cast<std::streamsize>(model_3mf.size()));
-        if (!out) {
+        if (!out.good()) {
             std::error_code ec;
             std::filesystem::remove(file_path, ec);
-            spdlog::warn("BoardRuntimeCache: failed writing board model {} to {}", board_id,
-                         file_path.string());
+            spdlog::error("WriteBoardModelFile: write failed for board {} to {}", board_id,
+                          file_path.string());
+            return std::nullopt;
+        }
+        out.close();
+        if (out.fail()) {
+            std::error_code ec;
+            std::filesystem::remove(file_path, ec);
+            spdlog::error("WriteBoardModelFile: close/flush failed for board {} at {}", board_id,
+                          file_path.string());
             return std::nullopt;
         }
     }
-    return SpillableArtifact::FromFile(std::move(file_path), model_3mf.size());
+
+    std::error_code ec;
+    auto actual_size = std::filesystem::file_size(file_path, ec);
+    if (ec || actual_size != model_3mf.size()) {
+        spdlog::error("WriteBoardModelFile: size mismatch for board {}: expected={}, actual={}, "
+                      "ec={}",
+                      board_id, model_3mf.size(), actual_size, ec.message());
+        std::filesystem::remove(file_path, ec);
+        return std::nullopt;
+    }
+
+    spdlog::info("WriteBoardModelFile: board {} written {} bytes to {}", board_id, actual_size,
+                 file_path.string());
+    return SpillableArtifact::FromFile(std::move(file_path), actual_size);
 }
 
 } // namespace
@@ -99,7 +123,8 @@ std::optional<BoardSnapshot> BoardRuntimeCache::FindBoard(const std::string& id)
 
     BoardSnapshot snapshot;
     if (it->second.spilled_3mf.has_file()) {
-        snapshot.model_3mf_path = it->second.spilled_3mf.path();
+        snapshot.model_3mf_path     = it->second.spilled_3mf.path();
+        snapshot.expected_file_size = it->second.spilled_3mf.file_size();
     } else {
         snapshot.model_3mf = it->second.model_3mf_fallback;
     }

--- a/web/backend/src/infrastructure/board_runtime_cache.h
+++ b/web/backend/src/infrastructure/board_runtime_cache.h
@@ -17,6 +17,7 @@ namespace chromaprint3d::backend {
 struct BoardSnapshot {
     std::vector<uint8_t> model_3mf;
     std::filesystem::path model_3mf_path;
+    std::size_t expected_file_size = 0;
     ChromaPrint3D::CalibrationBoardMeta meta;
 
     bool has_file_backed_model() const { return !model_3mf_path.empty(); }

--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -866,13 +866,37 @@ SubmitResult TaskRuntime::SubmitGenerateModel(const std::string& owner, const st
             if (!gen_result.model_3mf.empty()) {
                 auto spill_path = temp_dir_ / (id + "_gen.3mf");
                 pending_3mf     = PendingArtifactFile(spill_path);
-                std::ofstream ofs(spill_path, std::ios::binary);
+                spdlog::info("GenerateModel: writing 3MF for task {}, {} bytes to {}", id,
+                             gen_result.model_3mf.size(), spill_path.string());
+
+                std::ofstream ofs(spill_path, std::ios::binary | std::ios::trunc);
+                if (!ofs.is_open()) {
+                    throw std::runtime_error("Cannot open 3MF spill file: " + spill_path.string());
+                }
                 ofs.write(reinterpret_cast<const char*>(gen_result.model_3mf.data()),
                           static_cast<std::streamsize>(gen_result.model_3mf.size()));
+                if (!ofs.good()) {
+                    throw std::runtime_error("Failed to write 3MF spill file: " +
+                                             spill_path.string());
+                }
                 ofs.close();
-                spilled_3mf = pending_3mf.Commit(gen_result.model_3mf.size());
+                if (ofs.fail()) {
+                    throw std::runtime_error("Failed to flush/close 3MF spill file: " +
+                                             spill_path.string());
+                }
+
+                auto actual_size = std::filesystem::file_size(spill_path);
+                if (actual_size != gen_result.model_3mf.size()) {
+                    spdlog::error("GenerateModel: 3MF file size mismatch for task {}: expected={}, "
+                                  "actual={}",
+                                  id, gen_result.model_3mf.size(), actual_size);
+                    throw std::runtime_error("3MF file size mismatch after write");
+                }
+
+                spilled_3mf = pending_3mf.Commit(actual_size);
                 gen_result.model_3mf.clear();
                 gen_result.model_3mf.shrink_to_fit();
+                spdlog::info("GenerateModel: 3MF written for task {}, {} bytes", id, actual_size);
             }
 
             UpdateTaskRecord(id, [&](TaskRecord& rec) {
@@ -984,7 +1008,30 @@ std::optional<TaskArtifact> TaskRuntime::LoadArtifact(const std::string& owner,
                 (cp->input_name.empty() ? id.substr(0, 8) : cp->input_name) + ".3mf";
             const std::string ct = "application/vnd.ms-package.3dmanufacturing-3dmodel+xml";
             if (rec.spilled_3mf.has_file()) {
-                return TaskArtifact{{}, rec.spilled_3mf.path(), ct, std::move(fname)};
+                const auto& fpath  = rec.spilled_3mf.path();
+                auto expected_size = rec.spilled_3mf.file_size();
+                std::error_code ec;
+                bool exists      = std::filesystem::exists(fpath, ec);
+                auto actual_size = exists ? std::filesystem::file_size(fpath, ec) : 0ULL;
+                spdlog::info("LoadArtifact: serving file-based 3MF for task {}: path={}, "
+                             "exists={}, actual_size={}, expected_size={}",
+                             id, fpath.string(), exists, actual_size, expected_size);
+                if (!exists) {
+                    spdlog::error("LoadArtifact: spilled 3MF file missing for task {}: {}", id,
+                                  fpath.string());
+                    status_code = 404;
+                    message     = "3MF file missing from disk";
+                    return std::nullopt;
+                }
+                if (expected_size > 0 && actual_size != expected_size) {
+                    spdlog::error("LoadArtifact: 3MF file size mismatch for task {}: "
+                                  "expected={}, actual={}",
+                                  id, expected_size, actual_size);
+                    status_code = 500;
+                    message     = "3MF file is incomplete or corrupt";
+                    return std::nullopt;
+                }
+                return TaskArtifact{{}, fpath, ct, std::move(fname)};
             }
             if (cp->result.model_3mf.empty()) {
                 status_code = 404;

--- a/web/backend/src/presentation/api_v1_controller.cpp
+++ b/web/backend/src/presentation/api_v1_controller.cpp
@@ -517,10 +517,14 @@ void ApiV1Controller::ReplyBinary(Callback&& cb, const TaskArtifact& artifact,
     drogon::HttpResponsePtr resp;
 
     if (artifact.is_file_based()) {
+        spdlog::info("ReplyBinary: serving file artifact: path={}, filename={}, content_type={}",
+                     artifact.file_path.string(), artifact.filename, artifact.content_type);
         resp =
             drogon::HttpResponse::newFileResponse(artifact.file_path.string(), artifact.filename);
         resp->setContentTypeString(artifact.content_type);
     } else {
+        spdlog::info("ReplyBinary: serving buffer artifact: size={}, filename={}, content_type={}",
+                     artifact.bytes.size(), artifact.filename, artifact.content_type);
         resp = drogon::HttpResponse::newHttpResponse();
         resp->setStatusCode(drogon::k200OK);
         resp->setBody(std::string(reinterpret_cast<const char*>(artifact.bytes.data()),

--- a/web/frontend/src/composables/useParamPanelState.ts
+++ b/web/frontend/src/composables/useParamPanelState.ts
@@ -124,7 +124,7 @@ export function useParamPanelState() {
   type ClusterMode = 'off' | 'auto' | 'manual'
   const clusterMode = ref<ClusterMode>('auto')
 
-  const targetDimensionUpperBound = 2000
+  const targetDimensionUpperBound = 512
   const clusterCountUpperBound = 256
   const simpleLabelWidth = 112
   const inlineLabelWidth = 96


### PR DESCRIPTION
## Summary

- **修复 3MF 落盘根因（影响 1.2.7+）**：`WriteBufferToFileAtomically` 增加显式 `close()` 错误检查和写后文件大小验证，防止 flush 失败导致的静默截断
- **统一所有 3MF 写入路径**：recipe-editor 和校色板（`board_runtime_cache`）的 spill 写入均加入 `is_open`/`good`/`close`/`file_size` 全套校验
- **下载前硬校验**：`LoadArtifact` 和 `DownloadBoardModel` 在下发文件前比对 `SpillableArtifact::file_size()` 与磁盘实际大小，截断/缺失文件返回 404/500 而非下发损坏内容
- **全链路诊断日志**：覆盖 mesh 过滤、退化三角形统计、空 grid 跳过、ZIP magic 验证、artifact 下发路径、bambu_metadata 解析错误
- **前端目标尺寸上限**：2000mm → 512mm，避免极端输入导致的内存溢出

## 改动文件

| 文件 | 改动 |
|---|---|
| `core/src/geo/three_mf_writer.cpp` | close 校验 + file_size 验证 + ZIP magic check + 日志 |
| `core/src/geo/export_3mf.cpp` | BuildWriterObjects/EnsureNonEmptyGeometry/BuildMeshes 日志 |
| `core/src/geo/geo.cpp` | Mesh::Build 空结果 warn |
| `core/src/geo/three_mf_extensions.cpp` | CoreModelExtension 跳过/退化统计日志 |
| `core/src/geo/bambu_metadata.cpp` | ReadFilamentColours 消除 catch(...) 静默失败 |
| `core/src/pipeline/pipeline.cpp` | ConvertRaster 写入日志对齐 vector_pipeline |
| `web/backend/src/infrastructure/task_runtime.cpp` | recipe-editor 写入加固 + LoadArtifact 大小硬校验 |
| `web/backend/src/infrastructure/board_runtime_cache.cpp/.h` | WriteBoardModelFile 加固 + expected_file_size 传递 |
| `web/backend/src/application/server_facade.cpp` | DownloadBoardModel 文件存在性+大小校验 |
| `web/backend/src/presentation/api_v1_controller.cpp` | ReplyBinary 日志 |
| `web/frontend/src/composables/useParamPanelState.ts` | 目标尺寸上限 2000→512 |

## Test plan

- [ ] 上传图像执行 raster 转换，验证 3MF 下载正常且日志中可见 `WriteBufferToFileAtomically` 入口/成功信息
- [ ] 通过 recipe-editor 生成 3MF，验证 spill 写入日志和下载正常
- [ ] 生成校色板并下载 3MF，验证 `WriteBoardModelFile` 日志和文件校验通过
- [ ] 模拟磁盘满/文件被删场景，验证下载返回 404/500 而非空文件
- [ ] 前端目标尺寸输入框确认上限为 512mm

Made with [Cursor](https://cursor.com)