### PR TITLE
fix: replace M_PI with std::numbers::pi_v for MSVC compatibility

### DIFF
--- a/core/src/match/recipe_alternatives.cpp
+++ b/core/src/match/recipe_alternatives.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <numbers>
 #include <string>
 #include <unordered_set>
 
@@ -23,11 +24,12 @@ std::string RecipeToKey(const std::vector<uint8_t>& recipe) {
 }
 
 float ComputeHueDiff(const Lab& a, const Lab& b) {
-    const float ha = std::atan2(a.b(), a.a());
-    const float hb = std::atan2(b.b(), b.a());
-    float diff     = std::abs(ha - hb);
-    if (diff > static_cast<float>(M_PI)) { diff = 2.0f * static_cast<float>(M_PI) - diff; }
-    return diff * (180.0f / static_cast<float>(M_PI));
+    const float ha      = std::atan2(a.b(), a.a());
+    const float hb      = std::atan2(b.b(), b.a());
+    constexpr float kPi = std::numbers::pi_v<float>;
+    float diff          = std::abs(ha - hb);
+    if (diff > kPi) { diff = 2.0f * kPi - diff; }
+    return diff * (180.0f / kPi);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

- 将 `recipe_alternatives.cpp` 中的非标准 `M_PI` 替换为 C++20 标准的 `std::numbers::pi_v<float>`，修复 MSVC 编译失败

## 原因

MSVC 默认不定义 `M_PI`（需要 `_USE_MATH_DEFINES` 宏），导致 Windows CI 编译报错 `C2065: 'M_PI': undeclared identifier`。

## Test plan

- [ ] Windows CI (MSVC) 编译通过

Made with [Cursor](https://cursor.com)