### PR TITLE
docs: sync build/development/deployment docs with actual project

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -93,6 +93,7 @@ cmake --build build -j$(nproc)
 | `gen_stage` | 生成建模阶梯色板 |
 | `gen_representative_board` | 从配方文件生成代表性校准板 |
 | `svg_to_3mf` | SVG 转 3MF |
+| `gen_test_preset_3mf` | 生成测试预设 3MF |
 
 ### 2.4 构建 Web 前端
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,8 +94,6 @@ cd ~/chromaprint3d-deploy
 
 ```yaml
 # ~/chromaprint3d-deploy/docker-compose.yml
-version: "3.8"
-
 services:
   chromaprint3d:
     # API-only 镜像（不含前端），跨域部署专用
@@ -153,7 +151,7 @@ services:
     memswap_limit: 4g
     pids_limit: 512
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8080'"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/api/v1/health"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,13 +21,17 @@
 
 ```text
 ChromaPrint3D/
+├── 3dparty/               # 第三方子模块（spdlog、Clipper2、lunasvg、neroued_vectorizer）
 ├── core/                  # C++ 核心库（颜色匹配、图像处理、3MF 导出）
 ├── infer/                 # 深度学习推理封装（ONNX Runtime 后端）
 ├── apps/                  # CLI 工具
 ├── web/
 │   ├── frontend/          # Vue 3 前端
-│   └── backend/           # C++ Drogon HTTP 服务
+│   ├── backend/           # C++ Drogon HTTP 服务
+│   └── electron/          # Electron 桌面壳
 ├── modeling/              # Python 建模管线
+├── scripts/               # 发布、部署、CI 打包、模型下载/上传脚本
+├── tools/                 # 辅助工具（npy_to_colordb.py 等）
 ├── data/                  # 运行时数据（db/model_pack/models 等）
 └── docs/                  # 文档
 ```


### PR DESCRIPTION
## Summary

- **build.md**：构建产物表补充遗漏的 `gen_test_preset_3mf` CLI 工具
- **development.md**：项目结构树补充 `3dparty/`（第三方子模块）、`scripts/`（发布/CI/模型脚本）、`tools/`（辅助工具）、`web/electron/`（桌面壳）
- **deployment.md**：移除已弃用的 `version: "3.8"` docker-compose 声明；healthcheck 从 TCP 探活改为 `curl` HTTP `/api/v1/health` 端点检测，与 Dockerfile 内置 HEALTHCHECK 保持一致

## Test plan

- [ ] 确认 `docs/build.md` 产物表与 `apps/CMakeLists.txt` 中的可执行文件完全一致
- [ ] 确认 `docs/development.md` 结构树与仓库顶层目录吻合
- [ ] 确认 `docs/deployment.md` compose 示例可通过 `docker compose config` 校验（无 version warning）

Made with [Cursor](https://cursor.com)