### PR TITLE
fix: prevent recipe editor task from TTL eviction during idle editing

### DIFF
--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -700,7 +700,7 @@ ServiceResult ServerFacade::ListTasks(const std::string& owner) const {
     return ServiceResult::Success(200, {{"tasks", std::move(tasks)}});
 }
 
-ServiceResult ServerFacade::GetTask(const std::string& owner, const std::string& id) const {
+ServiceResult ServerFacade::GetTask(const std::string& owner, const std::string& id) {
     if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
     auto task = tasks_.FindTask(owner, id);
     if (!task) return ServiceResult::Error(404, "not_found", "Task not found");
@@ -717,8 +717,7 @@ ServiceResult ServerFacade::DeleteTask(const std::string& owner, const std::stri
 }
 
 ServiceResult ServerFacade::DownloadTaskArtifact(const std::string& owner, const std::string& id,
-                                                 const std::string& artifact,
-                                                 TaskArtifact& out) const {
+                                                 const std::string& artifact, TaskArtifact& out) {
     if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
     int status          = 500;
     std::string message = "Unknown error";

--- a/web/backend/src/application/server_facade.h
+++ b/web/backend/src/application/server_facade.h
@@ -81,10 +81,10 @@ public:
     ServiceResult RecipeEditorGenerate(const std::string& owner, const std::string& task_id);
 
     ServiceResult ListTasks(const std::string& owner) const;
-    ServiceResult GetTask(const std::string& owner, const std::string& id) const;
+    ServiceResult GetTask(const std::string& owner, const std::string& id);
     ServiceResult DeleteTask(const std::string& owner, const std::string& id);
     ServiceResult DownloadTaskArtifact(const std::string& owner, const std::string& id,
-                                       const std::string& artifact, TaskArtifact& out) const;
+                                       const std::string& artifact, TaskArtifact& out);
 
     ServiceResult MattingMethods() const;
 

--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -988,8 +988,7 @@ std::vector<TaskSnapshot> TaskRuntime::ListTasks(const std::string& owner) const
     return out;
 }
 
-std::optional<TaskSnapshot> TaskRuntime::FindTask(const std::string& owner,
-                                                  const std::string& id) const {
+std::optional<TaskSnapshot> TaskRuntime::FindTask(const std::string& owner, const std::string& id) {
     std::lock_guard<std::mutex> lock(task_mtx_);
     auto it = tasks_.find(id);
     if (it == tasks_.end()) {
@@ -1000,6 +999,9 @@ std::optional<TaskSnapshot> TaskRuntime::FindTask(const std::string& owner,
         spdlog::warn("FindTask: task {} owner mismatch: request={} vs task={}", id, OwnerTag(owner),
                      OwnerTag(it->second.snapshot.owner));
         return std::nullopt;
+    }
+    if (it->second.snapshot.status == RuntimeTaskStatus::Completed) {
+        it->second.snapshot.completed_at = std::chrono::steady_clock::now();
     }
     return it->second.snapshot;
 }
@@ -1042,7 +1044,7 @@ bool TaskRuntime::DeleteTask(const std::string& owner, const std::string& id, in
 std::optional<TaskArtifact> TaskRuntime::LoadArtifact(const std::string& owner,
                                                       const std::string& id,
                                                       const std::string& artifact, int& status_code,
-                                                      std::string& message) const {
+                                                      std::string& message) {
     std::lock_guard<std::mutex> lock(task_mtx_);
     auto it = tasks_.find(id);
     if (it == tasks_.end() || it->second.snapshot.owner != owner) {
@@ -1056,6 +1058,7 @@ std::optional<TaskArtifact> TaskRuntime::LoadArtifact(const std::string& owner,
         message     = "Task not completed";
         return std::nullopt;
     }
+    it->second.snapshot.completed_at = std::chrono::steady_clock::now();
 
     const auto& rec = it->second;
 

--- a/web/backend/src/infrastructure/task_runtime.h
+++ b/web/backend/src/infrastructure/task_runtime.h
@@ -181,12 +181,12 @@ public:
                                      const ChromaPrint3D::ModelPackage* model_pack);
 
     std::vector<TaskSnapshot> ListTasks(const std::string& owner) const;
-    std::optional<TaskSnapshot> FindTask(const std::string& owner, const std::string& id) const;
+    std::optional<TaskSnapshot> FindTask(const std::string& owner, const std::string& id);
     bool DeleteTask(const std::string& owner, const std::string& id, int& status_code,
                     std::string& message);
     std::optional<TaskArtifact> LoadArtifact(const std::string& owner, const std::string& id,
                                              const std::string& artifact, int& status_code,
-                                             std::string& message) const;
+                                             std::string& message);
 
     int ActiveTaskCount() const;
 

--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { NCard, NButton, NSpace, NText, NAlert, NSwitch, NTooltip, useMessage } from 'naive-ui'
 import type { RecipeEditorSummary, RecipeCandidate, LabColor, RecipeInfo } from '../../types'
@@ -105,6 +105,7 @@ async function loadSummary() {
     summary.value = await fetchRecipeEditorSummary(props.taskId)
     await loadRegionMap(props.taskId, summary.value.width, summary.value.height)
     await loadPreview()
+    startKeepalive()
   } catch (e) {
     summaryError.value = e instanceof Error ? e.message : String(e)
   } finally {
@@ -393,6 +394,31 @@ async function handleDownload3MF() {
   }
 }
 
+// ── Keep-alive heartbeat ─────────────────────────────────────────────────────
+
+const KEEPALIVE_INTERVAL_MS = 5 * 60 * 1000
+
+let keepaliveTimer: ReturnType<typeof setInterval> | null = null
+
+function startKeepalive() {
+  stopKeepalive()
+  keepaliveTimer = setInterval(async () => {
+    if (!props.taskId || !summary.value) return
+    try {
+      summary.value = await fetchRecipeEditorSummary(props.taskId)
+    } catch {
+      /* silent – don't disrupt the user on heartbeat failure */
+    }
+  }, KEEPALIVE_INTERVAL_MS)
+}
+
+function stopKeepalive() {
+  if (keepaliveTimer) {
+    clearInterval(keepaliveTimer)
+    keepaliveTimer = null
+  }
+}
+
 // ── Lifecycle ────────────────────────────────────────────────────────────────
 
 watch(
@@ -404,12 +430,17 @@ watch(
     undoStack.value = []
     generateDone.value = false
     editedAfterGenerate.value = false
+    stopKeepalive()
     clearRegionMap()
     panZoom.resetView()
     if (props.taskId) void loadSummary()
   },
   { immediate: true },
 )
+
+onUnmounted(() => {
+  stopKeepalive()
+})
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

- 用户在配方编辑器中查看预览、缩放平移、思考配色方案时不会触发服务端请求，导致任务在 `--task-ttl 900`（15 分钟）后被 `CleanupExpiredLocked` 驱逐，再次操作时出现 "Alternatives not available" 错误
- **前端心跳**：在 `RecipeEditorPanel` 中添加 5 分钟间隔的 keep-alive 定时器，周期性调用 `fetchRecipeEditorSummary` 刷新服务端 `completed_at`
- **后端 touch-on-read**：`LoadArtifact` 和 `FindTask` 不再是 `const` 方法，成功访问时刷新 `completed_at`，使预览图加载、状态轮询等只读操作也能续期 TTL

## Test plan

- [ ] 部署后在配方编辑器中保持 >15 分钟不做替换操作（仅查看预览、缩放），确认不再出现 "Alternatives not available"
- [ ] 确认心跳请求在 Network 面板中可见（每 5 分钟一次 `fetchRecipeEditorSummary`）
- [ ] 确认切换 taskId 或离开编辑器后心跳定时器被正确清理
- [ ] 确认正常配方替换、撤销、生成 3MF 流程不受影响


Made with [Cursor](https://cursor.com)