### PR TITLE
feat: enrich default watermark with timestamp and Shakespeare soliloquy

### DIFF
--- a/core/src/geo/export_3mf.cpp
+++ b/core/src/geo/export_3mf.cpp
@@ -9,6 +9,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
@@ -194,8 +195,62 @@ void EnsureNonEmptyGeometry(const std::vector<InputObject>& objects, std::size_t
 
 neroued_3mf::WriteOptions DefaultWriteOptions() {
     neroued_3mf::WriteOptions opts;
-    std::string tag = std::string("ChromaPrint3D ") + CHROMAPRINT3D_VERSION_STRING;
-    opts.watermark.payload.assign(tag.begin(), tag.end());
+
+    // Header: version + ISO 8601 timestamp
+    std::string header = std::string("ChromaPrint3D ") + CHROMAPRINT3D_VERSION_STRING + " | ";
+    {
+        auto now      = std::chrono::system_clock::now();
+        std::time_t t = std::chrono::system_clock::to_time_t(now);
+        std::tm utc{};
+#ifdef _WIN32
+        gmtime_s(&utc, &t);
+#else
+        gmtime_r(&t, &utc);
+#endif
+        char buf[32];
+        std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &utc);
+        header += buf;
+    }
+    header += "\n\n";
+
+    // Hamlet Act 3, Scene 1 — the infinite-monkey-theorem monologue
+    static constexpr const char* kShakespeare =
+        "To be, or not to be, that is the question:\n"
+        "Whether 'tis nobler in the mind to suffer\n"
+        "The slings and arrows of outrageous fortune,\n"
+        "Or to take arms against a sea of troubles\n"
+        "And by opposing end them. To die: to sleep;\n"
+        "No more; and by a sleep to say we end\n"
+        "The heart-ache and the thousand natural shocks\n"
+        "That flesh is heir to, 'tis a consummation\n"
+        "Devoutly to be wish'd. To die, to sleep;\n"
+        "To sleep: perchance to dream: ay, there's the rub;\n"
+        "For in that sleep of death what dreams may come\n"
+        "When we have shuffled off this mortal coil,\n"
+        "Must give us pause: there's the respect\n"
+        "That makes calamity of so long life;\n"
+        "For who would bear the whips and scorns of time,\n"
+        "The oppressor's wrong, the proud man's contumely,\n"
+        "The pangs of despised love, the law's delay,\n"
+        "The insolence of office and the spurns\n"
+        "That patient merit of the unworthy takes,\n"
+        "When he himself might his quietus make\n"
+        "With a bare bodkin? who would fardels bear,\n"
+        "To grunt and sweat under a weary life,\n"
+        "But that the dread of something after death,\n"
+        "The undiscovere'd country from whose bourn\n"
+        "No traveller returns, puzzles the will\n"
+        "And makes us rather bear those ills we have\n"
+        "Than fly to others that we know not of?\n"
+        "Thus conscience does make cowards of us all;\n"
+        "And thus the native hue of resolution\n"
+        "Is sicklied o'er with the pale cast of thought,\n"
+        "And enterprises of great pith and moment\n"
+        "With this regard their currents turn awry,\n"
+        "And lose the name of action.";
+
+    std::string payload = header + kShakespeare;
+    opts.watermark.payload.assign(payload.begin(), payload.end());
     return opts;
 }
 

--- a/core/tests/test_3mf_writer.cpp
+++ b/core/tests/test_3mf_writer.cpp
@@ -465,7 +465,7 @@ TEST(ThreeMfExport, ExportedBufferHasL2Signature) {
 }
 
 TEST(ThreeMfExport, ExportedBufferHasL1Payload) {
-    Mesh mesh                    = MakeHighTriCountMesh(500);
+    Mesh mesh                    = MakeHighTriCountMesh(50000);
     std::vector<Channel> palette = {Channel{.color = "Blue", .hex_color = "#0000FF"}};
     std::vector<Mesh> meshes     = {mesh};
 
@@ -476,7 +476,10 @@ TEST(ThreeMfExport, ExportedBufferHasL1Payload) {
     EXPECT_TRUE(result.has_l2_signature);
     EXPECT_TRUE(result.has_l1_payload);
 
-    std::string expected = std::string("ChromaPrint3D ") + CHROMAPRINT3D_VERSION_STRING;
     std::string decoded(result.payload.begin(), result.payload.end());
-    EXPECT_EQ(decoded, expected);
+    std::string version_prefix =
+        std::string("ChromaPrint3D ") + CHROMAPRINT3D_VERSION_STRING + " | ";
+    EXPECT_EQ(decoded.substr(0, version_prefix.size()), version_prefix);
+    EXPECT_NE(decoded.find("To be, or not to be"), std::string::npos);
+    EXPECT_NE(decoded.find("And lose the name of action."), std::string::npos);
 }


### PR DESCRIPTION
## Summary

- Expand the default 3MF watermark payload from a bare version tag (`ChromaPrint3D 1.2.12`) to a richer format:
  1. **Version string** — `ChromaPrint3D <version>`
  2. **ISO 8601 UTC timestamp** — export time, e.g. `2026-03-30T12:34:56Z`
  3. **Shakespeare's "To be, or not to be" soliloquy** (Hamlet Act 3, Scene 1) — a playful nod to the infinite monkey theorem
- Cross-platform: uses `gmtime_r` (POSIX) / `gmtime_s` (Windows)
- Build verified, no warnings

## Test plan

- [ ] Build passes on Linux (`cmake --build .`)
- [ ] Verify exported 3MF contains the new watermark payload via `n3mf_detect`
- [ ] Cross-platform build check (Windows / macOS) if CI available

Made with [Cursor](https://cursor.com)