### PR TITLE
fix: 补充 v1.2.13 正式版 version-manifest changelog

### DIFF
--- a/web/frontend/public/version-manifest.json
+++ b/web/frontend/public/version-manifest.json
@@ -1,6 +1,7 @@
 {
   "version": "1.2.13",
   "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.2.13",
-  "changelog": "",
+  "changelog": "- 3MF 导出增加水印，便于识别作品来源与时间\n- 配方编辑器十字线与选中高亮更准确，减少偏移与抖动\n- 其他体验与稳定性改进",
+  "changelog_en": "- Watermarks on 3MF exports for source and time identification\n- More accurate crosshair and selection highlight in the recipe editor, with less jitter\n- Other experience and stability improvements",
   "published_at": "2026-04-09"
 }


### PR DESCRIPTION
## 说明

v1.2.13 正式发布时 `release.sh` 未传入 changelog，导致 `version-manifest.json` 中 `changelog` 为空。

本 PR 按 v1.2.12 → v1.2.13 的用户向变更补充中文与英文说明，便于线上静态资源与更新提示一致。

## 验证

- 合并后可将 `web/frontend/public/version-manifest.json` 同步到站点根目录的 `version-manifest.json`（或与 `VITE_UPDATE_MANIFEST_URL` 指向的位置一致）。

Made with [Cursor](https://cursor.com)