### PR TITLE
fix: restore raster layer preview rendering in direct convert path

### DIFF
--- a/core/src/pipeline/pipeline.cpp
+++ b/core/src/pipeline/pipeline.cpp
@@ -319,6 +319,50 @@ ConvertResult GenerateRasterModel(MatchRasterResult& mr, ProgressCallback progre
             LayerPreviewChannel{static_cast<int>(i), channel.color, channel.material});
     }
     result.layer_previews.layer_pngs.resize(static_cast<std::size_t>(mr.profile.color_layers));
+    std::atomic<bool> has_layer_preview_error{false};
+    std::string layer_preview_error_message;
+#ifdef _OPENMP
+#    pragma omp parallel for schedule(dynamic)
+#endif
+    for (int layer_idx = 0; layer_idx < mr.profile.color_layers; ++layer_idx) {
+        if (has_layer_preview_error.load(std::memory_order_relaxed)) { continue; }
+
+        try {
+            cv::Mat layer_bgra =
+                DownsampleForPreview(mr.recipe_map.ToLayerBgraImage(layer_idx, mr.profile.palette));
+            if (layer_bgra.empty()) {
+                throw InputError("Failed to render raster layer preview image");
+            }
+            result.layer_previews.layer_pngs[static_cast<std::size_t>(layer_idx)] =
+                EncodePng(layer_bgra);
+        } catch (const std::exception& e) {
+#ifdef _OPENMP
+#    pragma omp critical(pipeline_layer_preview_error)
+#endif
+            {
+                if (!has_layer_preview_error.load(std::memory_order_relaxed)) {
+                    layer_preview_error_message = e.what();
+                    has_layer_preview_error.store(true, std::memory_order_relaxed);
+                }
+            }
+        } catch (...) {
+#ifdef _OPENMP
+#    pragma omp critical(pipeline_layer_preview_error)
+#endif
+            {
+                if (!has_layer_preview_error.load(std::memory_order_relaxed)) {
+                    layer_preview_error_message =
+                        "Unknown error while rendering layer preview images";
+                    has_layer_preview_error.store(true, std::memory_order_relaxed);
+                }
+            }
+        }
+    }
+    if (has_layer_preview_error.load(std::memory_order_relaxed)) {
+        throw InputError(layer_preview_error_message.empty()
+                             ? "Failed to render raster layer preview image"
+                             : layer_preview_error_message);
+    }
 
     // === Build 3D model ===
     NotifyProgress(progress, ConvertStage::BuildingModel, 0.0f);


### PR DESCRIPTION
## Summary

- Perf 优化 (#48, 37840bc) 删除了 `GenerateRasterModel` 中的分层预览渲染循环，改为依赖 `LoadArtifact` 的懒渲染路径
- 但"直接生成"路径（`SubmitConvertRaster`）不保存 `raster_match_state`，导致懒渲染无法工作，分层预览为空
- 恢复并行渲染循环，同时保留 `DownsampleForPreview` 优化（分辨率上限 2048px）
- 矢量路径不受影响（`vector_pipeline.cpp` 未被修改）

## Test plan

- [ ] 位图直接生成后，检查分层预览是否正常显示
- [ ] 位图分步操作（match-only → 生成模型）后，检查分层预览是否正常显示
- [ ] 矢量直接生成后，检查分层预览是否正常显示
- [ ] 确认 C++ 编译通过


Made with [Cursor](https://cursor.com)