### PR TITLE
release: v1.2.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ChromaPrint3D VERSION 1.2.8 LANGUAGES CXX)
+project(ChromaPrint3D VERSION 1.2.9 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "private": true,
   "description": "ChromaPrint3D - Multi-color 3D printing image processor",
   "author": "neroued <neroued@gmail.com>",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d-web",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Web frontend for ChromaPrint3D — multi-color 3D print image processor",
   "type": "module",
   "license": "Apache-2.0",

--- a/web/frontend/public/version-manifest.json
+++ b/web/frontend/public/version-manifest.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.2.8",
-  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.8",
-  "changelog": "- 新增配方编辑器：支持查看和调整图像中的颜色配方，修改后自动提醒重新生成\n- 校准工具全面升级：上传照片后即可预览定位效果，支持手动微调角点位置\n- 校准结果按色系分组展示，配方一目了然\n- 修复校准配方颜色显示为灰色的问题\n- 自动配色分析更准确，首次使用即为最佳效果\n- 3MF 模型文件生成更稳定，避免导出损坏\n- 下载文件名自动标注通道数，更易识别和管理",
-  "changelog_en": "- New recipe editor: view and adjust color recipes, with auto-reminder to regenerate after changes\n- Calibration tools upgraded: preview positioning after photo upload, manual corner adjustment\n- Calibration results grouped by color family for easy overview\n- Fixed calibration recipe colors showing as gray\n- Improved auto color analysis accuracy, best results on first use\n- More stable 3MF model file generation, preventing export corruption\n- Download filenames now include channel count for easier identification",
-  "published_at": "2026-03-21"
+  "version": "1.2.9",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.9",
+  "changelog": "- 新增「最近更新」弹窗，升级后自动展示版本亮点\n- 修复配方编辑器中撤销操作可能导致颜色数据异常的问题\n- 配方替换响应更快，减少不必要的数据加载",
+  "changelog_en": "- New What's New dialog shows version highlights after updates\n- Fix undo in recipe editor that could corrupt color data when adjacent regions share the same recipe\n- Faster recipe replacement with reduced unnecessary data transfers",
+  "published_at": "2026-03-22"
 }


### PR DESCRIPTION
## Release v1.2.9

Bumps version to `1.2.9` in:
- `CMakeLists.txt`
- `web/frontend/package.json`
- `web/electron/package.json`
- `web/frontend/public/version-manifest.json`

After this PR is merged, the `release-tag` workflow will automatically
create tag `v1.2.9` and trigger the full release pipeline.