### PR TITLE
fix: SVG pipeline review fixes — gradient handling, precision, and cleanup

### DIFF
--- a/apps/svg_to_3mf.cpp
+++ b/apps/svg_to_3mf.cpp
@@ -30,6 +30,7 @@ struct Options {
 
     float layer_height_mm           = 0.0f;
     float tessellation_tolerance_mm = 0.03f;
+    float gradient_pixel_mm         = 0.0f;
     int base_layers                 = -1;
     bool double_sided               = false;
 
@@ -55,6 +56,7 @@ void PrintUsage(const char* exe) {
         "  --base-layers N     Base layers override (-1 inherit, >=0 explicit, default -1)\n"
         "  --double-sided 0|1  Generate mirrored color layers on both sides (default 0)\n"
         "  --tess-tol X        Bezier tessellation tolerance in mm (default 0.03)\n"
+        "  --gradient-px-mm X  Gradient rasterization resolution in mm/px (0=auto)\n"
         "  --log-level LEVEL   trace/debug/info/warn/error/off (default: info)\n",
         exe);
 }
@@ -236,6 +238,13 @@ bool ParseArgs(int argc, char** argv, Options& opt) {
             }
             continue;
         }
+        if (arg == "--gradient-px-mm" && i + 1 < argc) {
+            if (!ParseFloat(argv[++i], opt.gradient_pixel_mm) || opt.gradient_pixel_mm < 0.0f) {
+                std::fprintf(stderr, "Invalid --gradient-px-mm\n");
+                return false;
+            }
+            continue;
+        }
         if (arg == "--log-level" && i + 1 < argc) {
             opt.log_level = argv[++i];
             continue;
@@ -281,6 +290,7 @@ int main(int argc, char** argv) {
         req.base_layers               = opt.base_layers;
         req.double_sided              = opt.double_sided;
         req.tessellation_tolerance_mm = opt.tessellation_tolerance_mm;
+        req.gradient_pixel_mm         = opt.gradient_pixel_mm;
         req.output_3mf_path           = opt.out_path;
         req.generate_preview          = false;
 

--- a/core/include/chromaprint3d/pipeline.h
+++ b/core/include/chromaprint3d/pipeline.h
@@ -216,9 +216,7 @@ struct ConvertVectorRequest {
     float model_margin     = -1.0f;
     std::vector<std::string> allowed_channel_keys;
 
-    DitherMethod gradient_dither   = DitherMethod::FloydSteinberg;
-    float gradient_dither_strength = 0.8f;
-    float gradient_pixel_mm        = 0.0f; ///< Gradient rasterization resolution (0 = auto).
+    float gradient_pixel_mm = 0.0f; ///< Gradient rasterization resolution (0 = auto).
 
     float layer_height_mm           = 0.0f; ///< 0 = derive from profile.
     float tessellation_tolerance_mm = 0.03f;

--- a/core/include/chromaprint3d/vector_image.h
+++ b/core/include/chromaprint3d/vector_image.h
@@ -29,8 +29,16 @@ enum class SvgFillRule : uint8_t {
 
 /// Gradient color stop.
 struct GradientStop {
-    float offset = 0.0f;
+    float offset  = 0.0f;
+    float opacity = 1.0f;
     Rgb color;
+};
+
+/// SVG gradient spread method.
+enum class SpreadMethod : uint8_t {
+    Pad,
+    Reflect,
+    Repeat,
 };
 
 /// Gradient definition extracted from SVG.
@@ -38,7 +46,8 @@ struct GradientInfo {
     std::vector<GradientStop> stops;
     float x1 = 0.0f, y1 = 0.0f; ///< Start point (linear) or center (radial).
     float x2 = 0.0f, y2 = 0.0f; ///< End point (linear).
-    float r = 0.0f;             ///< Radius (radial only).
+    float r             = 0.0f; ///< Radius (radial only).
+    SpreadMethod spread = SpreadMethod::Pad;
 };
 
 /// A single shape from a vector image, with contours and fill information.

--- a/core/include/chromaprint3d/vector_proc.h
+++ b/core/include/chromaprint3d/vector_proc.h
@@ -33,6 +33,10 @@ struct VectorProcConfig {
 
     float tessellation_tolerance_mm = 0.03f; ///< Bezier flattening tolerance.
     bool flip_y                     = false;
+
+    /// Rasterization resolution for gradient flattening (mm/pixel).
+    /// 0 = auto (3x tessellation_tolerance_mm).
+    float gradient_pixel_mm = 0.0f;
 };
 
 /// Vector image preprocessor: parses SVG, flattens beziers, scales, clips occlusion.

--- a/core/src/imgproc/clipper_scale.h
+++ b/core/src/imgproc/clipper_scale.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace ChromaPrint3D::detail {
+
+constexpr double kClipperScale = 1000000.0;
+
+} // namespace ChromaPrint3D::detail

--- a/core/src/imgproc/gradient.cpp
+++ b/core/src/imgproc/gradient.cpp
@@ -9,26 +9,54 @@ namespace ChromaPrint3D::detail {
 
 namespace {
 
+float ApplySpreadMethod(float t, SpreadMethod spread) {
+    switch (spread) {
+    case SpreadMethod::Repeat:
+        t = t - std::floor(t);
+        break;
+    case SpreadMethod::Reflect:
+        t = 1.0f - std::abs(std::fmod(t, 2.0f) - 1.0f);
+        break;
+    case SpreadMethod::Pad:
+    default:
+        t = std::clamp(t, 0.0f, 1.0f);
+        break;
+    }
+    return t;
+}
+
 Rgb InterpolateGradient(const GradientInfo& grad, float t) {
     if (grad.stops.empty()) { return Rgb(0.5f, 0.5f, 0.5f); }
 
-    t = std::clamp(t, 0.0f, 1.0f);
+    t = ApplySpreadMethod(t, grad.spread);
 
-    if (t <= grad.stops.front().offset) { return grad.stops.front().color; }
-    if (t >= grad.stops.back().offset) { return grad.stops.back().color; }
+    if (t <= grad.stops.front().offset) {
+        const auto& s = grad.stops.front();
+        return Rgb(s.color.x * s.opacity, s.color.y * s.opacity, s.color.z * s.opacity);
+    }
+    if (t >= grad.stops.back().offset) {
+        const auto& s = grad.stops.back();
+        return Rgb(s.color.x * s.opacity, s.color.y * s.opacity, s.color.z * s.opacity);
+    }
 
     for (size_t i = 0; i + 1 < grad.stops.size(); ++i) {
         if (t >= grad.stops[i].offset && t <= grad.stops[i + 1].offset) {
             float range   = grad.stops[i + 1].offset - grad.stops[i].offset;
             float frac    = (range > 0.0f) ? (t - grad.stops[i].offset) / range : 0.0f;
+            float a0      = grad.stops[i].opacity;
+            float a1      = grad.stops[i + 1].opacity;
+            float a       = a0 + (a1 - a0) * frac;
             const Rgb& c0 = grad.stops[i].color;
             const Rgb& c1 = grad.stops[i + 1].color;
-            return Rgb(c0.x + (c1.x - c0.x) * frac, c0.y + (c1.y - c0.y) * frac,
-                       c0.z + (c1.z - c0.z) * frac);
+            return Rgb((c0.x + (c1.x - c0.x) * frac) * a, (c0.y + (c1.y - c0.y) * frac) * a,
+                       (c0.z + (c1.z - c0.z) * frac) * a);
         }
     }
-    return grad.stops.back().color;
+    const auto& s = grad.stops.back();
+    return Rgb(s.color.x * s.opacity, s.color.y * s.opacity, s.color.z * s.opacity);
 }
+
+} // namespace
 
 bool PointInContours(const std::vector<Contour>& contours, float px, float py) {
     int crossings = 0;
@@ -45,8 +73,6 @@ bool PointInContours(const std::vector<Contour>& contours, float px, float py) {
     }
     return (crossings % 2) == 1;
 }
-
-} // namespace
 
 cv::Mat RasterizeGradientShape(const VectorShape& shape, float pixel_mm, float& out_offset_x,
                                float& out_offset_y) {
@@ -72,7 +98,7 @@ cv::Mat RasterizeGradientShape(const VectorShape& shape, float pixel_mm, float& 
     out_offset_x = min_x;
     out_offset_y = min_y;
 
-    cv::Mat result(h, w, CV_32FC3, cv::Scalar(0, 0, 0));
+    cv::Mat result(h, w, CV_32FC4, cv::Scalar(0, 0, 0, 0));
 
     const GradientInfo& grad = shape.gradient;
     bool is_radial           = (shape.fill_type == FillType::RadialGradient);
@@ -80,7 +106,7 @@ cv::Mat RasterizeGradientShape(const VectorShape& shape, float pixel_mm, float& 
 #pragma omp parallel for schedule(dynamic)
     for (int row = 0; row < h; ++row) {
         float py  = min_y + (static_cast<float>(row) + 0.5f) * pixel_mm;
-        auto* ptr = result.ptr<cv::Vec3f>(row);
+        auto* ptr = result.ptr<cv::Vec4f>(row);
         for (int col = 0; col < w; ++col) {
             float px = min_x + (static_cast<float>(col) + 0.5f) * pixel_mm;
 
@@ -104,7 +130,7 @@ cv::Mat RasterizeGradientShape(const VectorShape& shape, float pixel_mm, float& 
             }
 
             Rgb color = InterpolateGradient(grad, t);
-            ptr[col]  = cv::Vec3f(color.r(), color.g(), color.b());
+            ptr[col]  = cv::Vec4f(color.r(), color.g(), color.b(), 1.0f);
         }
     }
 

--- a/core/src/imgproc/gradient.h
+++ b/core/src/imgproc/gradient.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "chromaprint3d/vector_image.h"
-#include "chromaprint3d/raster_proc.h"
 
 #include <opencv2/core.hpp>
 
@@ -9,8 +8,11 @@
 
 namespace ChromaPrint3D::detail {
 
+/// Ray-casting point-in-polygon test against a set of contours.
+bool PointInContours(const std::vector<Contour>& contours, float px, float py);
+
 /// Rasterize a gradient-filled shape into a local bitmap.
-/// Returns an OpenCV Mat (CV_32FC3, linear RGB) covering the shape's bounding box.
+/// Returns an OpenCV Mat (CV_32FC4, linear RGBA; alpha=1 inside, 0 outside).
 /// `out_offset_x` and `out_offset_y` receive the bounding box origin in mm.
 cv::Mat RasterizeGradientShape(const VectorShape& shape, float pixel_mm, float& out_offset_x,
                                float& out_offset_y);

--- a/core/src/imgproc/occlusion.cpp
+++ b/core/src/imgproc/occlusion.cpp
@@ -1,4 +1,5 @@
 #include "occlusion.h"
+#include "clipper_scale.h"
 
 #include <clipper2/clipper.h>
 
@@ -24,16 +25,16 @@
 
 namespace ChromaPrint3D::detail {
 
-namespace {
+using detail::kClipperScale;
 
-constexpr double kScale = 1000000.0;
+namespace {
 
 Clipper2Lib::Path64 ContourToPath(const Contour& c) {
     Clipper2Lib::Path64 path;
     path.reserve(c.size());
     for (const Vec2f& p : c) {
-        path.emplace_back(static_cast<int64_t>(std::round(p.x * kScale)),
-                          static_cast<int64_t>(std::round(p.y * kScale)));
+        path.emplace_back(static_cast<int64_t>(std::round(p.x * kClipperScale)),
+                          static_cast<int64_t>(std::round(p.y * kClipperScale)));
     }
     return path;
 }
@@ -42,8 +43,8 @@ Contour PathToContour(const Clipper2Lib::Path64& path) {
     Contour c;
     c.reserve(path.size());
     for (const auto& pt : path) {
-        c.emplace_back(static_cast<float>(pt.x) / static_cast<float>(kScale),
-                       static_cast<float>(pt.y) / static_cast<float>(kScale));
+        c.emplace_back(static_cast<float>(pt.x) / static_cast<float>(kClipperScale),
+                       static_cast<float>(pt.y) / static_cast<float>(kClipperScale));
     }
     return c;
 }

--- a/core/src/imgproc/shape_width_analyzer.cpp
+++ b/core/src/imgproc/shape_width_analyzer.cpp
@@ -1,4 +1,5 @@
 #include "chromaprint3d/shape_width_analyzer.h"
+#include "clipper_scale.h"
 
 #include <clipper2/clipper.h>
 #include <opencv2/imgproc.hpp>
@@ -11,10 +12,10 @@
 
 namespace ChromaPrint3D {
 
-namespace {
+using detail::kClipperScale;
 
-constexpr double kClipperScale = 100000.0;
-constexpr int kRasterPadding   = 2;
+namespace {
+constexpr int kRasterPadding = 2;
 
 struct ShapeBounds {
     float min_x = std::numeric_limits<float>::max();

--- a/core/src/imgproc/vector_proc.cpp
+++ b/core/src/imgproc/vector_proc.cpp
@@ -2,9 +2,12 @@
 #include "chromaprint3d/color.h"
 #include "chromaprint3d/error.h"
 #include "bezier.h"
+#include "clipper_scale.h"
+#include "gradient.h"
 #include "occlusion.h"
 
 #include <clipper2/clipper.h>
+#include <opencv2/imgproc.hpp>
 #include <spdlog/spdlog.h>
 
 #include <lunasvg.h>
@@ -37,9 +40,9 @@
 
 namespace ChromaPrint3D {
 
-namespace {
+using detail::kClipperScale;
 
-constexpr double kClipperScale = 100000.0;
+namespace {
 
 struct NormalizeContoursStats {
     std::atomic<int64_t> convert_us{0};
@@ -103,7 +106,7 @@ static std::vector<Contour> NormalizeContours(const std::vector<Contour>& contou
     std::vector<Contour> normalized;
     if (contours.empty()) return normalized;
 
-    double simplify_eps = std::max(100.0, static_cast<double>(tolerance_mm) * kClipperScale * 0.4);
+    double simplify_eps = std::max(100.0, static_cast<double>(tolerance_mm) * kClipperScale * 0.01);
     double min_area_scaled =
         std::max(1e-5, static_cast<double>(tolerance_mm) * tolerance_mm * 0.01) * kClipperScale *
         kClipperScale;
@@ -174,6 +177,35 @@ static Rgb LunaSvgColorToRgb(const lunasvg::Color& color) {
     return Rgb{SrgbToLinear(r), SrgbToLinear(g), SrgbToLinear(b)};
 }
 
+static SpreadMethod ConvertSpreadMethod(lunasvg::SpreadMethod sm) {
+    switch (sm) {
+    case lunasvg::SpreadMethod::Reflect:
+        return SpreadMethod::Reflect;
+    case lunasvg::SpreadMethod::Repeat:
+        return SpreadMethod::Repeat;
+    default:
+        return SpreadMethod::Pad;
+    }
+}
+
+static void CollectGradientStops(const lunasvg::SVGGradientElement* contentElem,
+                                 GradientInfo& info) {
+    if (!contentElem) return;
+    for (const auto& child : contentElem->children()) {
+        auto* childElem = lunasvg::toSVGElement(child);
+        if (childElem && childElem->id() == lunasvg::ElementID::Stop) {
+            auto* stopElem = static_cast<const lunasvg::SVGStopElement*>(childElem);
+            auto gstop     = stopElem->gradientStop(1.0f);
+            GradientStop s;
+            s.offset  = gstop.offset;
+            s.opacity = gstop.color.a;
+            s.color   = Rgb{SrgbToLinear(gstop.color.r), SrgbToLinear(gstop.color.g),
+                          SrgbToLinear(gstop.color.b)};
+            info.stops.push_back(s);
+        }
+    }
+}
+
 static GradientInfo ExtractGradientFromPaintElement(const lunasvg::SVGPaintElement* paintElem,
                                                     const lunasvg::SVGGeometryElement* geoElem,
                                                     FillType& out_fill_type) {
@@ -182,54 +214,102 @@ static GradientInfo ExtractGradientFromPaintElement(const lunasvg::SVGPaintEleme
     if (!paintElem) return info;
 
     auto eid = paintElem->id();
-    lunasvg::LengthContext lengthCtx(paintElem);
 
     if (eid == lunasvg::ElementID::LinearGradient) {
-        auto* lg      = static_cast<const lunasvg::SVGLinearGradientElement*>(paintElem);
-        out_fill_type = FillType::LinearGradient;
-        info.x1       = lengthCtx.valueForLength(lg->x1());
-        info.y1       = lengthCtx.valueForLength(lg->y1());
-        info.x2       = lengthCtx.valueForLength(lg->x2());
-        info.y2       = lengthCtx.valueForLength(lg->y2());
-    } else if (eid == lunasvg::ElementID::RadialGradient) {
-        auto* rg      = static_cast<const lunasvg::SVGRadialGradientElement*>(paintElem);
-        out_fill_type = FillType::RadialGradient;
-        info.x1       = lengthCtx.valueForLength(rg->cx());
-        info.y1       = lengthCtx.valueForLength(rg->cy());
-        info.r        = lengthCtx.valueForLength(rg->r());
-        info.x2       = lengthCtx.valueForLength(rg->fx());
-        info.y2       = lengthCtx.valueForLength(rg->fy());
-    } else {
-        return info;
-    }
+        auto* lg        = static_cast<const lunasvg::SVGLinearGradientElement*>(paintElem);
+        auto attributes = lg->collectGradientAttributes();
+        auto units      = attributes.gradientUnits();
+        lunasvg::LengthContext lengthCtx(paintElem, units);
 
-    for (const auto& child : paintElem->children()) {
-        auto* childElem = lunasvg::toSVGElement(child);
-        if (childElem && childElem->id() == lunasvg::ElementID::Stop) {
-            auto* stopElem = static_cast<const lunasvg::SVGStopElement*>(childElem);
-            auto gstop     = stopElem->gradientStop(1.0f);
-            GradientStop s;
-            s.offset = gstop.offset;
-            s.color  = Rgb{SrgbToLinear(gstop.color.r), SrgbToLinear(gstop.color.g),
-                          SrgbToLinear(gstop.color.b)};
-            info.stops.push_back(s);
+        out_fill_type = FillType::LinearGradient;
+        float raw_x1  = lengthCtx.valueForLength(attributes.x1());
+        float raw_y1  = lengthCtx.valueForLength(attributes.y1());
+        float raw_x2  = lengthCtx.valueForLength(attributes.x2());
+        float raw_y2  = lengthCtx.valueForLength(attributes.y2());
+
+        auto gradTransform = attributes.gradientTransform();
+        if (units == lunasvg::Units::ObjectBoundingBox) {
+            auto bbox = geoElem->fillBoundingBox();
+            gradTransform.postMultiply(lunasvg::Transform(bbox.w, 0, 0, bbox.h, bbox.x, bbox.y));
         }
+
+        auto p1     = gradTransform.mapPoint(raw_x1, raw_y1);
+        auto p2     = gradTransform.mapPoint(raw_x2, raw_y2);
+        info.x1     = p1.x;
+        info.y1     = p1.y;
+        info.x2     = p2.x;
+        info.y2     = p2.y;
+        info.spread = ConvertSpreadMethod(attributes.spreadMethod());
+
+        CollectGradientStops(attributes.gradientContentElement(), info);
+    } else if (eid == lunasvg::ElementID::RadialGradient) {
+        auto* rg        = static_cast<const lunasvg::SVGRadialGradientElement*>(paintElem);
+        auto attributes = rg->collectGradientAttributes();
+        auto units      = attributes.gradientUnits();
+        lunasvg::LengthContext lengthCtx(paintElem, units);
+
+        out_fill_type = FillType::RadialGradient;
+        float raw_cx  = lengthCtx.valueForLength(attributes.cx());
+        float raw_cy  = lengthCtx.valueForLength(attributes.cy());
+        float raw_r   = lengthCtx.valueForLength(attributes.r());
+        float raw_fx  = lengthCtx.valueForLength(attributes.fx());
+        float raw_fy  = lengthCtx.valueForLength(attributes.fy());
+
+        auto gradTransform = attributes.gradientTransform();
+        if (units == lunasvg::Units::ObjectBoundingBox) {
+            auto bbox = geoElem->fillBoundingBox();
+            gradTransform.postMultiply(lunasvg::Transform(bbox.w, 0, 0, bbox.h, bbox.x, bbox.y));
+        }
+
+        auto pc     = gradTransform.mapPoint(raw_cx, raw_cy);
+        auto pf     = gradTransform.mapPoint(raw_fx, raw_fy);
+        info.x1     = pc.x;
+        info.y1     = pc.y;
+        info.r      = raw_r * std::sqrt(gradTransform.xScale() * gradTransform.yScale());
+        info.x2     = pf.x;
+        info.y2     = pf.y;
+        info.spread = ConvertSpreadMethod(attributes.spreadMethod());
+
+        CollectGradientStops(attributes.gradientContentElement(), info);
     }
 
     return info;
+}
+
+static lunasvg::Transform ComputeGlobalTransform(const lunasvg::SVGGeometryElement* geo) {
+    auto transform = geo->localTransform();
+    for (auto* parent = geo->parentElement(); parent; parent = parent->parentElement()) {
+        transform.postMultiply(parent->localTransform());
+    }
+    return transform;
+}
+
+static bool IsIdentityTransform(const lunasvg::Transform& t) {
+    constexpr float kEps = 1e-6f;
+    const auto& m        = t.matrix();
+    return std::abs(m.a - 1.0f) < kEps && std::abs(m.b) < kEps && std::abs(m.c) < kEps &&
+           std::abs(m.d - 1.0f) < kEps && std::abs(m.e) < kEps && std::abs(m.f) < kEps;
 }
 
 static VectorShape ConvertGeometryElement(const lunasvg::SVGGeometryElement* geo, float tolerance) {
     VectorShape vs;
 
     const auto& paint = geo->fillPaintServer();
-    if (!paint.isRenderable()) return vs;
+    if (!paint.isRenderable()) {
+        if (geo->strokePaintServer().isRenderable()) {
+            spdlog::warn("VectorProc: stroke-only shape skipped (not supported)");
+        }
+        return vs;
+    }
 
     if (paint.element()) {
         FillType ft  = FillType::Solid;
         vs.gradient  = ExtractGradientFromPaintElement(paint.element(), geo, ft);
         vs.fill_type = ft;
-        if (ft == FillType::Solid) return vs;
+        if (ft == FillType::Solid) {
+            spdlog::warn("VectorProc: unsupported paint type (pattern fill), element skipped");
+            return vs;
+        }
     } else {
         const auto& color = paint.color();
         if (color.alpha() == 0) return vs;
@@ -241,7 +321,23 @@ static VectorShape ConvertGeometryElement(const lunasvg::SVGGeometryElement* geo
     vs.svg_fill_rule = (geo->fill_rule() == lunasvg::FillRule::EvenOdd) ? SvgFillRule::EvenOdd
                                                                         : SvgFillRule::NonZero;
 
-    const auto& path = geo->path();
+    const auto& path          = geo->path();
+    lunasvg::Transform global = ComputeGlobalTransform(geo);
+    const bool has_transform  = !IsIdentityTransform(global);
+
+    if (has_transform && vs.fill_type != FillType::Solid) {
+        auto& g = vs.gradient;
+        auto p1 = global.mapPoint(g.x1, g.y1);
+        auto p2 = global.mapPoint(g.x2, g.y2);
+        g.x1    = p1.x;
+        g.y1    = p1.y;
+        g.x2    = p2.x;
+        g.y2    = p2.y;
+        if (vs.fill_type == FillType::RadialGradient) {
+            g.r *= std::sqrt(global.xScale() * global.yScale());
+        }
+    }
+
     lunasvg::PathIterator it(path);
     std::array<lunasvg::Point, 3> pts;
 
@@ -249,6 +345,11 @@ static VectorShape ConvertGeometryElement(const lunasvg::SVGGeometryElement* geo
 
     while (!it.isDone()) {
         auto cmd = it.currentSegment(pts);
+        if (has_transform) {
+            pts[0] = global.mapPoint(pts[0]);
+            pts[1] = global.mapPoint(pts[1]);
+            pts[2] = global.mapPoint(pts[2]);
+        }
         switch (cmd) {
         case lunasvg::PathCommand::MoveTo:
             if (current_contour.size() >= 3) { vs.contours.push_back(std::move(current_contour)); }
@@ -296,6 +397,131 @@ static double ElapsedMs(std::chrono::steady_clock::time_point start) {
     return std::chrono::duration<double, std::milli>(now - start).count();
 }
 
+static float ColorDistSq(const Rgb& a, const Rgb& b) {
+    float dr = a.r() - b.r();
+    float dg = a.g() - b.g();
+    float db = a.b() - b.b();
+    return dr * dr + dg * dg + db * db;
+}
+
+/// Rasterize a gradient shape, quantize to gradient stop colors, extract contours,
+/// and return a set of solid-color shapes that approximate the original gradient.
+static std::vector<VectorShape> FlattenGradientShape(const VectorShape& shape, float pixel_mm,
+                                                     float tolerance_mm) {
+    std::vector<VectorShape> result;
+    if (shape.fill_type == FillType::Solid || shape.contours.empty()) return result;
+
+    const auto& stops = shape.gradient.stops;
+    if (stops.empty()) return result;
+
+    if (stops.size() == 1) {
+        VectorShape solid = shape;
+        solid.fill_type   = FillType::Solid;
+        solid.fill_color  = stops.front().color;
+        solid.gradient    = {};
+        result.push_back(std::move(solid));
+        return result;
+    }
+
+    float ox = 0.0f, oy = 0.0f;
+    cv::Mat raster = detail::RasterizeGradientShape(shape, pixel_mm, ox, oy);
+    if (raster.empty()) return result;
+
+    const int h = raster.rows;
+    const int w = raster.cols;
+
+    cv::Mat label_map(h, w, CV_32S, cv::Scalar(-1));
+    for (int row = 0; row < h; ++row) {
+        const auto* rgba_ptr = raster.ptr<cv::Vec4f>(row);
+        auto* lbl_ptr        = label_map.ptr<int32_t>(row);
+        for (int col = 0; col < w; ++col) {
+            const auto& px = rgba_ptr[col];
+            if (px[3] == 0.0f) continue;
+            Rgb pixel_color(px[0], px[1], px[2]);
+            int best_idx    = 0;
+            float best_dist = ColorDistSq(pixel_color, stops[0].color);
+            for (size_t si = 1; si < stops.size(); ++si) {
+                float d = ColorDistSq(pixel_color, stops[si].color);
+                if (d < best_dist) {
+                    best_dist = d;
+                    best_idx  = static_cast<int>(si);
+                }
+            }
+            lbl_ptr[col] = best_idx;
+        }
+    }
+
+    const double approx_eps_px = static_cast<double>(tolerance_mm / pixel_mm);
+
+    for (size_t si = 0; si < stops.size(); ++si) {
+        cv::Mat mask(h, w, CV_8UC1, cv::Scalar(0));
+        for (int row = 0; row < h; ++row) {
+            const auto* lbl_ptr = label_map.ptr<int32_t>(row);
+            auto* mask_ptr      = mask.ptr<uint8_t>(row);
+            for (int col = 0; col < w; ++col) {
+                if (lbl_ptr[col] == static_cast<int>(si)) { mask_ptr[col] = 255; }
+            }
+        }
+
+        std::vector<std::vector<cv::Point>> cv_contours;
+        cv::findContours(mask, cv_contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
+        if (cv_contours.empty()) continue;
+
+        VectorShape solid;
+        solid.fill_type     = FillType::Solid;
+        solid.fill_color    = stops[si].color;
+        solid.opacity       = shape.opacity;
+        solid.svg_fill_rule = SvgFillRule::NonZero;
+
+        for (auto& cv_cnt : cv_contours) {
+            std::vector<cv::Point> approx;
+            cv::approxPolyDP(cv_cnt, approx, approx_eps_px, true);
+            if (approx.size() < 3) continue;
+
+            Contour contour;
+            contour.reserve(approx.size());
+            for (const auto& pt : approx) {
+                float mx = ox + (static_cast<float>(pt.x) + 0.5f) * pixel_mm;
+                float my = oy + (static_cast<float>(pt.y) + 0.5f) * pixel_mm;
+                contour.push_back({mx, my});
+            }
+            solid.contours.push_back(std::move(contour));
+        }
+
+        if (!solid.contours.empty()) { result.push_back(std::move(solid)); }
+    }
+
+    return result;
+}
+
+/// Replace all gradient shapes in the vector with flattened solid-color sub-shapes.
+static void FlattenGradientShapes(std::vector<VectorShape>& shapes, float pixel_mm,
+                                  float tolerance_mm) {
+    std::vector<VectorShape> new_shapes;
+    new_shapes.reserve(shapes.size());
+
+    size_t gradient_count  = 0;
+    size_t sub_shape_count = 0;
+
+    for (auto& shape : shapes) {
+        if (shape.fill_type == FillType::Solid) {
+            new_shapes.push_back(std::move(shape));
+            continue;
+        }
+        ++gradient_count;
+        auto subs = FlattenGradientShape(shape, pixel_mm, tolerance_mm);
+        sub_shape_count += subs.size();
+        for (auto& s : subs) { new_shapes.push_back(std::move(s)); }
+    }
+
+    shapes = std::move(new_shapes);
+
+    if (gradient_count > 0) {
+        spdlog::info("VectorProc: flattened {} gradient shapes into {} solid sub-shapes",
+                     gradient_count, sub_shape_count);
+    }
+}
+
 static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorProcConfig& config,
                                          const std::string& result_name) {
     auto t_total = std::chrono::steady_clock::now();
@@ -332,12 +558,24 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
     auto* root = doc.documentElement().svgElement(true);
 
     std::vector<const lunasvg::SVGGeometryElement*> geo_elements;
+    int skipped_text = 0, skipped_image = 0;
     root->transverse([&](lunasvg::SVGElement* elem) {
-        if (!elem->isGeometryElement()) return;
-        auto* geo = static_cast<lunasvg::SVGGeometryElement*>(elem);
-        if (!geo->isRenderable()) return;
-        geo_elements.push_back(geo);
+        if (elem->isGeometryElement()) {
+            auto* geo = static_cast<lunasvg::SVGGeometryElement*>(elem);
+            if (geo->isRenderable()) { geo_elements.push_back(geo); }
+            return;
+        }
+        auto eid = elem->id();
+        if (eid == lunasvg::ElementID::Text || eid == lunasvg::ElementID::Tspan) {
+            ++skipped_text;
+        } else if (eid == lunasvg::ElementID::Image) {
+            ++skipped_image;
+        }
     });
+    if (skipped_text > 0 || skipped_image > 0) {
+        spdlog::warn("VectorProc: skipped {} <text> and {} <image> elements (not supported)",
+                     skipped_text, skipped_image);
+    }
 
     spdlog::debug(
         "[perf] VectorProc phase 1 (parse+layout+traverse): {:.1f} ms, {} geometry elements",
@@ -363,10 +601,23 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
                     p.y *= scale;
                 }
             }
+            if (vs.fill_type != FillType::Solid) {
+                auto& g = vs.gradient;
+                g.x1 *= scale;
+                g.y1 *= scale;
+                g.x2 *= scale;
+                g.y2 *= scale;
+                g.r *= scale;
+            }
         }
         if (do_flip) {
             for (Contour& c : vs.contours) {
                 for (Vec2f& p : c) { p.y = final_h - p.y; }
+            }
+            if (vs.fill_type != FillType::Solid) {
+                auto& g = vs.gradient;
+                g.y1    = final_h - g.y1;
+                g.y2    = final_h - g.y2;
             }
         }
         converted[idx] = std::move(vs);
@@ -392,6 +643,15 @@ static VectorProcResult ProcessParsedSvg(lunasvg::Document& doc, const VectorPro
                   ElapsedMs(t1), vimg.shapes.size(), total_contours, total_vertices);
     g_normalize_stats.Log("phase2 per-shape");
     g_normalize_stats.Reset();
+
+    auto t_grad = std::chrono::steady_clock::now();
+    {
+        float gpx = config.gradient_pixel_mm;
+        if (gpx <= 0.0f) { gpx = config.tessellation_tolerance_mm * 3.0f; }
+        FlattenGradientShapes(vimg.shapes, gpx, config.tessellation_tolerance_mm);
+    }
+    spdlog::debug("[perf] VectorProc phase 2.5 (FlattenGradientShapes): {:.1f} ms",
+                  ElapsedMs(t_grad));
 
     auto t2 = std::chrono::steady_clock::now();
 

--- a/core/src/pipeline/vector_pipeline.cpp
+++ b/core/src/pipeline/vector_pipeline.cpp
@@ -141,6 +141,7 @@ MatchVectorResult MatchVector(const ConvertVectorRequest& request, ProgressCallb
     vproc_cfg.target_height_mm          = request.target_height_mm;
     vproc_cfg.tessellation_tolerance_mm = request.tessellation_tolerance_mm;
     vproc_cfg.flip_y                    = request.flip_y;
+    vproc_cfg.gradient_pixel_mm         = request.gradient_pixel_mm;
 
     VectorProc vproc(vproc_cfg);
     VectorProcResult vimg;

--- a/docs/agents/core/README.md
+++ b/docs/agents/core/README.md
@@ -26,6 +26,7 @@
 | 修改体素/网格生成 | `core/src/geo/geo.cpp`、`core/src/vecgeo/vector_mesh_builder.cpp` |
 | 修改 3MF 导出 | `core/src/geo/export_3mf.cpp` |
 | 修改 Bambu 预设与耗材元数据 | `core/src/geo/bambu_metadata.cpp` |
+| 修改 SVG 几何提取与遮挡裁剪 | `core/src/imgproc/vector_proc.cpp`、`core/src/imgproc/occlusion.cpp`、`core/src/imgproc/gradient.cpp` |
 | 修改端到端转换编排 | `core/src/pipeline/pipeline.cpp`、`core/src/pipeline/vector_pipeline.cpp` |
 | 修改校准板与 ColorDB 构建 | `core/src/calib/calib.cpp` |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -192,6 +192,7 @@ npm run dev
 | `base_layers` | int / null | `null` | `-1`（CLI 语义）或 `>=0` | 底板层数覆盖。API 不传表示继承 ColorDB；CLI 中 `-1` 表示继承，`0` 表示无底板 |
 | `double_sided` | bool | `false` | `true`, `false` | 双面生成开关。开启后在底板两侧生成镜像颜色层 |
 | `transparent_layer_mm` | float | `0` | `0`, `0.04`, `0.08` | 透明镀层厚度（mm）。仅在 `face_orientation=facedown` 且 `double_sided=false` 时可用。启用后在打印模型最底层追加一层透明材料网格 |
+| `gradient_pixel_mm` | float | `0` | `>=0` | 渐变色区域栅格化分辨率（mm/px）。`0`=自动（3×`tessellation_tolerance_mm`）。SVG 中的渐变填充会被栅格化并拆分为纯色子区域参与颜色匹配与 3MF 生成 |
 
 组合后会先选择 `data/presets/` 下 4 个预设之一（如 `bambu_p2s_0.08mm_n04_faceup.json`）。预设中的耗材丝配置（颜色、类型、温度等）完整写入 3MF，Bambu Studio 打开时优先加载文件内配置。模型颜色自动匹配到预设中最接近的耗材丝槽位（RGB 欧氏距离）。此外，`face_orientation=facedown` 会在导出阶段将模型几何整体绕 Y 轴旋转 180°，`faceup` 则保持原方向。
 

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -1507,21 +1507,6 @@ ServiceResult ServerFacade::BuildVectorRequest(const json& params, const std::ve
         if (params.contains("tessellation_tolerance_mm")) {
             out.tessellation_tolerance_mm = params["tessellation_tolerance_mm"].get<float>();
         }
-        if (params.contains("gradient_dither")) {
-            std::string d = params["gradient_dither"].get<std::string>();
-            if (d == "blue_noise") {
-                out.gradient_dither = DitherMethod::BlueNoise;
-            } else if (d == "floyd_steinberg") {
-                out.gradient_dither = DitherMethod::FloydSteinberg;
-            } else if (d == "none") {
-                out.gradient_dither = DitherMethod::None;
-            } else {
-                throw std::runtime_error("Invalid gradient_dither method: " + d);
-            }
-        }
-        if (params.contains("gradient_dither_strength")) {
-            out.gradient_dither_strength = params["gradient_dither_strength"].get<float>();
-        }
         if (params.contains("gradient_pixel_mm")) {
             out.gradient_pixel_mm = params["gradient_pixel_mm"].get<float>();
         }
@@ -1551,10 +1536,6 @@ ServiceResult ServerFacade::BuildVectorRequest(const json& params, const std::ve
 
     if (out.k_candidates < 1) {
         return ServiceResult::Error(400, "invalid_params", "k_candidates must be >= 1");
-    }
-    if (out.gradient_dither_strength < 0.0f || out.gradient_dither_strength > 1.0f) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "gradient_dither_strength must be in [0,1]");
     }
     if (out.base_layers < -1) {
         return ServiceResult::Error(400, "invalid_params", "base_layers must be >= -1");

--- a/web/frontend/src/components/ParamPanel.vue
+++ b/web/frontend/src/components/ParamPanel.vue
@@ -48,7 +48,6 @@ const {
   error,
   filteredDBOptions,
   formatTooltip2Decimals,
-  gradientDitherOptions,
   handleChannelKeysChange,
   imageDimensions,
   inlineLabelWidth,
@@ -507,53 +506,26 @@ watch(canEnableTransparentLayer, (can) => {
           </NFormItem>
         </div>
 
-        <div
-          v-else-if="isVector"
-          class="param-inline-row"
-          :class="{ 'param-inline-row--single': !supportsModelGate }"
+        <NFormItem
+          v-else-if="isVector && supportsModelGate"
+          class="param-inline-item"
+          label-placement="left"
+          :label-width="simpleLabelWidth"
         >
-          <!-- Gradient dither (vector only) -->
-          <NFormItem
-            class="param-inline-item"
-            label-placement="left"
-            :label-width="inlineLabelWidth"
-          >
-            <template #label>
-              <NTooltip>
-                <template #trigger>
-                  <span class="tip-label">{{ t('param.gradientDither') }}</span>
-                </template>
-                {{ tooltips.gradient_dither }}
-              </NTooltip>
-            </template>
-            <NSelect
-              :value="modelValue.gradient_dither ?? 'none'"
-              :options="gradientDitherOptions"
-              @update:value="(v: string) => update({ gradient_dither: v })"
-            />
-          </NFormItem>
-
-          <NFormItem
-            v-if="supportsModelGate"
-            class="param-inline-item"
-            label-placement="left"
-            :label-width="inlineLabelWidth"
-          >
-            <template #label>
-              <NTooltip>
-                <template #trigger>
-                  <span class="tip-label">{{ t('param.enableModel') }}</span>
-                </template>
-                {{ modelPackAvailable ? tooltips.model_enable : t('param.modelOnlyHint') }}
-              </NTooltip>
-            </template>
-            <NSwitch
-              :value="modelValue.model_enable"
-              :disabled="!modelPackAvailable"
-              @update:value="(v: boolean) => update({ model_enable: v })"
-            />
-          </NFormItem>
-        </div>
+          <template #label>
+            <NTooltip>
+              <template #trigger>
+                <span class="tip-label">{{ t('param.enableModel') }}</span>
+              </template>
+              {{ modelPackAvailable ? tooltips.model_enable : t('param.modelOnlyHint') }}
+            </NTooltip>
+          </template>
+          <NSwitch
+            :value="modelValue.model_enable"
+            :disabled="!modelPackAvailable"
+            @update:value="(v: boolean) => update({ model_enable: v })"
+          />
+        </NFormItem>
 
         <NFormItem
           v-else-if="supportsModelGate"
@@ -596,30 +568,6 @@ watch(canEnableTransparentLayer, (can) => {
             :tooltip="true"
             :format-tooltip="formatTooltip2Decimals"
             @update:value="(v: number) => update({ dither_strength: roundTo(v, 2) })"
-          />
-        </NFormItem>
-
-        <NFormItem
-          v-if="isVector && modelValue.gradient_dither && modelValue.gradient_dither !== 'none'"
-          label-placement="left"
-          :label-width="simpleLabelWidth"
-        >
-          <template #label>
-            <NTooltip>
-              <template #trigger>
-                <span class="tip-label">{{ t('param.gradientDitherStrength') }}</span>
-              </template>
-              {{ tooltips.gradient_dither_strength }}
-            </NTooltip>
-          </template>
-          <NSlider
-            :value="modelValue.gradient_dither_strength ?? 0.8"
-            :min="0"
-            :max="1"
-            :step="0.05"
-            :tooltip="true"
-            :format-tooltip="formatTooltip2Decimals"
-            @update:value="(v: number) => update({ gradient_dither_strength: roundTo(v, 2) })"
           />
         </NFormItem>
 
@@ -800,42 +748,6 @@ watch(canEnableTransparentLayer, (can) => {
                 @update:value="
                   (v: number | null) => update({ tessellation_tolerance_mm: roundTo(v ?? 0.03, 2) })
                 "
-              />
-            </NFormItem>
-
-            <NFormItem>
-              <template #label>
-                <NTooltip>
-                  <template #trigger>
-                    <span class="tip-label">{{ t('param.gradientDither') }}</span>
-                  </template>
-                  {{ tooltips.gradient_dither }}
-                </NTooltip>
-              </template>
-              <NSelect
-                :value="modelValue.gradient_dither ?? 'none'"
-                :options="gradientDitherOptions"
-                @update:value="(v: string) => update({ gradient_dither: v })"
-              />
-            </NFormItem>
-
-            <NFormItem v-if="modelValue.gradient_dither && modelValue.gradient_dither !== 'none'">
-              <template #label>
-                <NTooltip>
-                  <template #trigger>
-                    <span class="tip-label">{{ t('param.gradientDitherStrength') }}</span>
-                  </template>
-                  {{ tooltips.gradient_dither_strength }}
-                </NTooltip>
-              </template>
-              <NSlider
-                :value="modelValue.gradient_dither_strength ?? 0.8"
-                :min="0"
-                :max="1"
-                :step="0.05"
-                :tooltip="true"
-                :format-tooltip="formatTooltip2Decimals"
-                @update:value="(v: number) => update({ gradient_dither_strength: roundTo(v, 2) })"
               />
             </NFormItem>
           </NCollapseItem>

--- a/web/frontend/src/composables/useParamPanelState.ts
+++ b/web/frontend/src/composables/useParamPanelState.ts
@@ -49,11 +49,6 @@ export function useParamPanelState() {
     { label: 'Floyd-Steinberg', value: 'floyd_steinberg' },
   ]
 
-  const gradientDitherOpts: SelectOption[] = [
-    { label: t('param.off'), value: 'none' },
-    { label: 'Floyd-Steinberg', value: 'floyd_steinberg' },
-  ]
-
   const clusterModeOpts: SelectOption[] = [
     { label: t('param.clusterModeOff'), value: 'off' },
     { label: t('param.clusterModeAuto'), value: 'auto' },
@@ -88,8 +83,6 @@ export function useParamPanelState() {
     generate_preview: t('param.tooltips.generate_preview'),
     generate_source_mask: t('param.tooltips.generate_source_mask'),
     tessellation_tolerance_mm: t('param.tooltips.tessellation_tolerance_mm'),
-    gradient_dither: t('param.tooltips.gradient_dither'),
-    gradient_dither_strength: t('param.tooltips.gradient_dither_strength'),
   }
 
   function buildDBOptions(dbs: ColorDBInfo[]): SelectOption[] {
@@ -238,8 +231,6 @@ export function useParamPanelState() {
       if (newType === 'vector') {
         update({
           tessellation_tolerance_mm: modelValue.value.tessellation_tolerance_mm ?? 0.03,
-          gradient_dither: modelValue.value.gradient_dither ?? 'none',
-          gradient_dither_strength: modelValue.value.gradient_dither_strength ?? 0.8,
         })
       }
       if (mode.value === 'simple') {
@@ -257,16 +248,6 @@ export function useParamPanelState() {
       if (type !== 'raster') return
       if (dither === 'blue_noise') {
         update({ dither: 'none' })
-      }
-    },
-    { immediate: true },
-  )
-
-  watch(
-    () => modelValue.value.gradient_dither,
-    (gradientDither) => {
-      if (gradientDither === 'blue_noise') {
-        update({ gradient_dither: 'none' })
       }
     },
     { immediate: true },
@@ -572,7 +553,6 @@ export function useParamPanelState() {
     filteredDBOptions,
     formatTooltip1Decimal,
     formatTooltip2Decimals,
-    gradientDitherOptions: gradientDitherOpts,
     handleChannelKeysChange,
     imageDimensions,
     inlineLabelWidth,

--- a/web/frontend/src/domain/params/convertDefaults.ts
+++ b/web/frontend/src/domain/params/convertDefaults.ts
@@ -41,7 +41,5 @@ export function createInitialConvertParams({
     generate_source_mask: defaults.generate_source_mask,
     db_names: dbNames,
     tessellation_tolerance_mm: 0.03,
-    gradient_dither: 'none',
-    gradient_dither_strength: 0.8,
   }
 }

--- a/web/frontend/src/domain/params/convertParamBuilders.test.ts
+++ b/web/frontend/src/domain/params/convertParamBuilders.test.ts
@@ -31,8 +31,6 @@ describe('convertParamBuilders', () => {
     nozzle_size: 'n02',
     face_orientation: 'facedown',
     tessellation_tolerance_mm: 0.15,
-    gradient_dither: 'none',
-    gradient_dither_strength: 0.5,
   }
 
   it('buildRasterParams should exclude vector-only fields', () => {
@@ -45,13 +43,11 @@ describe('convertParamBuilders', () => {
     expect(raster.base_layers).toBe(3)
     expect(raster.double_sided).toBe(true)
     expect((raster as Record<string, unknown>).tessellation_tolerance_mm).toBeUndefined()
-    expect((raster as Record<string, unknown>).gradient_dither).toBeUndefined()
   })
 
   it('buildVectorParams should exclude raster-only fields', () => {
     const vector = buildVectorParams(input)
     expect(vector.tessellation_tolerance_mm).toBe(0.15)
-    expect(vector.gradient_dither).toBe('none')
     expect(vector.model_enable).toBe(true)
     expect(vector.model_only).toBe(false)
     expect(vector.model_threshold).toBe(2.5)

--- a/web/frontend/src/domain/params/convertParamBuilders.ts
+++ b/web/frontend/src/domain/params/convertParamBuilders.ts
@@ -50,8 +50,6 @@ const VECTOR_FIELDS: Array<keyof ConvertVectorParams> = [
   'allowed_channels',
   'generate_preview',
   'tessellation_tolerance_mm',
-  'gradient_dither',
-  'gradient_dither_strength',
   'nozzle_size',
   'face_orientation',
 ]

--- a/web/frontend/src/locales/en.ts
+++ b/web/frontend/src/locales/en.ts
@@ -121,9 +121,7 @@ export default {
     halftone: 'Halftone Dither',
     enableModel: 'Enable Model',
     modelOnlyHint: 'Model enhancement only available for BambooLab PLA databases',
-    gradientDither: 'Gradient Dither',
     ditherStrength: 'Dither Strength',
-    gradientDitherStrength: 'Gradient Dither Strength',
     imageProcessing: 'Image Processing',
     sizeSettings: 'Size Settings',
     scaleFactor: 'Scale Factor',
@@ -206,9 +204,6 @@ export default {
         'Generate source mask (PNG). White = model prediction, Black = ColorDB match',
       tessellation_tolerance_mm:
         'Curve tessellation tolerance (mm). Smaller = smoother but more mesh. Default 0.03',
-      gradient_dither: 'Dither SVG gradient regions to improve transitions with limited palette',
-      gradient_dither_strength:
-        'Gradient dither strength. Higher = smoother transitions but may add grain',
     },
   },
 

--- a/web/frontend/src/locales/zh-CN.ts
+++ b/web/frontend/src/locales/zh-CN.ts
@@ -151,9 +151,7 @@ export default {
     halftone: '半色调抖动',
     enableModel: '启用模型',
     modelOnlyHint: '仅 BambooLab PLA 数据库支持模型增强',
-    gradientDither: '渐变抖动',
     ditherStrength: '抖动强度',
-    gradientDitherStrength: '渐变抖动强度',
     imageProcessing: '图像处理',
     sizeSettings: '尺寸设置',
     scaleFactor: '缩放倍率',
@@ -239,8 +237,6 @@ export default {
         '生成来源掩码图（PNG），白色像素表示使用了模型预测的配方，黑色表示使用了 ColorDB 匹配',
       tessellation_tolerance_mm:
         '矢量曲线三角化时的容差（毫米），值越小曲线越平滑但网格越多。默认 0.03，推荐 0.03-0.12',
-      gradient_dither: '对 SVG 渐变区域进行抖动处理，改善渐变在有限调色板下的过渡效果',
-      gradient_dither_strength: '渐变区域的抖动强度。值越大渐变过渡越平滑，但可能产生颗粒感',
     },
   },
 

--- a/web/frontend/src/types.ts
+++ b/web/frontend/src/types.ts
@@ -70,8 +70,6 @@ export interface ConvertVectorParams {
   allowed_channels?: PaletteChannel[]
   generate_preview?: boolean
   tessellation_tolerance_mm?: number
-  gradient_dither?: string
-  gradient_dither_strength?: number
   nozzle_size?: NozzleSize
   face_orientation?: FaceOrientation
 }


### PR DESCRIPTION
## Summary

- **Gradient rasterization bug fixes**: `findContours` 改用 `RETR_LIST`；`approxPolyDP` epsilon 改为基于 `tessellation_tolerance_mm`；`RasterizeGradientShape` 改用 `CV_32FC4` + alpha 通道消除黑色像素歧义
- **移除 gradient_dither**: 前端 8 文件 + 后端 2 文件完整清理，该参数从未实际接入渲染管线
- **精度与一致性改进**: `IsIdentityTransform` 改用 epsilon 比较；统一 `kClipperScale` 到 `1e6` 并提取到共享头文件 `clipper_scale.h`
- **渐变增强**: `GradientInfo` 新增 `SpreadMethod`（pad/reflect/repeat）；`GradientStop` 新增 `opacity` 字段；`InterpolateGradient` 实现完整插值
- **Warning 日志**: stroke-only / pattern fill / `<text>` / `<image>` 元素跳过时输出告警

## 变更文件（23 files, +399 -224）

| 模块 | 文件 | 变更 |
|---|---|---|
| core | `vector_proc.cpp` | 渐变提取、SpreadMethod、epsilon 修复、warn 日志 |
| core | `gradient.cpp/h` | CV_32FC4 alpha 通道、SpreadMethod 插值、stop-opacity |
| core | `vector_image.h` | `SpreadMethod` 枚举、`GradientStop.opacity` 字段 |
| core | `clipper_scale.h` (new) | 统一 `kClipperScale = 1e6` |
| core | `occlusion.cpp`, `shape_width_analyzer.cpp` | 引用共享 `kClipperScale` |
| core | `pipeline.h` | 移除 `gradient_dither` 字段 |
| apps | `svg_to_3mf.cpp` | 新增 `--gradient-px-mm` CLI 参数 |
| backend | `server_facade.cpp` | 移除 `gradient_dither` JSON 解析 |
| frontend | `ParamPanel.vue`, `useParamPanelState.ts`, `types.ts` 等 8 文件 | 移除 gradient_dither UI 及相关逻辑 |
| 3dparty | `lunasvg` | `collectGradientAttributes` 改为 public |
| docs | `development.md`, `agents/core/README.md` | 同步文档 |

## Test plan

- [x] 全量 C++ 编译通过（0 error, 0 warning）
- [x] `交大校徽.svg` — 50 shapes, 100×100mm, 纯 solid fill, 9ms
- [x] `IMG_20260322_233043降亮度.svg` — 3 个渐变 shape 成功 flatten 为 9 个 solid sub-shape, 共 3485 shapes, 107ms
- [ ] 前端 `npm run build` 验证
- [ ] 端到端：Web UI 上传 SVG → 预览 → 生成 3MF 验证渐变区域不再为空

Made with [Cursor](https://cursor.com)