### PR TITLE
chore: change default pixel_mm from 0.42 to 0.1 in simple mode

### DIFF
--- a/web/frontend/src/composables/useParamPanelState.ts
+++ b/web/frontend/src/composables/useParamPanelState.ts
@@ -111,8 +111,8 @@ export function useParamPanelState() {
   const selectedVendor = ref('BambooLab')
   const targetWidthMm = ref(200)
   const targetHeightMm = ref(200)
-  const selectedPixelPresetIndex = ref(1)
-  const customPixelMm = ref(0.42)
+  const selectedPixelPresetIndex = ref(2)
+  const customPixelMm = ref(0.1)
   const selectedChannelKeys = ref<string[]>([])
   type ClusterMode = 'off' | 'auto' | 'manual'
   const clusterMode = ref<ClusterMode>('auto')
@@ -463,8 +463,8 @@ export function useParamPanelState() {
     targetHeightMm.value = 200
     mode.value = 'simple'
     clusterMode.value = 'auto'
-    selectedPixelPresetIndex.value = 1
-    customPixelMm.value = 0.42
+    selectedPixelPresetIndex.value = 2
+    customPixelMm.value = 0.1
     const currentDbNames = modelValue.value.db_names ?? filteredDBs.value.map((db) => db.name)
     appStore.setParams(
       createInitialConvertParams({


### PR DESCRIPTION
## Summary

- 将简易模式下的默认像素尺寸从 0.42mm（0.4mm 喷嘴预设）改为 0.1mm，以提供更精细的默认分辨率
- 仅修改前端 composable 中的两处硬编码默认值（初始值 + resetParams），不涉及后端或预设系统变更

## Changes

- `web/frontend/src/composables/useParamPanelState.ts`
  - `selectedPixelPresetIndex`: `ref(1)` -> `ref(2)`（切到"自定义"项）
  - `customPixelMm`: `ref(0.42)` -> `ref(0.1)`
  - `resetParams()` 中的对应重置值同步修改

## Test plan

- [ ] 打开前端简易模式，确认默认像素尺寸为 0.1mm
- [ ] 执行一次转换，确认后端收到 `pixel_mm: 0.1` 并正常处理
- [ ] 点击重置参数按钮，确认像素尺寸恢复为 0.1mm
- [ ] 切换到高级模式，确认 0.22/0.42 预设仍可正常选择


Made with [Cursor](https://cursor.com)