### PR TITLE
fix(frontend): 修复配方编辑器十字标取色偏移与高亮震动

### DIFF
--- a/web/frontend/src/components/common/ZoomableImageViewport.vue
+++ b/web/frontend/src/components/common/ZoomableImageViewport.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { usePanZoom } from '../../composables/usePanZoom'
 import type { PanZoomController } from '../../composables/usePanZoom'
 
@@ -11,6 +11,8 @@ const props = withDefaults(
     checkerboard?: boolean
     controller?: PanZoomController
     showImage?: boolean
+    contentWidth?: number
+    contentHeight?: number
   }>(),
   {
     src: '',
@@ -19,12 +21,81 @@ const props = withDefaults(
     checkerboard: true,
     controller: undefined,
     showImage: true,
+    contentWidth: 0,
+    contentHeight: 0,
   },
 )
 
+const containerRef = ref<HTMLElement | null>(null)
+const containerW = ref(0)
+const containerH = ref(0)
+
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  const el = containerRef.value
+  if (!el) return
+  containerW.value = el.clientWidth
+  containerH.value = el.clientHeight
+  resizeObserver = new ResizeObserver(() => {
+    containerW.value = el.clientWidth
+    containerH.value = el.clientHeight
+  })
+  resizeObserver.observe(el)
+})
+
+onUnmounted(() => {
+  resizeObserver?.disconnect()
+})
+
+const useExplicitFit = computed(
+  () =>
+    props.contentWidth > 0 &&
+    props.contentHeight > 0 &&
+    containerW.value > 0 &&
+    containerH.value > 0,
+)
+
+const fitParams = computed(() => {
+  if (!useExplicitFit.value) return null
+  const cw = containerW.value
+  const ch = containerH.value
+  const nw = props.contentWidth
+  const nh = props.contentHeight
+  const fitScale = Math.min(cw / nw, ch / nh)
+  const offsetX = (cw - nw * fitScale) / 2
+  const offsetY = (ch - nh * fitScale) / 2
+  return { fitScale, offsetX, offsetY }
+})
+
 const internalPanZoom = usePanZoom()
 const panZoom = computed<PanZoomController>(() => props.controller ?? internalPanZoom)
-const transformValue = computed(() => panZoom.value.previewTransform.value)
+
+const transformValue = computed(() => {
+  const pz = panZoom.value
+  const s = pz.scale.value
+  const tx = pz.translateX.value
+  const ty = pz.translateY.value
+  const fp = fitParams.value
+  if (fp) {
+    const cx = tx + fp.offsetX * s
+    const cy = ty + fp.offsetY * s
+    const cs = fp.fitScale * s
+    return `translate(${cx}px, ${cy}px) scale(${cs})`
+  }
+  return pz.previewTransform.value
+})
+
+const imgStyle = computed(() => {
+  const base: Record<string, string> = { transform: transformValue.value }
+  if (useExplicitFit.value) {
+    base.width = `${props.contentWidth}px`
+    base.height = `${props.contentHeight}px`
+    base.objectFit = 'none'
+  }
+  return base
+})
+
 const imageSrc = computed(() => props.src ?? '')
 const viewportStyle = computed(() => {
   const value = props.height
@@ -64,6 +135,7 @@ defineExpose({
 
 <template>
   <div
+    ref="containerRef"
     class="zoomable-image-viewport"
     :class="viewportClass"
     :style="viewportStyle"
@@ -77,7 +149,7 @@ defineExpose({
       v-if="showImage && imageSrc"
       :src="imageSrc"
       class="zoomable-image-viewport__img"
-      :style="{ transform: transformValue }"
+      :style="imgStyle"
       draggable="false"
       :alt="alt"
     />

--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -458,10 +458,21 @@ onUnmounted(() => {
           </template>
           {{ t('recipeEditor.globalModeTooltip') }}
         </NTooltip>
-        <NButton v-if="hasSelection" size="small" quaternary @click="clearSelection">
+        <NButton
+          size="small"
+          quaternary
+          :style="hasSelection ? undefined : { visibility: 'hidden', pointerEvents: 'none' }"
+          @click="clearSelection"
+        >
           {{ t('recipeEditor.clearSelection') }}
         </NButton>
-        <NButton v-if="canUndo" size="small" quaternary :disabled="replacing" @click="handleUndo">
+        <NButton
+          size="small"
+          quaternary
+          :disabled="replacing"
+          :style="canUndo ? undefined : { visibility: 'hidden', pointerEvents: 'none' }"
+          @click="handleUndo"
+        >
           {{ t('recipeEditor.undo') }}
         </NButton>
       </NSpace>
@@ -485,12 +496,16 @@ onUnmounted(() => {
           alt="recipe preview"
           :height="420"
           :controller="panZoom"
+          :content-width="summary?.width ?? 0"
+          :content-height="summary?.height ?? 0"
         >
           <template #default="{ transform }">
             <RegionOverlayCanvas
               :region-map="regionMap"
               :selected-region-ids="selectedRegionIds"
               :transform="transform"
+              :source-width="summary?.width ?? 0"
+              :source-height="summary?.height ?? 0"
             />
           </template>
         </ZoomableImageViewport>

--- a/web/frontend/src/components/recipeEditor/RegionOverlayCanvas.vue
+++ b/web/frontend/src/components/recipeEditor/RegionOverlayCanvas.vue
@@ -6,6 +6,8 @@ const props = defineProps<{
   regionMap: RegionMapData | null
   selectedRegionIds: Set<number>
   transform: string
+  sourceWidth: number
+  sourceHeight: number
 }>()
 
 const canvasRef = ref<HTMLCanvasElement | null>(null)
@@ -19,12 +21,19 @@ function redraw() {
   const ctx = canvas.getContext('2d')
   if (!ctx) return
 
+  const sw = props.sourceWidth
+  const sh = props.sourceHeight
+
   if (props.selectedRegionIds.size === 0) {
-    ctx.clearRect(0, 0, map.width, map.height)
+    ctx.clearRect(0, 0, sw, sh)
     return
   }
 
-  const imageData = ctx.createImageData(map.width, map.height)
+  const tmpCanvas = document.createElement('canvas')
+  tmpCanvas.width = map.width
+  tmpCanvas.height = map.height
+  const tmpCtx = tmpCanvas.getContext('2d')!
+  const imageData = tmpCtx.createImageData(map.width, map.height)
   const data = imageData.data
   const regionIds = map.regionIds
   const selected = props.selectedRegionIds
@@ -35,7 +44,11 @@ function redraw() {
     data[i * 4 + 3] = MASK_ALPHA
   }
 
-  ctx.putImageData(imageData, 0, 0)
+  tmpCtx.putImageData(imageData, 0, 0)
+
+  ctx.clearRect(0, 0, sw, sh)
+  ctx.imageSmoothingEnabled = false
+  ctx.drawImage(tmpCanvas, 0, 0, sw, sh)
 }
 
 watch(
@@ -50,8 +63,8 @@ watch(
     v-if="regionMap"
     ref="canvasRef"
     class="zoomable-image-viewport__layer"
-    :width="regionMap.width"
-    :height="regionMap.height"
-    :style="{ transform }"
+    :width="sourceWidth"
+    :height="sourceHeight"
+    :style="{ transform, width: sourceWidth + 'px', height: sourceHeight + 'px' }"
   />
 </template>

--- a/web/frontend/src/composables/usePanZoom.ts
+++ b/web/frontend/src/composables/usePanZoom.ts
@@ -39,9 +39,10 @@ export function usePanZoom(options: PanZoomOptions = {}) {
     const newScale = Math.max(minScale, Math.min(maxScale, scale.value * factor))
     const ratio = newScale / scale.value
 
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-    const mx = e.clientX - rect.left
-    const my = e.clientY - rect.top
+    const el = e.currentTarget as HTMLElement
+    const rect = el.getBoundingClientRect()
+    const mx = e.clientX - rect.left - el.clientLeft
+    const my = e.clientY - rect.top - el.clientTop
 
     translateX.value = mx - (mx - translateX.value) * ratio
     translateY.value = my - (my - translateY.value) * ratio


### PR DESCRIPTION
## Summary

- 修复配方编辑器在高倍缩放下十字标选色偏移（偏右下数像素）和选中高亮时预览区"震动"的问题
- 三个独立根因已全部修复，改动向后兼容（其他使用 ZoomableImageViewport 的页面不受影响）

## Root Causes & Fixes

### 1. 缩放锚点坐标系不一致（usePanZoom.ts）
`handleWheel` 以 border-box 计算光标坐标，而 CSS transform 作用在 content-box。1px 边框偏移在多次缩放后累积到 ~19px（20x 缩放时）。
**Fix**: 减去 `el.clientLeft` / `el.clientTop`。

### 2. 浏览器 object-fit 取整 vs JS 计算的亚像素差异（ZoomableImageViewport.vue）
`<img>` 的 `object-fit: contain` 由浏览器内部计算 contain 偏移，可能与 JS 的 `screenToImagePixel` 公式存在浮点取整差异（~0.3px），在 20x 缩放下被放大为 ~7px 视觉偏移。
**Fix**: 移除 `object-fit: contain`，改由 JS 计算 fitScale/offset 并融入 CSS transform，使渲染、取色、遮罩三者共用同一组浮点值。通过 ResizeObserver 跟踪容器尺寸，新增 `contentWidth`/`contentHeight` props（默认 0 = 走原有路径）。

### 3. 卡片头部按钮 v-if 导致布局回流（RecipeEditorPanel.vue）
"清除选择"和"撤销"按钮使用 `v-if`，选中状态切换时反复插入/移除 DOM 导致 NCard 头部高度变化。
**Fix**: 改用 `visibility: hidden` + `pointer-events: none`，按钮始终占据布局空间。

### 4. Canvas 遮罩层固有尺寸不匹配（RegionOverlayCanvas.vue）
overlay canvas 使用 regionMap 降采样尺寸，与底图原始尺寸不同，导致两者的 contain 渲染不一致。
**Fix**: 新增 `sourceWidth`/`sourceHeight` props，canvas 固有尺寸改用源分辨率，采用两步绘制（小尺寸 temp canvas + drawImage 缩放）；inline style 覆盖 `:slotted()` 的 `width: 100%`。

## Changed Files

| File | Change |
|------|--------|
| `web/frontend/src/composables/usePanZoom.ts` | handleWheel 减去 border 宽度 |
| `web/frontend/src/components/common/ZoomableImageViewport.vue` | 新增 props + ResizeObserver + 组合 transform |
| `web/frontend/src/components/recipeEditor/RegionOverlayCanvas.vue` | 源分辨率 canvas + 两步绘制 + inline size |
| `web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue` | 传参 + 按钮 visibility 替代 v-if |

## Test plan

- [ ] 打开配方编辑器，上传图像，缩放到最大倍率（20x）
- [ ] 将十字标对准某个像素边界，验证 infobar 显示的坐标与视觉位置一致
- [ ] 点击选中区域，观察高亮遮罩是否与底图完全对齐，无"震动"
- [ ] 反复切换选中/取消选中，确认预览区无布局跳动
- [ ] 拖拽平移后再缩放，验证坐标仍然精确
- [ ] 验证其他使用 ZoomableImageViewport 的页面（上传预览、结果、抠图、矢量化）行为不变

Made with [Cursor](https://cursor.com)