### PR TITLE
feat: add video tutorial link to header navbar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ChromaPrint3D VERSION 1.2.10 LANGUAGES CXX)
+project(ChromaPrint3D VERSION 1.2.11 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "private": true,
   "description": "ChromaPrint3D - Multi-color 3D printing image processor",
   "author": "neroued <neroued@gmail.com>",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d-web",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Web frontend for ChromaPrint3D — multi-color 3D print image processor",
   "type": "module",
   "license": "Apache-2.0",

--- a/web/frontend/public/version-manifest.json
+++ b/web/frontend/public/version-manifest.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.2.10",
-  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.10",
-  "changelog": "- 矢量图处理速度大幅提升\n- 改进 SVG 文件解析，支持更多格式特性\n- 配方编辑器响应速度优化，支持包含更多颜色的图片\n- 修复全局选色模式下无法取消选择的问题\n- 修复特定颜色库组合下配方匹配失败的问题",
-  "changelog_en": "- Significantly faster vector image processing\n- Improved SVG parsing with better format support\n- Faster recipe editor with support for more colors\n- Fixed deselect in global color-select mode\n- Fixed recipe matching with certain color DB combinations",
-  "published_at": "2026-03-24"
+  "version": "1.2.11",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.11",
+  "changelog": "- 矢量模式渐变处理和精度优化\n- 3MF 导出性能与稳定性提升",
+  "changelog_en": "- Improved gradient handling and precision in vector mode\n- Enhanced 3MF export performance and stability",
+  "published_at": "2026-03-25"
 }

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -166,6 +166,15 @@ function toggleLocale() {
                 <NText depth="3" class="app-shell__meta-text">{{ t('common.darkMode') }}</NText>
                 <NSwitch v-model:value="isDark" size="small" />
               </NSpace>
+              <NButton
+                tag="a"
+                href="https://www.bilibili.com/video/BV1cPATzyEz9/"
+                target="_blank"
+                size="small"
+                quaternary
+              >
+                {{ t('common.videoTutorial') }}
+              </NButton>
               <NButton size="small" quaternary @click="toggleLocale">
                 {{ locale === 'zh-CN' ? 'EN' : '中' }}
               </NButton>

--- a/web/frontend/src/locales/en.ts
+++ b/web/frontend/src/locales/en.ts
@@ -22,6 +22,7 @@ export default {
     disabled: 'Disabled',
     pollFailed: 'Task polling failed, please retry ({message})',
     downloadFailed: 'Download failed, please retry',
+    videoTutorial: 'Video Tutorial',
   },
 
   app: {

--- a/web/frontend/src/locales/zh-CN.ts
+++ b/web/frontend/src/locales/zh-CN.ts
@@ -52,6 +52,7 @@ export default {
     disabled: '禁用',
     pollFailed: '任务状态轮询失败，请重试（{message}）',
     downloadFailed: '下载失败，请重试',
+    videoTutorial: '视频教程',
   },
 
   app: {


### PR DESCRIPTION
## Summary

- 在前端顶栏导航区域添加了 Bilibili 视频教程链接按钮（https://www.bilibili.com/video/BV1cPATzyEz9/）
- 按钮位于深色模式开关和语言切换按钮之间，点击后在新标签页打开
- 支持中英文国际化（`视频教程` / `Video Tutorial`）

## Changes

- `web/frontend/src/App.vue` — 顶栏添加 `NButton` (tag="a") 视频教程链接
- `web/frontend/src/locales/zh-CN.ts` — 添加 `common.videoTutorial` 中文翻译
- `web/frontend/src/locales/en.ts` — 添加 `common.videoTutorial` 英文翻译

## Test plan

- [ ] 中文模式下顶栏显示"视频教程"按钮
- [ ] 英文模式下顶栏显示"Video Tutorial"按钮
- [ ] 点击按钮在新标签页打开 Bilibili 视频链接
- [ ] 按钮样式与相邻的语言切换按钮保持一致


Made with [Cursor](https://cursor.com)