### PR TITLE
feat: add What's New modal for current version highlights

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Usage: ./scripts/release.sh <new_version> [changelog]
+# Usage: ./scripts/release.sh <new_version> [changelog] [changelog_en]
 #   e.g. ./scripts/release.sh 1.2.6
-#   e.g. ./scripts/release.sh 1.3.0 "- New feature A\n- Bug fix B"
+#   e.g. ./scripts/release.sh 1.3.0 "- 新功能 A\n- 修复 B" "- New feature A\n- Bug fix B"
 #
 # Creates a release branch + PR. After the PR is merged, the
 # release-tag.yml workflow auto-creates the git tag, which triggers
@@ -26,7 +26,8 @@ info() { echo "==> $*"; }
 
 VERSION="${1:-}"
 CHANGELOG="${2:-}"
-[[ -z "$VERSION" ]] && die "Usage: $0 <version> [changelog]  (e.g. 1.2.0)"
+CHANGELOG_EN="${3:-}"
+[[ -z "$VERSION" ]] && die "Usage: $0 <version> [changelog] [changelog_en]  (e.g. 1.2.0)"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "Version must be MAJOR.MINOR.PATCH (got: $VERSION)"
 
 TAG="v${VERSION}"
@@ -104,6 +105,17 @@ grep -q "\"version\": \"${VERSION}\"" "$ROOT/web/electron/package.json" || die "
 
 info "Generating version-manifest.json..."
 mkdir -p "$ROOT/web/frontend/public"
+if [[ -n "$CHANGELOG_EN" ]]; then
+cat > "$ROOT/web/frontend/public/version-manifest.json" <<MANIFEST
+{
+  "version": "${VERSION}",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v${VERSION}",
+  "changelog": "${CHANGELOG}",
+  "changelog_en": "${CHANGELOG_EN}",
+  "published_at": "$(date -u +%Y-%m-%d)"
+}
+MANIFEST
+else
 cat > "$ROOT/web/frontend/public/version-manifest.json" <<MANIFEST
 {
   "version": "${VERSION}",
@@ -112,6 +124,7 @@ cat > "$ROOT/web/frontend/public/version-manifest.json" <<MANIFEST
   "published_at": "$(date -u +%Y-%m-%d)"
 }
 MANIFEST
+fi
 
 # ---------- 3. Commit, push, create PR ----------
 

--- a/web/frontend/public/version-manifest.json
+++ b/web/frontend/public/version-manifest.json
@@ -2,5 +2,6 @@
   "version": "1.2.8",
   "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.8",
   "changelog": "- 新增配方编辑器：支持查看和调整图像中的颜色配方，修改后自动提醒重新生成\n- 校准工具全面升级：上传照片后即可预览定位效果，支持手动微调角点位置\n- 校准结果按色系分组展示，配方一目了然\n- 修复校准配方颜色显示为灰色的问题\n- 自动配色分析更准确，首次使用即为最佳效果\n- 3MF 模型文件生成更稳定，避免导出损坏\n- 下载文件名自动标注通道数，更易识别和管理",
+  "changelog_en": "- New recipe editor: view and adjust color recipes, with auto-reminder to regenerate after changes\n- Calibration tools upgraded: preview positioning after photo upload, manual corner adjustment\n- Calibration results grouped by color family for easy overview\n- Fixed calibration recipe colors showing as gray\n- Improved auto color analysis accuracy, best results on first use\n- More stable 3MF model file generation, preventing export corruption\n- Download filenames now include channel count for easier identification",
   "published_at": "2026-03-21"
 }

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -36,11 +36,13 @@ import VectorizePanel from './components/VectorizePanel.vue'
 import ColorDBBuildSection from './components/calibration/ColorDBBuildSection.vue'
 import ColorDBUploadSection from './components/calibration/ColorDBUploadSection.vue'
 import UpdateBanner from './components/UpdateBanner.vue'
+import WhatsNewModal from './components/WhatsNewModal.vue'
 import CheckUpdateLink from './components/CheckUpdateLink.vue'
 import { darkThemeOverrides, lightThemeOverrides } from './theme'
 import { useAppStore } from './stores/app'
 import { useAppLifecycle } from './composables/feature/useAppLifecycle'
 import { useUpdateChecker } from './composables/feature/useUpdateChecker'
+import { useWhatsNew } from './composables/feature/useWhatsNew'
 import { isElectronRuntime } from './runtime/platform'
 import {
   getSiteIcpNumber,
@@ -103,6 +105,9 @@ useAppLifecycle()
 const { initOnce: initUpdateChecker } = useUpdateChecker()
 initUpdateChecker()
 
+const { initOnce: initWhatsNew, show: showWhatsNew } = useWhatsNew()
+initWhatsNew()
+
 function handleColorDBUpdated() {
   appStore.refreshColorDBs()
 }
@@ -137,7 +142,12 @@ function toggleLocale() {
           <div class="app-shell__header-inner">
             <NSpace align="center" :size="12">
               <NText strong class="app-shell__brand-title">ChromaPrint3D</NText>
-              <NText v-if="serverVersion" depth="3" class="app-shell__version">
+              <NText
+                v-if="serverVersion"
+                depth="3"
+                class="app-shell__version app-shell__version--clickable"
+                @click="showWhatsNew"
+              >
                 v{{ serverVersion }}
               </NText>
             </NSpace>
@@ -169,6 +179,7 @@ function toggleLocale() {
         <NLayoutContent class="app-shell__content">
           <div class="app-shell__content-inner">
             <UpdateBanner />
+            <WhatsNewModal />
             <div class="app-shell__announce">
               <div class="app-shell__announce-inner">
                 <span class="app-shell__announce-text">

--- a/web/frontend/src/components/WhatsNewModal.vue
+++ b/web/frontend/src/components/WhatsNewModal.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { NModal, NCard, NButton, NSpace, NText } from 'naive-ui'
+import { useWhatsNew } from '../composables/feature/useWhatsNew'
+
+const { t } = useI18n()
+const { visible, version, changelogLines, markAsSeen } = useWhatsNew()
+</script>
+
+<template>
+  <NModal v-model:show="visible" :mask-closable="true" @after-leave="markAsSeen">
+    <NCard
+      class="whats-new-card"
+      :title="t('app.whatsNew.title', { version })"
+      :bordered="false"
+      role="dialog"
+      aria-modal="true"
+      closable
+      @close="visible = false"
+    >
+      <NSpace vertical :size="6">
+        <ul v-if="changelogLines.length" class="whats-new-card__list">
+          <li v-for="(line, i) in changelogLines" :key="i">
+            <NText>{{ line }}</NText>
+          </li>
+        </ul>
+      </NSpace>
+      <template #footer>
+        <NSpace justify="end">
+          <NButton type="primary" @click="visible = false">
+            {{ t('app.whatsNew.gotIt') }}
+          </NButton>
+        </NSpace>
+      </template>
+    </NCard>
+  </NModal>
+</template>
+
+<style scoped>
+.whats-new-card {
+  width: min(480px, 90vw);
+}
+
+.whats-new-card__list {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.whats-new-card__list li {
+  margin: 6px 0;
+  line-height: 1.6;
+}
+</style>

--- a/web/frontend/src/composables/feature/useUpdateChecker.ts
+++ b/web/frontend/src/composables/feature/useUpdateChecker.ts
@@ -1,40 +1,16 @@
 import { ref, computed, readonly } from 'vue'
 import { useAppStore } from '../../stores/app'
 import { isElectronRuntime } from '../../runtime/platform'
-
-export type VersionManifest = {
-  version: string
-  download_url: string
-  changelog: string
-  published_at: string
-}
+import { compareVersions, fetchManifestFromUrl } from './versionManifest'
+export type { VersionManifest } from './versionManifest'
 
 const DISMISS_KEY = 'chromaprint3d-update-dismissed'
-const FETCH_TIMEOUT_MS = 5000
 
 function getManifestUrl(): string {
   const electronUrl = window.electron?.env?.updateManifestUrl
   if (electronUrl?.trim()) return electronUrl.trim()
   const envUrl = import.meta.env.VITE_UPDATE_MANIFEST_URL
   return typeof envUrl === 'string' ? envUrl.trim() : ''
-}
-
-function compareVersions(a: string, b: string): number {
-  const pa = a.split('.').map(Number)
-  const pb = b.split('.').map(Number)
-  const len = Math.max(pa.length, pb.length)
-  for (let i = 0; i < len; i++) {
-    const na = pa[i] ?? 0
-    const nb = pb[i] ?? 0
-    if (na !== nb) return na - nb
-  }
-  return 0
-}
-
-function isValidManifest(data: unknown): data is VersionManifest {
-  if (typeof data !== 'object' || data === null) return false
-  const obj = data as Record<string, unknown>
-  return typeof obj.version === 'string' && /^\d+\.\d+\.\d+/.test(obj.version)
 }
 
 function isDismissedForVersion(version: string): boolean {
@@ -73,23 +49,8 @@ export function useUpdateChecker() {
 
   const showBanner = computed(() => hasUpdate.value && !dismissed.value)
 
-  async function fetchManifest(): Promise<VersionManifest | null> {
-    const url = getManifestUrl()
-    if (!url) return null
-
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-    try {
-      const resp = await fetch(url, { signal: controller.signal, cache: 'no-cache' })
-      if (!resp.ok) return null
-      const data: unknown = await resp.json()
-      if (!isValidManifest(data)) return null
-      return data
-    } catch {
-      return null
-    } finally {
-      clearTimeout(timer)
-    }
+  async function fetchManifest() {
+    return fetchManifestFromUrl(getManifestUrl())
   }
 
   async function checkForUpdate(): Promise<boolean> {

--- a/web/frontend/src/composables/feature/useWhatsNew.ts
+++ b/web/frontend/src/composables/feature/useWhatsNew.ts
@@ -1,0 +1,74 @@
+import { ref, computed, readonly } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { fetchManifestFromUrl } from './versionManifest'
+import type { VersionManifest } from './versionManifest'
+import { getStorageItem, setStorageItem } from '../../runtime/storage'
+
+const SEEN_KEY = 'chromaprint3d-whats-new-seen'
+const LOCAL_MANIFEST_PATH = `${import.meta.env.BASE_URL}version-manifest.json`
+
+const manifest = ref<VersionManifest | null>(null)
+const visible = ref(false)
+let initialized = false
+
+function parseChangelogLines(raw: string): string[] {
+  if (!raw) return []
+  return raw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => l.replace(/^[-·•]\s*/, ''))
+}
+
+export function useWhatsNew() {
+  const { locale } = useI18n()
+
+  const version = computed(() => manifest.value?.version ?? '')
+
+  const changelogLines = computed(() => {
+    if (!manifest.value) return []
+    const raw =
+      locale.value === 'en' && manifest.value.changelog_en
+        ? manifest.value.changelog_en
+        : manifest.value.changelog
+    return parseChangelogLines(raw ?? '')
+  })
+
+  function show() {
+    if (manifest.value && changelogLines.value.length > 0) {
+      visible.value = true
+    }
+  }
+
+  async function markAsSeen() {
+    visible.value = false
+    if (manifest.value?.version) {
+      await setStorageItem(SEEN_KEY, manifest.value.version)
+    }
+  }
+
+  async function initOnce() {
+    if (initialized) return
+    initialized = true
+
+    const data = await fetchManifestFromUrl(LOCAL_MANIFEST_PATH)
+    if (!data) return
+    manifest.value = data
+
+    if (!data.changelog?.trim()) return
+
+    const seen = await getStorageItem(SEEN_KEY)
+    if (seen !== data.version) {
+      visible.value = true
+    }
+  }
+
+  return {
+    visible,
+    version: readonly(version),
+    changelogLines,
+    show,
+    markAsSeen,
+    initOnce,
+  }
+}

--- a/web/frontend/src/composables/feature/versionManifest.ts
+++ b/web/frontend/src/composables/feature/versionManifest.ts
@@ -1,0 +1,48 @@
+export type VersionManifest = {
+  version: string
+  download_url: string
+  changelog: string
+  changelog_en?: string
+  published_at: string
+}
+
+const DEFAULT_TIMEOUT_MS = 5000
+
+export function isValidManifest(data: unknown): data is VersionManifest {
+  if (typeof data !== 'object' || data === null) return false
+  const obj = data as Record<string, unknown>
+  return typeof obj.version === 'string' && /^\d+\.\d+\.\d+/.test(obj.version)
+}
+
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  const len = Math.max(pa.length, pb.length)
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0
+    const nb = pb[i] ?? 0
+    if (na !== nb) return na - nb
+  }
+  return 0
+}
+
+export async function fetchManifestFromUrl(
+  url: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<VersionManifest | null> {
+  if (!url) return null
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const resp = await fetch(url, { signal: controller.signal, cache: 'no-cache' })
+    if (!resp.ok) return null
+    const data: unknown = await resp.json()
+    if (!isValidManifest(data)) return null
+    return data
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/web/frontend/src/locales/en.ts
+++ b/web/frontend/src/locales/en.ts
@@ -63,6 +63,10 @@ export default {
       upToDate: 'You are up to date',
       checkFailed: 'Unable to check for updates, please try again later',
     },
+    whatsNew: {
+      title: "What's New in v{version}",
+      gotIt: 'Got it',
+    },
   },
 
   convert: {

--- a/web/frontend/src/locales/zh-CN.ts
+++ b/web/frontend/src/locales/zh-CN.ts
@@ -93,6 +93,10 @@ export default {
       upToDate: '已是最新版本',
       checkFailed: '无法检查更新，请稍后重试',
     },
+    whatsNew: {
+      title: 'v{version} 版本亮点',
+      gotIt: '知道了',
+    },
   },
 
   convert: {

--- a/web/frontend/src/styles/app-shell.css
+++ b/web/frontend/src/styles/app-shell.css
@@ -48,6 +48,17 @@
   font-size: 12px;
 }
 
+.app-shell__version--clickable {
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 1px 4px;
+  transition: background-color 0.2s;
+}
+
+.app-shell__version--clickable:hover {
+  background-color: rgba(128, 128, 128, 0.12);
+}
+
 .app-shell__header-status {
   justify-content: flex-end;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- 新增"版本亮点"模态框（What's New Modal），用户升级后首次访问自动展示当前版本新特性，关闭后不再打扰，可通过 Header 版本号随时重新查看
- 复用已有 `version-manifest.json` 作为统一数据源，不引入额外数据文件
- 从 `useUpdateChecker` 提取共享的 `VersionManifest` 类型和工具函数到 `versionManifest.ts`，消除重复代码
- 扩展 manifest 格式支持可选 `changelog_en` 字段，`release.sh` 同步支持英文 changelog 参数

## Changes

| File | Change |
|------|--------|
| `web/frontend/src/composables/feature/versionManifest.ts` | **New** — shared VersionManifest type, validation, fetch utility |
| `web/frontend/src/composables/feature/useWhatsNew.ts` | **New** — composable: local manifest fetch, localStorage version compare, show/dismiss logic |
| `web/frontend/src/components/WhatsNewModal.vue` | **New** — NModal + NCard component for displaying changelog |
| `web/frontend/src/composables/feature/useUpdateChecker.ts` | Refactored to import from shared module, no behavior change |
| `web/frontend/src/App.vue` | Integrate WhatsNewModal, make version badge clickable |
| `web/frontend/src/locales/zh-CN.ts` / `en.ts` | Add `app.whatsNew` i18n keys |
| `web/frontend/src/styles/app-shell.css` | Clickable version badge hover style |
| `web/frontend/public/version-manifest.json` | Add `changelog_en` field |
| `scripts/release.sh` | Accept optional 3rd arg for English changelog |

## Test plan

- [ ] 清除 localStorage 中 `chromaprint3d-whats-new-seen`，打开页面确认弹窗自动出现
- [ ] 点击"知道了"关闭弹窗，刷新页面确认不再弹出
- [ ] 点击 Header 版本号，确认可手动重新打开弹窗
- [ ] 切换语言到 English，确认弹窗标题和 changelog 切换为英文
- [ ] 深色模式下确认弹窗样式正常
- [ ] 确认 UpdateBanner（远程更新提示）功能不受影响
- [ ] `vue-tsc --noEmit` 类型检查通过


Made with [Cursor](https://cursor.com)