### PR TITLE
feat: embed watermark in all 3MF exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(LUNASVG_DISABLE_LOAD_SYSTEM_FONTS ON CACHE BOOL "Disable system font loading
 add_subdirectory(3dparty/lunasvg)
 
 set(N3MF_BUILD_TESTS OFF CACHE BOOL "Disable neroued_3mf tests" FORCE)
+set(N3MF_BUILD_TOOLS OFF CACHE BOOL "Disable neroued_3mf CLI tools" FORCE)
 add_subdirectory(3dparty/neroued_3mf)
 if(TARGET Clipper2)
     if(MSVC)

--- a/core/src/geo/export_3mf.cpp
+++ b/core/src/geo/export_3mf.cpp
@@ -1,6 +1,7 @@
 #include "chromaprint3d/error.h"
 #include "chromaprint3d/export_3mf.h"
 #include "chromaprint3d/mesh.h"
+#include "chromaprint3d/version.h"
 #include "chromaprint3d/voxel.h"
 #include "bambu_metadata.h"
 
@@ -191,7 +192,12 @@ void EnsureNonEmptyGeometry(const std::vector<InputObject>& objects, std::size_t
     }
 }
 
-neroued_3mf::WriteOptions DefaultWriteOptions() { return {}; }
+neroued_3mf::WriteOptions DefaultWriteOptions() {
+    neroued_3mf::WriteOptions opts;
+    std::string tag = std::string("ChromaPrint3D ") + CHROMAPRINT3D_VERSION_STRING;
+    opts.watermark.payload.assign(tag.begin(), tag.end());
+    return opts;
+}
 
 neroued_3mf::Document BuildStandardDocument(const std::vector<InputObject>& objects) {
     neroued_3mf::DocumentBuilder builder;

--- a/core/tests/test_3mf_writer.cpp
+++ b/core/tests/test_3mf_writer.cpp
@@ -2,6 +2,7 @@
 
 #include "chromaprint3d/error.h"
 #include "chromaprint3d/export_3mf.h"
+#include "chromaprint3d/version.h"
 #include "chromaprint3d/voxel.h"
 
 #include <neroued/3mf/neroued_3mf.h>
@@ -174,6 +175,21 @@ Mesh MakeDenseMesh(int size_xy, int layers) {
         }
     }
     return Mesh::Build(grid);
+}
+
+Mesh MakeHighTriCountMesh(int num_triangles) {
+    Mesh mesh;
+    mesh.vertices.reserve(static_cast<std::size_t>(num_triangles) * 3);
+    mesh.indices.reserve(static_cast<std::size_t>(num_triangles));
+    for (int i = 0; i < num_triangles; ++i) {
+        float x  = static_cast<float>(i) * 2.0f;
+        int base = static_cast<int>(mesh.vertices.size());
+        mesh.vertices.push_back({x, 0.0f, 0.0f});
+        mesh.vertices.push_back({x + 1.0f, 0.0f, 0.0f});
+        mesh.vertices.push_back({x + 0.5f, 1.0f, 0.0f});
+        mesh.indices.push_back({base, base + 1, base + 2});
+    }
+    return mesh;
 }
 
 } // namespace
@@ -433,4 +449,34 @@ TEST(ThreeMfExport, ThrowsOnEmptyMeshes) {
     std::vector<Mesh> meshes;
 
     EXPECT_THROW(Export3mfFromMeshes(meshes, palette), InputError);
+}
+
+// ── Watermark verification ─────────────────────────────────────────────────
+
+TEST(ThreeMfExport, ExportedBufferHasL2Signature) {
+    Mesh mesh                    = MakeHighTriCountMesh(500);
+    std::vector<Channel> palette = {Channel{.color = "Red", .hex_color = "#FF0000"}};
+    std::vector<Mesh> meshes     = {mesh};
+
+    auto buffer = Export3mfFromMeshes(meshes, palette);
+    ASSERT_FALSE(buffer.empty());
+
+    EXPECT_TRUE(neroued_3mf::HasL2Signature({buffer.data(), buffer.size()}));
+}
+
+TEST(ThreeMfExport, ExportedBufferHasL1Payload) {
+    Mesh mesh                    = MakeHighTriCountMesh(500);
+    std::vector<Channel> palette = {Channel{.color = "Blue", .hex_color = "#0000FF"}};
+    std::vector<Mesh> meshes     = {mesh};
+
+    auto buffer = Export3mfFromMeshes(meshes, palette);
+    ASSERT_FALSE(buffer.empty());
+
+    auto result = neroued_3mf::DetectWatermark({buffer.data(), buffer.size()});
+    EXPECT_TRUE(result.has_l2_signature);
+    EXPECT_TRUE(result.has_l1_payload);
+
+    std::string expected = std::string("ChromaPrint3D ") + CHROMAPRINT3D_VERSION_STRING;
+    std::string decoded(result.payload.begin(), result.payload.end());
+    EXPECT_EQ(decoded, expected);
 }


### PR DESCRIPTION
## Summary

- Update neroued_3mf submodule to v0.3.0 with dual-layer watermark support
- Enable L1 watermark in all 3MF export paths by populating `DefaultWriteOptions().watermark.payload` with application identifier and version
- Disable neroued_3mf CLI tools build (`N3MF_BUILD_TOOLS OFF`)
- Add L1/L2 round-trip verification tests

## Test plan

- [x] `ExportedBufferHasL2Signature` — verify L2 ZIP fingerprint present
- [x] `ExportedBufferHasL1Payload` — verify L1 payload decodes to expected string
- [x] All 13 existing 3MF tests pass (no regression)
- [x] Build succeeds with neroued_3mf tools disabled

Made with [Cursor](https://cursor.com)