### PR TITLE
release: v1.2.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ChromaPrint3D VERSION 1.2.10 LANGUAGES CXX)
+project(ChromaPrint3D VERSION 1.2.11 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "private": true,
   "description": "ChromaPrint3D - Multi-color 3D printing image processor",
   "author": "neroued <neroued@gmail.com>",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d-web",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Web frontend for ChromaPrint3D — multi-color 3D print image processor",
   "type": "module",
   "license": "Apache-2.0",

--- a/web/frontend/public/version-manifest.json
+++ b/web/frontend/public/version-manifest.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.2.10",
-  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.10",
-  "changelog": "- 矢量图处理速度大幅提升\n- 改进 SVG 文件解析，支持更多格式特性\n- 配方编辑器响应速度优化，支持包含更多颜色的图片\n- 修复全局选色模式下无法取消选择的问题\n- 修复特定颜色库组合下配方匹配失败的问题",
-  "changelog_en": "- Significantly faster vector image processing\n- Improved SVG parsing with better format support\n- Faster recipe editor with support for more colors\n- Fixed deselect in global color-select mode\n- Fixed recipe matching with certain color DB combinations",
-  "published_at": "2026-03-24"
+  "version": "1.2.11",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.11",
+  "changelog": "- 矢量模式渐变处理和精度优化\n- 3MF 导出性能与稳定性提升",
+  "changelog_en": "- Improved gradient handling and precision in vector mode\n- Enhanced 3MF export performance and stability",
+  "published_at": "2026-03-25"
 }


### PR DESCRIPTION
## Release v1.2.11

Bumps version to `1.2.11` in:
- `CMakeLists.txt`
- `web/frontend/package.json`
- `web/electron/package.json`
- `web/frontend/public/version-manifest.json`

After this PR is merged, the `release-tag` workflow will automatically
create tag `v1.2.11` and trigger the full release pipeline.