### PR TITLE
release: v1.2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ChromaPrint3D VERSION 1.2.7 LANGUAGES CXX)
+project(ChromaPrint3D VERSION 1.2.8 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": true,
   "description": "ChromaPrint3D - Multi-color 3D printing image processor",
   "author": "neroued <neroued@gmail.com>",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d-web",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Web frontend for ChromaPrint3D — multi-color 3D print image processor",
   "type": "module",
   "license": "Apache-2.0",

--- a/web/frontend/public/version-manifest.json
+++ b/web/frontend/public/version-manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.2.7",
-  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.7",
-  "changelog": "- 新增版本更新提醒，有新版本时自动通知\n- 矢量化处理性能优化",
-  "published_at": "2026-03-17"
+  "version": "1.2.8",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.8",
+  "changelog": "- 新增配方编辑器：支持查看和调整图像中的颜色配方，修改后自动提醒重新生成\n- 校准工具全面升级：上传照片后即可预览定位效果，支持手动微调角点位置\n- 校准结果按色系分组展示，配方一目了然\n- 修复校准配方颜色显示为灰色的问题\n- 自动配色分析更准确，首次使用即为最佳效果\n- 3MF 模型文件生成更稳定，避免导出损坏\n- 下载文件名自动标注通道数，更易识别和管理",
+  "published_at": "2026-03-21"
 }


### PR DESCRIPTION
## Release v1.2.8

Bumps version to `1.2.8` in:
- `CMakeLists.txt`
- `web/frontend/package.json`
- `web/electron/package.json`
- `web/frontend/public/version-manifest.json`

After this PR is merged, the `release-tag` workflow will automatically
create tag `v1.2.8` and trigger the full release pipeline.