### PR TITLE
refactor: demote diagnostic/perf logs from info to debug across core and backend

### DIFF
--- a/core/src/calib/calib.cpp
+++ b/core/src/calib/calib.cpp
@@ -744,8 +744,8 @@ CalibrationBoardMeshes GenCalibrationBoardMeshes(const CalibrationBoardConfig& c
         total_verts += m.vertices.size();
         total_tris += m.indices.size();
     }
-    spdlog::info("Mesh::Build: {} grids, total vertices={}, triangles={}", n, total_verts,
-                 total_tris);
+    spdlog::debug("Mesh::Build: {} grids, total vertices={}, triangles={}", n, total_verts,
+                  total_tris);
 
     CalibrationBoardMeshes out;
     out.meta             = std::move(meta);
@@ -775,8 +775,8 @@ CalibrationBoardMeshes GenCalibrationBoardMeshesFromMeta(CalibrationBoardMeta me
         total_verts += m.vertices.size();
         total_tris += m.indices.size();
     }
-    spdlog::info("Mesh::Build(custom): {} grids, total vertices={}, triangles={}", n, total_verts,
-                 total_tris);
+    spdlog::debug("Mesh::Build(custom): {} grids, total vertices={}, triangles={}", n, total_verts,
+                  total_tris);
 
     CalibrationBoardMeshes out;
     out.meta             = std::move(meta);

--- a/core/src/geo/bambu_metadata.cpp
+++ b/core/src/geo/bambu_metadata.cpp
@@ -376,8 +376,8 @@ std::string BuildProjectSettings(const SlicerPreset& preset) {
     // hard-checks this value to enable different_settings_to_system handling.
     if (!j.contains("name")) { j["name"] = "project_settings"; }
 
-    spdlog::info("BuildProjectSettings: loaded preset {} ({} filament overrides)",
-                 preset.preset_json_path, preset.filaments.size());
+    spdlog::debug("BuildProjectSettings: loaded preset {} ({} filament overrides)",
+                  preset.preset_json_path, preset.filaments.size());
     return j.dump(4);
 }
 
@@ -408,7 +408,7 @@ std::string BuildEmbeddedProcessPreset(const SlicerPreset& preset) {
                              : "0.08mm High Quality @BBL P2S";
     j["inherits"]      = parent;
 
-    spdlog::info("BuildEmbeddedProcessPreset: name={}, inherits={}", id_buf, parent);
+    spdlog::debug("BuildEmbeddedProcessPreset: name={}, inherits={}", id_buf, parent);
     return j.dump(4);
 }
 
@@ -461,8 +461,8 @@ std::string BuildLayerConfigRanges(const SlicerPreset& preset) {
                   "</objects>\n",
                   dmin, dmax, dlh);
 
-    spdlog::info("BuildLayerConfigRanges: base=[{},{}]@{}mm, face={}, double_sided={}", dmin, dmax,
-                 dlh, FaceOrientationTag(preset.face), preset.double_sided);
+    spdlog::debug("BuildLayerConfigRanges: base=[{},{}]@{}mm, face={}, double_sided={}", dmin, dmax,
+                  dlh, FaceOrientationTag(preset.face), preset.double_sided);
     return buf;
 }
 

--- a/core/src/geo/export_3mf.cpp
+++ b/core/src/geo/export_3mf.cpp
@@ -99,8 +99,8 @@ std::vector<Mesh> BuildMeshes(const ModelIR& model_ir, const BuildMeshConfig& cf
         total_verts += mesh.vertices.size();
         total_tris += mesh.indices.size();
     }
-    spdlog::info("Mesh::Build: {} grids, total vertices={}, triangles={}", n, total_verts,
-                 total_tris);
+    spdlog::debug("Mesh::Build: {} grids, total vertices={}, triangles={}", n, total_verts,
+                  total_tris);
     return meshes;
 }
 
@@ -145,8 +145,8 @@ Mesh BuildTransparentLayerFromModelIR(const ModelIR& model_ir, float pixel_mm,
     }
     for (auto& v : mesh.vertices) { v.z += total_z; }
 
-    spdlog::info("BuildTransparentLayerFromModelIR: verts={}, tris={}, z=[{}, {}]",
-                 mesh.vertices.size(), mesh.indices.size(), total_z, total_z + thickness_mm);
+    spdlog::debug("BuildTransparentLayerFromModelIR: verts={}, tris={}, z=[{}, {}]",
+                  mesh.vertices.size(), mesh.indices.size(), total_z, total_z + thickness_mm);
     return mesh;
 }
 
@@ -245,8 +245,8 @@ BuildWriterObjects(const std::vector<Mesh>& meshes,
         object.transform         = detail::ThreeMfTransform::Identity();
         objects.push_back(std::move(object));
     }
-    spdlog::info("BuildWriterObjects: {} mesh(es) in, {} object(s) out, {} skipped", meshes.size(),
-                 objects.size(), skipped);
+    spdlog::debug("BuildWriterObjects: {} mesh(es) in, {} object(s) out, {} skipped", meshes.size(),
+                  objects.size(), skipped);
     return objects;
 }
 
@@ -280,8 +280,8 @@ BuildWriterObjectsAndSlots(const std::vector<Mesh>& meshes,
         result.objects.push_back(std::move(object));
         result.slots.push_back(slot_fn(i));
     }
-    spdlog::info("BuildWriterObjectsAndSlots: {} mesh(es) in, {} object(s) out, {} skipped",
-                 meshes.size(), result.objects.size(), skipped);
+    spdlog::debug("BuildWriterObjectsAndSlots: {} mesh(es) in, {} object(s) out, {} skipped",
+                  meshes.size(), result.objects.size(), skipped);
     return result;
 }
 
@@ -335,7 +335,7 @@ void Export3mf(const std::string& path, const ModelIR& model_ir) {
 
 void Export3mf(const std::string& path, const ModelIR& model_ir, const BuildMeshConfig& cfg) {
     if (path.empty()) { throw InputError("Export3mf path is empty"); }
-    spdlog::info("Export3mf: exporting to file {}, {} grid(s)", path, model_ir.voxel_grids.size());
+    spdlog::debug("Export3mf: exporting to file {}, {} grid(s)", path, model_ir.voxel_grids.size());
 
     std::vector<Mesh> meshes = BuildMeshes(model_ir, cfg);
     auto objects             = BuildWriterObjects(
@@ -359,7 +359,7 @@ void Export3mf(const std::string& path, const ModelIR& model_ir, const BuildMesh
 
 std::vector<uint8_t> Export3mfToBuffer(const ModelIR& model_ir, const BuildMeshConfig& cfg,
                                        FaceOrientation face_orientation) {
-    spdlog::info("Export3mfToBuffer: exporting {} grid(s) to memory", model_ir.voxel_grids.size());
+    spdlog::debug("Export3mfToBuffer: exporting {} grid(s) to memory", model_ir.voxel_grids.size());
     std::vector<Mesh> meshes = BuildMeshes(model_ir, cfg);
     OrientMeshesInPlace(meshes, face_orientation);
 
@@ -388,7 +388,7 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
                                          const std::vector<Channel>& palette, int base_channel_idx,
                                          int base_layers, FaceOrientation face_orientation) {
     if (meshes.empty()) { throw InputError("meshes vector is empty"); }
-    spdlog::info("Export3mfFromMeshes: exporting {} mesh(es) to memory", meshes.size());
+    spdlog::debug("Export3mfFromMeshes: exporting {} mesh(es) to memory", meshes.size());
     std::vector<Mesh> mutable_meshes(meshes.begin(), meshes.end());
     OrientMeshesInPlace(mutable_meshes, face_orientation);
 
@@ -420,7 +420,7 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
                                          FaceOrientation face_orientation) {
     if (meshes.empty()) { throw InputError("meshes vector is empty"); }
     if (names.size() != meshes.size()) { throw InputError("names size must match meshes size"); }
-    spdlog::info("Export3mfFromMeshes (explicit names): exporting {} mesh(es)", meshes.size());
+    spdlog::debug("Export3mfFromMeshes (explicit names): exporting {} mesh(es)", meshes.size());
     std::vector<Mesh> mutable_meshes(meshes.begin(), meshes.end());
     OrientMeshesInPlace(mutable_meshes, face_orientation);
 
@@ -445,7 +445,7 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
                                          FaceOrientation face_orientation,
                                          const std::string& model_name) {
     if (meshes.empty()) { throw InputError("meshes vector is empty"); }
-    spdlog::info("Export3mfFromMeshes (with preset): exporting {} mesh(es)", meshes.size());
+    spdlog::debug("Export3mfFromMeshes (with preset): exporting {} mesh(es)", meshes.size());
     std::vector<Mesh> mutable_meshes(meshes.begin(), meshes.end());
     OrientMeshesInPlace(mutable_meshes, face_orientation);
 
@@ -486,7 +486,7 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
     if (names.size() != meshes.size() || slots.size() != meshes.size()) {
         throw InputError("names/slots size must match meshes size");
     }
-    spdlog::info("Export3mfFromMeshes (explicit slots): exporting {} mesh(es)", meshes.size());
+    spdlog::debug("Export3mfFromMeshes (explicit slots): exporting {} mesh(es)", meshes.size());
     std::vector<Mesh> mutable_meshes(meshes.begin(), meshes.end());
     OrientMeshesInPlace(mutable_meshes, face_orientation);
 
@@ -512,8 +512,8 @@ std::vector<uint8_t> Export3mfFromMeshes(const std::vector<Mesh>& meshes,
 std::vector<uint8_t> Export3mfToBuffer(const ModelIR& model_ir, const BuildMeshConfig& cfg,
                                        const SlicerPreset& preset,
                                        FaceOrientation face_orientation) {
-    spdlog::info("Export3mfToBuffer (with preset): exporting {} grid(s)",
-                 model_ir.voxel_grids.size());
+    spdlog::debug("Export3mfToBuffer (with preset): exporting {} grid(s)",
+                  model_ir.voxel_grids.size());
     std::vector<Mesh> meshes = BuildMeshes(model_ir, cfg);
     OrientMeshesInPlace(meshes, face_orientation);
 
@@ -550,7 +550,7 @@ std::vector<uint8_t> Export3mfToBuffer(const ModelIR& model_ir, const BuildMeshC
 void Export3mfToFile(const std::string& path, const ModelIR& model_ir, const BuildMeshConfig& cfg,
                      FaceOrientation face_orientation) {
     if (path.empty()) { throw InputError("Export3mfToFile path is empty"); }
-    spdlog::info("Export3mfToFile: exporting {} grid(s) to {}", model_ir.voxel_grids.size(), path);
+    spdlog::debug("Export3mfToFile: exporting {} grid(s) to {}", model_ir.voxel_grids.size(), path);
     std::vector<Mesh> meshes = BuildMeshes(model_ir, cfg);
     OrientMeshesInPlace(meshes, face_orientation);
 
@@ -574,8 +574,8 @@ void Export3mfToFile(const std::string& path, const ModelIR& model_ir, const Bui
 void Export3mfToFile(const std::string& path, const ModelIR& model_ir, const BuildMeshConfig& cfg,
                      const SlicerPreset& preset, FaceOrientation face_orientation) {
     if (path.empty()) { throw InputError("Export3mfToFile path is empty"); }
-    spdlog::info("Export3mfToFile (with preset): exporting {} grid(s) to {}",
-                 model_ir.voxel_grids.size(), path);
+    spdlog::debug("Export3mfToFile (with preset): exporting {} grid(s) to {}",
+                  model_ir.voxel_grids.size(), path);
     std::vector<Mesh> meshes = BuildMeshes(model_ir, cfg);
     OrientMeshesInPlace(meshes, face_orientation);
 
@@ -609,7 +609,7 @@ void Export3mfFromMeshesToFile(const std::string& path, const std::vector<Mesh>&
                                int base_layers, FaceOrientation face_orientation) {
     if (path.empty()) { throw InputError("Export3mfFromMeshesToFile path is empty"); }
     if (meshes.empty()) { throw InputError("meshes vector is empty"); }
-    spdlog::info("Export3mfFromMeshesToFile: exporting {} mesh(es) to {}", meshes.size(), path);
+    spdlog::debug("Export3mfFromMeshesToFile: exporting {} mesh(es) to {}", meshes.size(), path);
     std::vector<Mesh> mutable_meshes(meshes.begin(), meshes.end());
     OrientMeshesInPlace(mutable_meshes, face_orientation);
 
@@ -637,8 +637,8 @@ void Export3mfFromMeshesToFile(const std::string& path, const std::vector<Mesh>&
                                FaceOrientation face_orientation, const std::string& model_name) {
     if (path.empty()) { throw InputError("Export3mfFromMeshesToFile path is empty"); }
     if (meshes.empty()) { throw InputError("meshes vector is empty"); }
-    spdlog::info("Export3mfFromMeshesToFile (with preset): exporting {} mesh(es) to {}",
-                 meshes.size(), path);
+    spdlog::debug("Export3mfFromMeshesToFile (with preset): exporting {} mesh(es) to {}",
+                  meshes.size(), path);
     std::vector<Mesh> mutable_meshes(meshes.begin(), meshes.end());
     OrientMeshesInPlace(mutable_meshes, face_orientation);
 

--- a/core/src/geo/three_mf_extensions.cpp
+++ b/core/src/geo/three_mf_extensions.cpp
@@ -203,10 +203,10 @@ public:
             });
         }
 
-        spdlog::info("CoreModelExtension: {} object(s) in, {} mesh(es) accepted, {} dropped "
-                     "(fully degenerate), {} degenerate triangle(s) filtered",
-                     objects.size(), document.mesh_resources.size(), meshes_dropped_full,
-                     dropped_degenerate);
+        spdlog::debug("CoreModelExtension: {} object(s) in, {} mesh(es) accepted, {} dropped "
+                      "(fully degenerate), {} degenerate triangle(s) filtered",
+                      objects.size(), document.mesh_resources.size(), meshes_dropped_full,
+                      dropped_degenerate);
     }
 };
 
@@ -414,7 +414,7 @@ public:
         document.content_type_defaults.push_back(
             OpcContentTypeDefault{.extension = "json", .content_type = "application/json"});
 
-        spdlog::info(
+        spdlog::debug(
             "Bambu assembly extension: {} parts, assembly_id={}, {} filaments, {} metadata files",
             group.objects.size(), assembly_id, preset_.filaments.size(), metadata_targets.size());
     }

--- a/core/src/geo/three_mf_writer.cpp
+++ b/core/src/geo/three_mf_writer.cpp
@@ -207,8 +207,8 @@ void WriteFileAtomically(const std::filesystem::path& final_path,
 
 void WriteBufferToFileAtomically(const std::filesystem::path& final_path,
                                  const std::vector<uint8_t>& bytes) {
-    spdlog::info("WriteBufferToFileAtomically: path={}, bytes={}", final_path.string(),
-                 bytes.size());
+    spdlog::debug("WriteBufferToFileAtomically: path={}, bytes={}", final_path.string(),
+                  bytes.size());
 
     WriteFileAtomically(final_path, [&](const std::filesystem::path& temp_path) {
         std::ofstream out(temp_path, std::ios::binary | std::ios::trunc);

--- a/core/src/imgproc/occlusion.cpp
+++ b/core/src/imgproc/occlusion.cpp
@@ -182,9 +182,9 @@ std::vector<VectorShape> ClipOcclusion(const std::vector<VectorShape>& shapes) {
 
     auto t_grid = std::chrono::steady_clock::now();
 
-    spdlog::info("[perf] ClipOcclusion prep: bbox+paths={:.1f} ms, grid={}x{} built in {:.1f} ms",
-                 std::chrono::duration<double, std::milli>(t_prep - t_start).count(), grid.cols,
-                 grid.rows, std::chrono::duration<double, std::milli>(t_grid - t_prep).count());
+    spdlog::debug("[perf] ClipOcclusion prep: bbox+paths={:.1f} ms, grid={}x{} built in {:.1f} ms",
+                  std::chrono::duration<double, std::milli>(t_prep - t_start).count(), grid.cols,
+                  grid.rows, std::chrono::duration<double, std::milli>(t_grid - t_prep).count());
 
     std::vector<VectorShape> result(static_cast<size_t>(n));
     const std::ptrdiff_t pn = static_cast<std::ptrdiff_t>(n);
@@ -257,8 +257,8 @@ std::vector<VectorShape> ClipOcclusion(const std::vector<VectorShape>& shapes) {
     double total_ms =
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_start)
             .count();
-    spdlog::info("[perf] ClipOcclusion done: {} -> {} shapes in {:.1f} ms (grid {}x{})", n,
-                 final_result.size(), total_ms, grid.cols, grid.rows);
+    spdlog::debug("[perf] ClipOcclusion done: {} -> {} shapes in {:.1f} ms (grid {}x{})", n,
+                  final_result.size(), total_ms, grid.cols, grid.rows);
     return final_result;
 }
 

--- a/core/src/imgproc/vector_proc.cpp
+++ b/core/src/imgproc/vector_proc.cpp
@@ -61,12 +61,12 @@ struct NormalizeContoursStats {
     void Log(const char* label) const {
         int64_t n = calls.load(std::memory_order_relaxed);
         if (n == 0) return;
-        spdlog::info("[perf] NormalizeContours ({}): {} calls, "
-                     "convert={:.1f} ms, union={:.1f} ms, simplify={:.1f} ms, "
-                     "filter={:.1f} ms, sort={:.1f} ms",
-                     label, n, convert_us.load() / 1000.0, union_us.load() / 1000.0,
-                     simplify_us.load() / 1000.0, filter_us.load() / 1000.0,
-                     sort_us.load() / 1000.0);
+        spdlog::debug("[perf] NormalizeContours ({}): {} calls, "
+                      "convert={:.1f} ms, union={:.1f} ms, simplify={:.1f} ms, "
+                      "filter={:.1f} ms, sort={:.1f} ms",
+                      label, n, convert_us.load() / 1000.0, union_us.load() / 1000.0,
+                      simplify_us.load() / 1000.0, filter_us.load() / 1000.0,
+                      sort_us.load() / 1000.0);
     }
 };
 
@@ -310,7 +310,7 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
 
     if (svg_w <= 0.0f || svg_h <= 0.0f) { throw InputError("SVG has no visible content"); }
 
-    spdlog::info("VectorProc: SVG dimensions {:.2f} x {:.2f} px", svg_w, svg_h);
+    spdlog::debug("VectorProc: SVG dimensions {:.2f} x {:.2f} px", svg_w, svg_h);
 
     float scale = 1.0f;
     if (config.target_width_mm > 0.0f || config.target_height_mm > 0.0f) {
@@ -326,8 +326,8 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
     float final_w = svg_w * scale;
     float final_h = svg_h * scale;
 
-    spdlog::info("VectorProc: scale={:.4f}, output {:.2f} x {:.2f} mm, tol={:.4f}", scale, final_w,
-                 final_h, tol);
+    spdlog::debug("VectorProc: scale={:.4f}, output {:.2f} x {:.2f} mm, tol={:.4f}", scale, final_w,
+                  final_h, tol);
 
     auto* root = doc.documentElement().svgElement(true);
 
@@ -339,7 +339,7 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
         geo_elements.push_back(geo);
     });
 
-    spdlog::info(
+    spdlog::debug(
         "[perf] VectorProc phase 1 (parse+layout+traverse): {:.1f} ms, {} geometry elements",
         ElapsedMs(t0), geo_elements.size());
 
@@ -387,9 +387,9 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
         }
     }
 
-    spdlog::info("[perf] VectorProc phase 2 (ConvertGeometryElement): {:.1f} ms, {} shapes, "
-                 "{} contours, {} vertices",
-                 ElapsedMs(t1), vimg.shapes.size(), total_contours, total_vertices);
+    spdlog::debug("[perf] VectorProc phase 2 (ConvertGeometryElement): {:.1f} ms, {} shapes, "
+                  "{} contours, {} vertices",
+                  ElapsedMs(t1), vimg.shapes.size(), total_contours, total_vertices);
     g_normalize_stats.Log("phase2 per-shape");
     g_normalize_stats.Reset();
 
@@ -397,8 +397,8 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
 
     std::vector<VectorShape> clipped = detail::ClipOcclusion(vimg.shapes);
 
-    spdlog::info("[perf] VectorProc phase 3 (ClipOcclusion): {:.1f} ms, {} -> {} shapes",
-                 ElapsedMs(t2), vimg.shapes.size(), clipped.size());
+    spdlog::debug("[perf] VectorProc phase 3 (ClipOcclusion): {:.1f} ms, {} -> {} shapes",
+                  ElapsedMs(t2), vimg.shapes.size(), clipped.size());
 
     auto t3 = std::chrono::steady_clock::now();
 
@@ -416,9 +416,9 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
                                  [](const VectorShape& vs) { return vs.contours.empty(); }),
                   clipped.end());
 
-    spdlog::info("[perf] VectorProc phase 4 (post-occlusion normalize+filter): {:.1f} ms, "
-                 "{} final shapes",
-                 ElapsedMs(t3), clipped.size());
+    spdlog::debug("[perf] VectorProc phase 4 (post-occlusion normalize+filter): {:.1f} ms, "
+                  "{} final shapes",
+                  ElapsedMs(t3), clipped.size());
     g_normalize_stats.Log("phase4 post-occlusion");
     g_normalize_stats.Reset();
 
@@ -429,8 +429,10 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
     result.y_flipped = config.flip_y;
     result.shapes    = std::move(clipped);
 
-    spdlog::info("[perf] VectorProc total: {:.1f} ms, output {} shapes, {:.2f} x {:.2f} mm",
-                 ElapsedMs(t_total), result.shapes.size(), result.width_mm, result.height_mm);
+    spdlog::debug("[perf] VectorProc total: {:.1f} ms, output {} shapes, {:.2f} x {:.2f} mm",
+                  ElapsedMs(t_total), result.shapes.size(), result.width_mm, result.height_mm);
+    spdlog::info("VectorProc: {} shapes, {:.1f}x{:.1f} mm, {:.0f} ms", result.shapes.size(),
+                 result.width_mm, result.height_mm, ElapsedMs(t_total));
     return result;
 }
 

--- a/core/src/match/candidate_select.cpp
+++ b/core/src/match/candidate_select.cpp
@@ -3,7 +3,7 @@
 #include "detail/recipe_convert.h"
 #include "chromaprint3d/error.h"
 
-#include <spdlog/spdlog.h>
+
 
 #include <algorithm>
 #include <cmath>

--- a/core/src/match/dither.cpp
+++ b/core/src/match/dither.cpp
@@ -43,7 +43,7 @@ void MatchWithBlueNoiseDither(RecipeMap& result, const cv::Mat& target, const cv
     const int H         = result.height;
     const bool has_mask = !mask.empty();
 
-    spdlog::info("MatchWithBlueNoiseDither: {}x{}, strength={:.2f}", W, H, strength);
+    spdlog::debug("MatchWithBlueNoiseDither: {}x{}, strength={:.2f}", W, H, strength);
 
     int local_total      = 0;
     int local_db_only    = 0;
@@ -117,7 +117,7 @@ void MatchWithFloydSteinberg(RecipeMap& result, const cv::Mat& target, const cv:
     const int H         = result.height;
     const bool has_mask = !mask.empty();
 
-    spdlog::info("MatchWithFloydSteinberg: {}x{}, strength={:.2f}", W, H, strength);
+    spdlog::debug("MatchWithFloydSteinberg: {}x{}, strength={:.2f}", W, H, strength);
 
     // Two-row rolling error buffer: current row and next row.
     const std::size_t row_size = static_cast<std::size_t>(W);

--- a/core/src/match/match.cpp
+++ b/core/src/match/match.cpp
@@ -117,8 +117,8 @@ int EstimateClusterCount(const cv::Mat& samples) {
 
     chosen_k = std::clamp(chosen_k, 4, std::min(128, n / 4));
 
-    spdlog::info("AutoK: selected k={} (elbow_k={}, mean_dE={:.2f})", chosen_k,
-                 valid_candidates[elbow_idx], mean_dE);
+    spdlog::debug("AutoK: selected k={} (elbow_k={}, mean_dE={:.2f})", chosen_k,
+                  valid_candidates[elbow_idx], mean_dE);
     return chosen_k;
 }
 
@@ -374,7 +374,7 @@ RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<cons
             std::min(requested_superpixels, static_cast<int>(valid_indices.size()));
         const bool use_slic = (requested_superpixels > 1 && target_superpixels > 1 &&
                                static_cast<std::size_t>(target_superpixels) < valid_indices.size());
-        spdlog::info(
+        spdlog::debug(
             "MatchFromRaster: valid_pixels={}, cluster_method=slic, clustering={} (target={})",
             valid_indices.size(), use_slic ? "yes" : "no", target_superpixels);
 
@@ -485,9 +485,9 @@ RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<cons
     const bool use_cluster =
         (resolved_k > 1 && static_cast<std::size_t>(resolved_k) < valid_indices.size());
 
-    spdlog::info("MatchFromRaster: valid_pixels={}, cluster_method=kmeans, clustering={} (k={}{})",
-                 valid_indices.size(), use_cluster ? "yes" : "no", resolved_k,
-                 auto_k ? ", auto" : "");
+    spdlog::debug("MatchFromRaster: valid_pixels={}, cluster_method=kmeans, clustering={} (k={}{})",
+                  valid_indices.size(), use_cluster ? "yes" : "no", resolved_k,
+                  auto_k ? ", auto" : "");
 
     if (!use_cluster) {
         run_per_pixel_matching();

--- a/core/src/match/print_profile.cpp
+++ b/core/src/match/print_profile.cpp
@@ -4,7 +4,7 @@
 #include "chromaprint3d/error.h"
 #include "detail/match_utils.h"
 
-#include <spdlog/spdlog.h>
+
 
 #include <algorithm>
 #include <cctype>

--- a/core/src/match/vector_match.cpp
+++ b/core/src/match/vector_match.cpp
@@ -214,7 +214,7 @@ VectorRecipeMap VectorRecipeMap::Match(const VectorProcResult& result, std::span
                 : 0.0f;
     }
 
-    spdlog::info(
+    spdlog::debug(
         "VectorRecipeMap::Match: {} shapes, {} unique colors, db_only={}, model_fallback={}, "
         "avg_db_de={:.2f}, avg_model_de={:.2f}",
         map.entries.size(), unique_colors.size(), stat_db_only, stat_model_used,

--- a/core/src/matting/dl_matting.cpp
+++ b/core/src/matting/dl_matting.cpp
@@ -83,9 +83,9 @@ public:
         double post_ms = ms(t3 - t2);
         double tot_ms  = ms(t3 - t0);
 
-        spdlog::info("DLMatting '{}': preprocess={:.1f}ms, inference={:.1f}ms, "
-                     "postprocess={:.1f}ms, total={:.1f}ms",
-                     name_, pre_ms, inf_ms, post_ms, tot_ms);
+        spdlog::debug("DLMatting '{}': preprocess={:.1f}ms, inference={:.1f}ms, "
+                      "postprocess={:.1f}ms, total={:.1f}ms",
+                      name_, pre_ms, inf_ms, post_ms, tot_ms);
 
         if (timing) {
             timing->preprocess_ms  = pre_ms;

--- a/core/src/matting/matting.cpp
+++ b/core/src/matting/matting.cpp
@@ -144,9 +144,9 @@ MattingOutput ThresholdMattingProvider::Run(const cv::Mat& bgr, MattingTimingInf
     double post_ms = ms(t3 - t2);
     double tot_ms  = ms(t3 - t0);
 
-    spdlog::info("ThresholdMatting: preprocess={:.1f}ms, threshold={:.1f}ms, morphology={:.1f}ms, "
-                 "total={:.1f}ms",
-                 pre_ms, inf_ms, post_ms, tot_ms);
+    spdlog::debug("ThresholdMatting: preprocess={:.1f}ms, threshold={:.1f}ms, morphology={:.1f}ms, "
+                  "total={:.1f}ms",
+                  pre_ms, inf_ms, post_ms, tot_ms);
 
     if (timing) {
         timing->preprocess_ms  = pre_ms;
@@ -161,7 +161,7 @@ MattingOutput ThresholdMattingProvider::Run(const cv::Mat& bgr, MattingTimingInf
 // ── MattingRegistry ─────────────────────────────────────────────────────────
 
 void MattingRegistry::Register(std::string key, MattingProviderPtr provider) {
-    spdlog::info("MattingRegistry: registered provider '{}'", key);
+    spdlog::debug("MattingRegistry: registered provider '{}'", key);
     providers_[std::move(key)] = std::move(provider);
 }
 

--- a/core/src/vecgeo/vector_mesh_builder.cpp
+++ b/core/src/vecgeo/vector_mesh_builder.cpp
@@ -439,8 +439,8 @@ std::vector<Mesh> BuildVectorMeshes(const std::vector<VectorShape>& shapes,
         total_verts += m.vertices.size();
         total_tris += m.indices.size();
     }
-    spdlog::info("BuildVectorMeshes: {} meshes, total vertices={}, triangles={}", meshes.size(),
-                 total_verts, total_tris);
+    spdlog::debug("BuildVectorMeshes: {} meshes, total vertices={}, triangles={}", meshes.size(),
+                  total_verts, total_tris);
 
     return meshes;
 }

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -939,9 +939,9 @@ ServiceResult ServerFacade::DownloadBoardModel(const std::string& board_id, Task
         std::error_code ec;
         bool exists      = std::filesystem::exists(fpath, ec);
         auto actual_size = exists ? std::filesystem::file_size(fpath, ec) : 0ULL;
-        spdlog::info("DownloadBoardModel: board={}, path={}, exists={}, actual_size={}, "
-                     "expected_size={}",
-                     board_id, fpath.string(), exists, actual_size, board->expected_file_size);
+        spdlog::debug("DownloadBoardModel: board={}, path={}, exists={}, actual_size={}, "
+                      "expected_size={}",
+                      board_id, fpath.string(), exists, actual_size, board->expected_file_size);
         if (!exists) {
             spdlog::error("DownloadBoardModel: file missing for board {}: {}", board_id,
                           fpath.string());

--- a/web/backend/src/infrastructure/board_runtime_cache.cpp
+++ b/web/backend/src/infrastructure/board_runtime_cache.cpp
@@ -16,8 +16,8 @@ std::optional<SpillableArtifact> WriteBoardModelFile(const std::filesystem::path
     if (temp_dir.empty() || model_3mf.empty()) return std::nullopt;
 
     auto file_path = temp_dir / (board_id + "_calibration_board.3mf");
-    spdlog::info("WriteBoardModelFile: board={}, path={}, bytes={}", board_id, file_path.string(),
-                 model_3mf.size());
+    spdlog::debug("WriteBoardModelFile: board={}, path={}, bytes={}", board_id, file_path.string(),
+                  model_3mf.size());
     {
         std::ofstream out(file_path, std::ios::binary | std::ios::trunc);
         if (!out.is_open()) {

--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -486,13 +486,14 @@ SubmitResult TaskRuntime::SubmitVectorize(const std::string& owner,
             using Clock                   = std::chrono::steady_clock;
             auto t0                       = Clock::now();
             const std::size_t input_bytes = buf.size();
-            spdlog::info(
-                "Vectorize task core start: task_id={}, image_bytes={}, num_colors={}, "
+            spdlog::info("Vectorize task core start: task_id={}, image_bytes={}", id, input_bytes);
+            spdlog::debug(
+                "Vectorize task core config: task_id={}, num_colors={}, "
                 "min_region_area={}, curve_fit_error={:.3f}, corner_angle_threshold={:.1f}, "
                 "smoothing_spatial={:.1f}, smoothing_color={:.1f}, upscale_short_edge={}, "
                 "max_working_pixels={}, slic_region_size={}, svg_enable_stroke={}, "
                 "svg_stroke_width={:.2f}",
-                id, input_bytes, config.num_colors, config.min_region_area, config.curve_fit_error,
+                id, config.num_colors, config.min_region_area, config.curve_fit_error,
                 config.corner_angle_threshold, config.smoothing_spatial, config.smoothing_color,
                 config.upscale_short_edge, config.max_working_pixels, config.slic_region_size,
                 config.svg_enable_stroke, config.svg_stroke_width);
@@ -867,8 +868,8 @@ SubmitResult TaskRuntime::SubmitGenerateModel(const std::string& owner, const st
             if (!gen_result.model_3mf.empty()) {
                 auto spill_path = temp_dir_ / (id + "_gen.3mf");
                 pending_3mf     = PendingArtifactFile(spill_path);
-                spdlog::info("GenerateModel: writing 3MF for task {}, {} bytes to {}", id,
-                             gen_result.model_3mf.size(), spill_path.string());
+                spdlog::debug("GenerateModel: writing 3MF for task {}, {} bytes to {}", id,
+                              gen_result.model_3mf.size(), spill_path.string());
 
                 std::ofstream ofs(spill_path, std::ios::binary | std::ios::trunc);
                 if (!ofs.is_open()) {
@@ -1014,9 +1015,9 @@ std::optional<TaskArtifact> TaskRuntime::LoadArtifact(const std::string& owner,
                 std::error_code ec;
                 bool exists      = std::filesystem::exists(fpath, ec);
                 auto actual_size = exists ? std::filesystem::file_size(fpath, ec) : 0ULL;
-                spdlog::info("LoadArtifact: serving file-based 3MF for task {}: path={}, "
-                             "exists={}, actual_size={}, expected_size={}",
-                             id, fpath.string(), exists, actual_size, expected_size);
+                spdlog::debug("LoadArtifact: serving file-based 3MF for task {}: path={}, "
+                              "exists={}, actual_size={}, expected_size={}",
+                              id, fpath.string(), exists, actual_size, expected_size);
                 if (!exists) {
                     spdlog::error("LoadArtifact: spilled 3MF file missing for task {}: {}", id,
                                   fpath.string());


### PR DESCRIPTION
## Summary

- Demote ~35 diagnostic/perf `spdlog::info` calls to `spdlog::debug` across 18 files in core/ and web/backend/
- Add a concise single-line `VectorProc` summary at info level to replace verbose phase-by-phase timing
- Downgrade all `[perf]` timing instrumentation, algorithm parameters (AutoK, clustering, dither), mesh/export internal statistics, and redundant "start" logs to debug
- Split verbose vectorize task config dump into brief info + detailed debug in web backend
- Remove unused `#include <spdlog/spdlog.h>` from `print_profile.cpp` and `candidate_select.cpp`

**Design principle**: info = user-facing progress/results; debug = developer diagnostics/perf profiling. warn/error unchanged.

**Verified**: builds clean (28/28), info-level SVG pipeline output reduced from 12+ lines to ~2 lines, no warn/error logs modified.

## Test plan

- [x] Build passes with all targets
- [x] `--log-level info` output is concise (only high-level progress and results)
- [x] `--log-level debug` retains all detailed timing and diagnostics
- [x] No warn/error level logs were modified (`git diff | rg spdlog::(warn|error)` = empty)


Made with [Cursor](https://cursor.com)