### PR TITLE
fix: improve recipe editor performance and fix global-mode deselect

### DIFF
--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -23,6 +23,8 @@
 
 namespace {
 
+constexpr int kMaxUniqueRecipes = 2048;
+
 std::string LabToHex(const ChromaPrint3D::Lab& lab) {
     auto rgb   = lab.ToRgb();
     uint8_t r8 = 0, g8 = 0, b8 = 0;
@@ -293,7 +295,6 @@ SubmitResult TaskRuntime::SubmitConvertRasterMatchOnly(const std::string& owner,
                 unique_recipes.insert(std::move(key));
             }
 
-            constexpr int kMaxUniqueRecipes = 128;
             if (static_cast<int>(unique_recipes.size()) > kMaxUniqueRecipes) {
                 throw std::runtime_error(
                     "Too many unique recipes: " + std::to_string(unique_recipes.size()) + ", max " +
@@ -367,7 +368,6 @@ SubmitResult TaskRuntime::SubmitConvertVectorMatchOnly(const std::string& owner,
                 unique_recipes.insert(std::move(key));
             }
 
-            constexpr int kMaxUniqueRecipes = 128;
             if (static_cast<int>(unique_recipes.size()) > kMaxUniqueRecipes) {
                 throw std::runtime_error(
                     "Too many unique recipes: " + std::to_string(unique_recipes.size()) + ", max " +

--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -87,6 +87,15 @@ const targetHex = computed<string | null>(() => {
   return recipe?.hex ?? null
 })
 
+const regionLookup = computed(() => {
+  const map = new Map<number, number>()
+  if (!summary.value) return map
+  for (const reg of summary.value.regions) {
+    map.set(reg.region_id, reg.recipe_index)
+  }
+  return map
+})
+
 // ── Data loading ─────────────────────────────────────────────────────────────
 
 async function loadSummary() {
@@ -164,9 +173,9 @@ function handlePreviewMouseMove(event: MouseEvent) {
   let recipeLabel: string | null = null
   let recipeHex: string | null = null
   if (rid !== null && rid !== 0xffffffff) {
-    const reg = summary.value.regions.find((r) => r.region_id === rid)
-    if (reg) {
-      const recipe = summary.value.unique_recipes[reg.recipe_index]
+    const recipeIdx = regionLookup.value.get(rid)
+    if (recipeIdx !== undefined) {
+      const recipe = summary.value.unique_recipes[recipeIdx]
       if (recipe) {
         recipeLabel = recipe.recipe.join('-')
         recipeHex = recipe.hex
@@ -208,14 +217,17 @@ function handleViewportClick(event: MouseEvent) {
   if (regionId === null || regionId === 0xffffffff) return
 
   if (globalMode.value) {
-    const region = summary.value.regions.find((r) => r.region_id === regionId)
-    if (region) {
-      selectRecipeByIndex(region.recipe_index)
+    const recipeIdx = regionLookup.value.get(regionId)
+    if (recipeIdx !== undefined) {
+      if (recipeIdx === selectedRecipeIndex.value) {
+        clearSelection()
+      } else {
+        selectRecipeByIndex(recipeIdx)
+      }
     }
   } else {
-    const clickedRegion = summary.value.regions.find((r) => r.region_id === regionId)
-    if (!clickedRegion) return
-    const clickedRecipeIdx = clickedRegion.recipe_index
+    const clickedRecipeIdx = regionLookup.value.get(regionId)
+    if (clickedRecipeIdx === undefined) return
 
     if (selectedRecipeIndex.value !== null && clickedRecipeIdx !== selectedRecipeIndex.value) {
       selectedRegionIds.value = new Set([regionId])
@@ -281,7 +293,8 @@ async function handleCandidateSelect(candidate: RecipeCandidate) {
     summary.value = newSummary
     await loadPreview()
 
-    const firstRegion = newSummary.regions.find((r) => regionIds.includes(r.region_id))
+    const selectedSet = selectedRegionIds.value
+    const firstRegion = newSummary.regions.find((r) => selectedSet.has(r.region_id))
     if (firstRegion !== undefined) {
       selectedRecipeIndex.value = firstRegion.recipe_index
     }
@@ -310,7 +323,8 @@ async function handleUndo() {
     summary.value = newSummary
     await loadPreview()
 
-    const firstRegion = newSummary.regions.find((r) => entry.regionIds.includes(r.region_id))
+    const undoSet = new Set(entry.regionIds)
+    const firstRegion = newSummary.regions.find((r) => undoSet.has(r.region_id))
     if (firstRegion !== undefined) {
       selectedRecipeIndex.value = firstRegion.recipe_index
       selectedRegionIds.value = new Set(entry.regionIds)

--- a/web/frontend/src/components/recipeEditor/RecipeSummaryPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeSummaryPanel.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, ref, watch, nextTick } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { NCard, NText, NScrollbar } from 'naive-ui'
+import { NCard, NText, NVirtualList } from 'naive-ui'
+import type { VirtualListInst } from 'naive-ui'
 import type { RecipeEditorSummary, RecipeInfo } from '../../types'
 import RecipeLayerBar from './RecipeLayerBar.vue'
 
@@ -29,20 +30,42 @@ interface RecipeRow {
 const recipeRows = computed<RecipeRow[]>(() => {
   const s = props.summary
   const total = totalPixels.value
-  const rows = s.unique_recipes.map((recipe, idx) => {
-    let regionCount = 0
-    let pixelCount = 0
-    for (const reg of s.regions) {
-      if (reg.recipe_index === idx) {
-        regionCount++
-        pixelCount += reg.pixel_count
-      }
+
+  const agg = new Map<number, { regionCount: number; pixelCount: number }>()
+  for (const reg of s.regions) {
+    const entry = agg.get(reg.recipe_index)
+    if (entry) {
+      entry.regionCount++
+      entry.pixelCount += reg.pixel_count
+    } else {
+      agg.set(reg.recipe_index, { regionCount: 1, pixelCount: reg.pixel_count })
     }
-    const pct = total > 0 ? ((pixelCount / total) * 100).toFixed(1) : '0.0'
-    return { index: idx, recipe, regionCount, pixelCount, areaPercent: pct }
+  }
+
+  const rows = s.unique_recipes.map((recipe, idx) => {
+    const a = agg.get(idx) ?? { regionCount: 0, pixelCount: 0 }
+    const pct = total > 0 ? ((a.pixelCount / total) * 100).toFixed(1) : '0.0'
+    return { index: idx, recipe, ...a, areaPercent: pct }
   })
   rows.sort((a, b) => b.pixelCount - a.pixelCount)
   return rows
+})
+
+interface PairedRow {
+  key: number
+  left: RecipeRow
+  right: RecipeRow | null
+}
+
+const pairedRows = computed<PairedRow[]>(() => {
+  const pairs: PairedRow[] = []
+  const rows = recipeRows.value
+  for (let i = 0; i < rows.length; i += 2) {
+    const left = rows[i]
+    if (!left) continue
+    pairs.push({ key: i, left, right: rows[i + 1] ?? null })
+  }
+  return pairs
 })
 
 const statsText = computed(() => {
@@ -51,7 +74,7 @@ const statsText = computed(() => {
   return t('recipeEditor.summary.stats', { recipes: rc, regions: rg })
 })
 
-const listRef = ref<HTMLElement | null>(null)
+const virtualListRef = ref<VirtualListInst | null>(null)
 
 function handleClick(index: number) {
   emit('selectRecipe', index)
@@ -60,11 +83,11 @@ function handleClick(index: number) {
 watch(
   () => props.selectedRecipeIndex,
   (idx) => {
-    if (idx === null || !listRef.value) return
-    void nextTick(() => {
-      const el = listRef.value?.querySelector(`[data-recipe-index="${idx}"]`)
-      if (el) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
-    })
+    if (idx === null) return
+    const sortedPos = recipeRows.value.findIndex((r) => r.index === idx)
+    if (sortedPos >= 0) {
+      virtualListRef.value?.scrollTo({ index: Math.floor(sortedPos / 2) })
+    }
   },
 )
 </script>
@@ -75,35 +98,71 @@ watch(
       <NText depth="3" style="font-size: 12px">{{ statsText }}</NText>
     </template>
     <div class="recipe-summary-scroll-wrapper">
-      <NScrollbar>
-        <div ref="listRef" class="recipe-summary-list">
-          <div
-            v-for="row in recipeRows"
-            :key="row.index"
-            :data-recipe-index="row.index"
-            class="recipe-summary-item"
-            :class="{ 'recipe-summary-item--selected': selectedRecipeIndex === row.index }"
-            @click="handleClick(row.index)"
-          >
-            <div class="recipe-summary-item__color" :style="{ backgroundColor: row.recipe.hex }" />
-            <div class="recipe-summary-item__info">
-              <RecipeLayerBar :recipe="row.recipe.recipe" :palette="summary.palette" />
-              <span class="recipe-summary-item__meta">
-                {{ t('recipeEditor.summary.regions', { count: row.regionCount }) }}
-                · {{ row.areaPercent }}%
-              </span>
-            </div>
-            <NText
-              v-if="row.recipe.from_model"
-              depth="3"
-              class="recipe-summary-item__badge"
-              type="warning"
+      <NVirtualList
+        ref="virtualListRef"
+        :items="pairedRows"
+        :item-size="38"
+        item-resizable
+        class="recipe-summary-vlist"
+      >
+        <template #default="{ item }: { item: PairedRow }">
+          <div class="recipe-summary-row">
+            <div
+              class="recipe-summary-item"
+              :class="{ 'recipe-summary-item--selected': selectedRecipeIndex === item.left.index }"
+              @click="handleClick(item.left.index)"
             >
-              M
-            </NText>
+              <div
+                class="recipe-summary-item__color"
+                :style="{ backgroundColor: item.left.recipe.hex }"
+              />
+              <div class="recipe-summary-item__info">
+                <RecipeLayerBar :recipe="item.left.recipe.recipe" :palette="summary.palette" />
+                <span class="recipe-summary-item__meta">
+                  {{ t('recipeEditor.summary.regions', { count: item.left.regionCount }) }}
+                  · {{ item.left.areaPercent }}%
+                </span>
+              </div>
+              <NText
+                v-if="item.left.recipe.from_model"
+                depth="3"
+                class="recipe-summary-item__badge"
+                type="warning"
+              >
+                M
+              </NText>
+            </div>
+            <div
+              v-if="item.right"
+              class="recipe-summary-item"
+              :class="{
+                'recipe-summary-item--selected': selectedRecipeIndex === item.right.index,
+              }"
+              @click="handleClick(item.right.index)"
+            >
+              <div
+                class="recipe-summary-item__color"
+                :style="{ backgroundColor: item.right.recipe.hex }"
+              />
+              <div class="recipe-summary-item__info">
+                <RecipeLayerBar :recipe="item.right.recipe.recipe" :palette="summary.palette" />
+                <span class="recipe-summary-item__meta">
+                  {{ t('recipeEditor.summary.regions', { count: item.right.regionCount }) }}
+                  · {{ item.right.areaPercent }}%
+                </span>
+              </div>
+              <NText
+                v-if="item.right.recipe.from_model"
+                depth="3"
+                class="recipe-summary-item__badge"
+                type="warning"
+              >
+                M
+              </NText>
+            </div>
           </div>
-        </div>
-      </NScrollbar>
+        </template>
+      </NVirtualList>
     </div>
   </NCard>
 </template>
@@ -130,7 +189,11 @@ watch(
   overflow: hidden;
 }
 
-.recipe-summary-list {
+.recipe-summary-vlist {
+  height: 100%;
+}
+
+.recipe-summary-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 2px;


### PR DESCRIPTION
## Summary

- **后端**：将 `kMaxUniqueRecipes` 从 128 提升至 2048，支持颜色数量较多的 SVG（如 Adobe Illustrator 导出），并提取为文件级常量消除重复定义
- **前端 RecipeSummaryPanel**：`recipeRows` 计算复杂度从 O(U×R) 优化至 O(R+U)（预聚合 Map）；用 `NVirtualList` 虚拟滚动替换 `NScrollbar` 全量渲染，两列配对布局
- **前端 RecipeEditorPanel**：新增 `regionLookup` computed Map，mousemove/click 中的区域查找从 O(R) 线性遍历优化为 O(1)；替换/撤销路径中 `Array.includes` 改为 `Set.has`
- **修复**：全局模式（选中同色）下点击已选中配方的区域现在可以正确取消选中

## Test plan

- [ ] 打开含 500+ 唯一配方的 SVG，确认配方编辑器正常加载且列表滚动流畅
- [ ] 验证配方列表两列布局正确显示，选中高亮和滚动定位正常
- [ ] 启用"选中同色"模式，点击区域选中配方，再次点击同一区域确认可以取消选中
- [ ] 非全局模式下，点击区域 toggle 选中/取消选中行为不变
- [ ] 鼠标悬停预览信息（配方标签、颜色）正常显示
- [ ] 替换配方和撤销操作功能正常

Made with [Cursor](https://cursor.com)