### PR TITLE
fix: stop rebuilding region_map after recipe replacement

### DIFF
--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -744,8 +744,13 @@ bool TaskRuntime::ReplaceRecipe(const std::string& owner, const std::string& id,
             return false;
         }
 
-        rmap                  = ChromaPrint3D::RasterRegionMap::Build(mstate.recipe_map);
-        cp->region_map_binary = rmap.SerializeRegionIds();
+        for (int rid : target_region_ids) {
+            if (rid < 0 || static_cast<std::size_t>(rid) >= rmap.regions.size()) continue;
+            auto& info        = rmap.regions[static_cast<std::size_t>(rid)];
+            info.recipe       = new_recipe;
+            info.mapped_color = new_mapped_color;
+            info.from_model   = new_from_model;
+        }
 
         cv::Mat preview_bgra = mstate.recipe_map.ToBgraImage();
         if (!preview_bgra.empty()) {
@@ -766,14 +771,6 @@ bool TaskRuntime::ReplaceRecipe(const std::string& owner, const std::string& id,
             message     = e.what();
             return false;
         }
-
-        cv::Mat region_ids_mat =
-            ChromaPrint3D::RenderVectorRegionIds(vstate.proc_result, vstate.recipe_map);
-        const std::size_t total = static_cast<std::size_t>(region_ids_mat.rows) *
-                                  static_cast<std::size_t>(region_ids_mat.cols);
-        cp->region_map_binary.resize(total * sizeof(uint32_t));
-        std::memcpy(cp->region_map_binary.data(), region_ids_mat.data,
-                    cp->region_map_binary.size());
 
         cp->result.preview_png = ChromaPrint3D::RenderVectorPreviewPng(
             vstate.proc_result, vstate.recipe_map, vstate.profile.palette);

--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -279,7 +279,6 @@ async function handleCandidateSelect(candidate: RecipeCandidate) {
     undoStack.value.push({ regionIds, oldRecipe, oldRecipeIndex })
 
     summary.value = newSummary
-    await loadRegionMap(props.taskId, newSummary.width, newSummary.height)
     await loadPreview()
 
     const firstRegion = newSummary.regions.find((r) => regionIds.includes(r.region_id))
@@ -309,7 +308,6 @@ async function handleUndo() {
       entry.oldRecipe.from_model,
     )
     summary.value = newSummary
-    await loadRegionMap(props.taskId, newSummary.width, newSummary.height)
     await loadPreview()
 
     const firstRegion = newSummary.regions.find((r) => entry.regionIds.includes(r.region_id))


### PR DESCRIPTION
## Summary

- **Fix undo data corruption (raster path)**: `RasterRegionMap::Build` was called after every recipe replacement, re-grouping pixels by recipe via BFS. When adjacent regions ended up with the same recipe, they merged and all region_ids were renumbered. This caused the frontend undo stack (which stores original region_ids) to point to wrong pixel sets — undo operations silently corrupted data.
- **Eliminate redundant computation (vector path)**: `RenderVectorRegionIds` was called after every replacement, but its output depends only on entry indices and `shape_idx` (neither modified by `ReplaceRecipeForEntries`), producing byte-for-byte identical output — pure waste.
- **Remove unnecessary ~812KB download**: Frontend no longer re-downloads `region_map.bin` after each replacement since the region map is now guaranteed stable.

## Changes

### Backend (`task_runtime.cpp`)
- Raster `ReplaceRecipe`: replaced `Build` + `SerializeRegionIds` with in-place update of `rmap.regions` metadata (`recipe`, `mapped_color`, `from_model`)
- Vector `ReplaceRecipe`: removed `RenderVectorRegionIds` + `memcpy` (7 lines deleted)
- Preview and source_mask re-rendering preserved in both paths

### Frontend (`RecipeEditorPanel.vue`)
- Removed `loadRegionMap` calls from `handleCandidateSelect` and `handleUndo`

## Correctness verification

- **Raster**: `ReplaceRecipeInRegions` locates pixels via the original `region_map.region_ids[i]`, independent of Build. Stable region_ids ensure undo stack entries always target the correct pixel set.
- **Vector**: `ReplaceRecipeForEntries` operates by entry index; entry count, indices, and `shape_idx` are invariant across replacements.
- **Model generation**: `GenerateRasterModel` / `GenerateVectorModel` use `recipe_map` (per-pixel/per-entry), not `rmap` or `region_map_binary`.
- **Summary generation**: Raster `GetRecipeEditorSummaryLocked` reads `rmap.regions` (now updated in-place); vector path reads `vstate.recipe_map.entries` (updated by `ReplaceRecipeForEntries`).
- **Initial load**: `loadSummary()` still downloads `region_map.bin` on first load — unchanged.

## Test plan

- [ ] Upload raster image → match → replace a region's recipe to match an adjacent region → verify undo restores only the originally selected region (not the adjacent one)
- [ ] Upload SVG → match → replace recipe → verify preview updates correctly without re-downloading region_map
- [ ] Verify multiple sequential replacements + undos maintain correct state
- [ ] Verify Generate Model produces correct 3MF after recipe edits


Made with [Cursor](https://cursor.com)