### PR TITLE
feat: 配方编辑器按层颜色模式搜索

### DIFF
--- a/core/include/chromaprint3d/recipe_alternatives.h
+++ b/core/include/chromaprint3d/recipe_alternatives.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace ChromaPrint3D {
@@ -24,6 +25,53 @@ struct RecipeCandidate {
     float hue_diff       = 0.0f;
     bool from_model      = false;
 };
+
+// ── Recipe pattern matching ─────────────────────────────────────────────────
+
+/// Constraint for a single layer position in a recipe pattern.
+struct LayerConstraint {
+    bool wildcard = true;                  ///< true → matches any channel.
+    std::vector<uint8_t> allowed_channels; ///< Valid when wildcard == false.
+};
+
+/// Parsed recipe pattern token (used internally by RecipePattern).
+enum class PatternTokenKind : uint8_t {
+    Letter,     ///< Matches specific channel(s) — consumes exactly 1 layer.
+    SingleWild, ///< '?' — matches any single layer.
+    MultiWild,  ///< '*' — matches 0 or more layers.
+};
+
+struct PatternToken {
+    PatternTokenKind kind = PatternTokenKind::SingleWild;
+    std::vector<uint8_t> allowed_channels; ///< Only meaningful for Letter kind.
+};
+
+/// A compiled recipe search pattern supporting glob-style matching.
+///
+/// Syntax (case-insensitive, `-` separators are ignored):
+///   - Letter   → matches palette channel(s) whose color name starts with that letter.
+///   - `?`      → matches any single layer.
+///   - `*`      → matches 0 or more layers.
+///   - Input shorter than color_layers (without `*`) → implicit trailing `*`.
+struct RecipePattern {
+    std::vector<PatternToken> tokens;
+
+    /// Returns true if the pattern has no tokens (empty / not set).
+    bool Empty() const { return tokens.empty(); }
+
+    /// Tests whether a recipe matches this pattern.
+    /// \param recipe Pointer to the first layer channel index.
+    /// \param color_layers Number of layers in the recipe.
+    bool Matches(const uint8_t* recipe, int color_layers) const;
+    bool Matches(const std::vector<uint8_t>& recipe) const;
+};
+
+/// Parse a user-supplied pattern string into a compiled RecipePattern.
+/// Returns an empty pattern if the string is empty or contains only separators.
+RecipePattern ParseRecipePattern(const std::string& pattern, const std::vector<Channel>& palette,
+                                 int color_layers);
+
+// ── RecipeSearchCache ───────────────────────────────────────────────────────
 
 /// Pre-computed search state for repeated alternative-recipe queries.
 /// Build once per (dbs, profile, model) combination and reuse across calls.
@@ -44,12 +92,22 @@ public:
 
     bool IsValid() const;
 
+    /// Access the merged palette used by this cache.
+    const std::vector<Channel>& Palette() const;
+
+    /// Number of color layers in the associated profile.
+    int ColorLayers() const;
+
 private:
     struct Impl;
     std::shared_ptr<const Impl> impl_;
     friend std::vector<RecipeCandidate> FindAlternativeRecipes(const Lab&, const RecipeSearchCache&,
                                                                int, int);
+    friend std::vector<RecipeCandidate> FindRecipesByPattern(const RecipePattern&, const Lab&,
+                                                             const RecipeSearchCache&, int, int);
 };
+
+// ── Search functions ────────────────────────────────────────────────────────
 
 std::vector<RecipeCandidate> FindAlternativeRecipes(
     const Lab& target_color, std::span<const ColorDB> dbs, const PrintProfile& profile,
@@ -60,5 +118,11 @@ std::vector<RecipeCandidate> FindAlternativeRecipes(
 std::vector<RecipeCandidate> FindAlternativeRecipes(const Lab& target_color,
                                                     const RecipeSearchCache& cache,
                                                     int max_candidates, int offset = 0);
+
+/// Find recipes matching a compiled pattern, ranked by DeltaE76 to target_color.
+std::vector<RecipeCandidate> FindRecipesByPattern(const RecipePattern& pattern,
+                                                  const Lab& target_color,
+                                                  const RecipeSearchCache& cache,
+                                                  int max_candidates, int offset = 0);
 
 } // namespace ChromaPrint3D

--- a/core/src/match/recipe_alternatives.cpp
+++ b/core/src/match/recipe_alternatives.cpp
@@ -100,20 +100,18 @@ RecipePattern ParseRecipePattern(const std::string& pattern, const std::vector<C
             auto it    = letter_map.find(upper);
             if (it == letter_map.end()) { return {}; }
             result.tokens.push_back({PatternTokenKind::Letter, it->second});
+        } else {
+            return {};
         }
-        // Ignore other characters.
     }
 
     if (result.tokens.empty()) { return result; }
 
-    // Implicit trailing * when pattern has no explicit * and fewer fixed tokens
-    // than color_layers.
     if (!has_multi_wild) {
-        int fixed_count = 0;
-        for (const auto& tok : result.tokens) {
-            if (tok.kind != PatternTokenKind::MultiWild) { ++fixed_count; }
-        }
-        if (fixed_count < color_layers) {
+        int fixed_count = static_cast<int>(result.tokens.size());
+        if (fixed_count > color_layers) {
+            result.tokens.resize(static_cast<std::size_t>(color_layers));
+        } else if (fixed_count < color_layers) {
             result.tokens.push_back({PatternTokenKind::MultiWild, {}});
         }
     }

--- a/core/src/match/recipe_alternatives.cpp
+++ b/core/src/match/recipe_alternatives.cpp
@@ -4,13 +4,125 @@
 #include "detail/recipe_convert.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstddef>
 #include <numbers>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace ChromaPrint3D {
+
+// ── RecipePattern ───────────────────────────────────────────────────────────
+
+bool RecipePattern::Matches(const std::vector<uint8_t>& recipe) const {
+    return Matches(recipe.data(), static_cast<int>(recipe.size()));
+}
+
+bool RecipePattern::Matches(const uint8_t* recipe, int color_layers) const {
+    if (tokens.empty() || color_layers <= 0 || !recipe) { return false; }
+
+    const int tn = static_cast<int>(tokens.size());
+    const int rn = color_layers;
+
+    // Glob-style matching via dual-pointer with backtracking.
+    int ti = 0, ri = 0;
+    int star_ti = -1, star_ri = -1;
+
+    while (ri < rn) {
+        if (ti < tn && tokens[static_cast<std::size_t>(ti)].kind == PatternTokenKind::Letter) {
+            const auto& allowed = tokens[static_cast<std::size_t>(ti)].allowed_channels;
+            bool found = std::find(allowed.begin(), allowed.end(), recipe[ri]) != allowed.end();
+            if (found) {
+                ++ti;
+                ++ri;
+                continue;
+            }
+        } else if (ti < tn &&
+                   tokens[static_cast<std::size_t>(ti)].kind == PatternTokenKind::SingleWild) {
+            ++ti;
+            ++ri;
+            continue;
+        } else if (ti < tn &&
+                   tokens[static_cast<std::size_t>(ti)].kind == PatternTokenKind::MultiWild) {
+            star_ti = ti;
+            star_ri = ri;
+            ++ti;
+            continue;
+        }
+
+        if (star_ti >= 0) {
+            ti = star_ti + 1;
+            ++star_ri;
+            ri = star_ri;
+            continue;
+        }
+
+        return false;
+    }
+
+    while (ti < tn && tokens[static_cast<std::size_t>(ti)].kind == PatternTokenKind::MultiWild) {
+        ++ti;
+    }
+    return ti == tn;
+}
+
+RecipePattern ParseRecipePattern(const std::string& pattern, const std::vector<Channel>& palette,
+                                 int color_layers) {
+    RecipePattern result;
+    if (pattern.empty()) { return result; }
+
+    // Build letter → channel indices map (first character of color name, uppercased).
+    std::unordered_map<char, std::vector<uint8_t>> letter_map;
+    for (std::size_t i = 0; i < palette.size(); ++i) {
+        if (palette[i].color.empty()) { continue; }
+        char key = static_cast<char>(std::toupper(static_cast<unsigned char>(palette[i].color[0])));
+        letter_map[key].push_back(static_cast<uint8_t>(i));
+    }
+
+    bool has_multi_wild = false;
+
+    for (char ch : pattern) {
+        if (ch == '-') { continue; }
+
+        if (ch == '*') {
+            has_multi_wild = true;
+            if (!result.tokens.empty() &&
+                result.tokens.back().kind == PatternTokenKind::MultiWild) {
+                continue; // collapse consecutive *
+            }
+            result.tokens.push_back({PatternTokenKind::MultiWild, {}});
+        } else if (ch == '?') {
+            result.tokens.push_back({PatternTokenKind::SingleWild, {}});
+        } else if (std::isalpha(static_cast<unsigned char>(ch))) {
+            char upper = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+            auto it    = letter_map.find(upper);
+            if (it == letter_map.end()) { return {}; }
+            result.tokens.push_back({PatternTokenKind::Letter, it->second});
+        }
+        // Ignore other characters.
+    }
+
+    if (result.tokens.empty()) { return result; }
+
+    // Implicit trailing * when pattern has no explicit * and fewer fixed tokens
+    // than color_layers.
+    if (!has_multi_wild) {
+        int fixed_count = 0;
+        for (const auto& tok : result.tokens) {
+            if (tok.kind != PatternTokenKind::MultiWild) { ++fixed_count; }
+        }
+        if (fixed_count < color_layers) {
+            result.tokens.push_back({PatternTokenKind::MultiWild, {}});
+        }
+    }
+
+    return result;
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────────────
+
 namespace {
 
 std::string RecipeToKey(const std::vector<uint8_t>& recipe) {
@@ -151,6 +263,13 @@ RecipeSearchCache RecipeSearchCache::Build(std::span<const ColorDB> dbs,
 
 bool RecipeSearchCache::IsValid() const { return impl_ && !impl_->prepared_dbs.empty(); }
 
+const std::vector<Channel>& RecipeSearchCache::Palette() const {
+    static const std::vector<Channel> kEmpty;
+    return impl_ ? impl_->profile.palette : kEmpty;
+}
+
+int RecipeSearchCache::ColorLayers() const { return impl_ ? impl_->profile.color_layers : 0; }
+
 // ── FindAlternativeRecipes (uncached) ────────────────────────────────────────
 
 std::vector<RecipeCandidate>
@@ -198,6 +317,94 @@ std::vector<RecipeCandidate> FindAlternativeRecipes(const Lab& target_color,
     }
 
     return CollectAndRank(target_color, raw, max_candidates, offset);
+}
+
+// ── FindRecipesByPattern ────────────────────────────────────────────────────
+
+std::vector<RecipeCandidate> FindRecipesByPattern(const RecipePattern& pattern,
+                                                  const Lab& target_color,
+                                                  const RecipeSearchCache& cache,
+                                                  int max_candidates, int offset) {
+    if (pattern.Empty() || !cache.impl_) { return {}; }
+    const auto& impl       = *cache.impl_;
+    const int color_layers = impl.profile.color_layers;
+
+    std::vector<RawCandidate> raw;
+    std::unordered_set<std::string> seen;
+    raw.reserve(1024);
+
+    // Scan all DB entries.
+    for (const auto& pdb : impl.prepared_dbs) {
+        const ColorDB* search_db = pdb.filtered_db ? pdb.filtered_db.get() : pdb.db;
+        if (!search_db || search_db->entries.empty()) { continue; }
+
+        for (const Entry& entry : search_db->entries) {
+            std::vector<uint8_t> mapped_recipe;
+            if (!detail::ConvertRecipeToProfile(entry, pdb, impl.profile, mapped_recipe)) {
+                continue;
+            }
+            if (!pattern.Matches(mapped_recipe.data(), color_layers)) { continue; }
+
+            std::string key = RecipeToKey(mapped_recipe);
+            if (seen.count(key)) { continue; }
+            seen.insert(std::move(key));
+
+            raw.push_back({std::move(mapped_recipe), entry.lab, false});
+        }
+    }
+
+    // Scan model candidates.
+    if (impl.prepared_model) {
+        const auto& model = *impl.prepared_model;
+        for (std::size_t i = 0; i < model.NumCandidates(); ++i) {
+            const uint8_t* recipe_ptr = model.RecipeAt(i);
+            if (!recipe_ptr) { continue; }
+            if (!pattern.Matches(recipe_ptr, color_layers)) { continue; }
+
+            std::vector<uint8_t> recipe(recipe_ptr, recipe_ptr + color_layers);
+            std::string key = RecipeToKey(recipe);
+            if (seen.count(key)) { continue; }
+            seen.insert(std::move(key));
+
+            raw.push_back({std::move(recipe), model.pred_lab[i], true});
+        }
+    }
+
+    // Rank by DeltaE76 with partial sort for efficiency.
+    const std::size_t needed =
+        static_cast<std::size_t>(std::max(0, offset)) + static_cast<std::size_t>(max_candidates);
+
+    std::vector<RecipeCandidate> candidates;
+    candidates.reserve(raw.size());
+    for (auto& r : raw) {
+        RecipeCandidate c;
+        c.recipe          = std::move(r.recipe);
+        c.predicted_color = r.predicted_color;
+        c.delta_e76       = Lab::DeltaE76(target_color, r.predicted_color);
+        c.lightness_diff  = std::abs(target_color.l() - r.predicted_color.l());
+        c.hue_diff        = ComputeHueDiff(target_color, r.predicted_color);
+        c.from_model      = r.from_model;
+        candidates.push_back(std::move(c));
+    }
+
+    const auto cmp = [](const RecipeCandidate& a, const RecipeCandidate& b) {
+        return a.delta_e76 < b.delta_e76;
+    };
+
+    if (needed < candidates.size()) {
+        std::partial_sort(candidates.begin(),
+                          candidates.begin() + static_cast<std::ptrdiff_t>(needed),
+                          candidates.end(), cmp);
+    } else {
+        std::sort(candidates.begin(), candidates.end(), cmp);
+    }
+
+    const std::size_t start = static_cast<std::size_t>(std::max(0, offset));
+    if (start >= candidates.size()) { return {}; }
+    const std::size_t end =
+        std::min(candidates.size(), start + static_cast<std::size_t>(max_candidates));
+    return {std::make_move_iterator(candidates.begin() + static_cast<std::ptrdiff_t>(start)),
+            std::make_move_iterator(candidates.begin() + static_cast<std::ptrdiff_t>(end))};
 }
 
 } // namespace ChromaPrint3D

--- a/docs/agents/web/backend/README.md
+++ b/docs/agents/web/backend/README.md
@@ -49,7 +49,7 @@
 `POST /api/v1/convert/raster/match-only` 提交 match-only 任务，完成颜色匹配但不生成 3MF。任务完成后通过以下端点进行配方编辑：
 
 - `GET /api/v1/tasks/{id}/recipe-editor/summary`：获取配方摘要（区域列表、唯一配方、调色板）
-- `POST /api/v1/tasks/{id}/recipe-editor/alternatives`：查询候选替代配方
+- `POST /api/v1/tasks/{id}/recipe-editor/alternatives`：查询候选替代配方（支持可选 `recipe_pattern` 参数按层颜色模式过滤）
 - `POST /api/v1/tasks/{id}/recipe-editor/replace`：替换指定区域的配方
 - `POST /api/v1/tasks/{id}/recipe-editor/generate`：异步生成 3MF 模型
 

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -629,11 +629,13 @@ ServiceResult ServerFacade::RecipeEditorAlternatives(const std::string& owner,
     int max_candidates = body.value("max_candidates", 10);
     int offset         = body.value("offset", 0);
 
+    std::string recipe_pattern = body.value("recipe_pattern", std::string{});
+
     const ChromaPrint3D::ModelPackage* model_pack = nullptr;
     if (data_.ModelPack().has_value()) { model_pack = &(*data_.ModelPack()); }
 
-    auto result =
-        tasks_.QueryRecipeAlternatives(owner, task_id, target, max_candidates, offset, model_pack);
+    auto result = tasks_.QueryRecipeAlternatives(owner, task_id, target, max_candidates, offset,
+                                                 model_pack, recipe_pattern);
     if (!result) return ServiceResult::Error(404, "not_found", "Alternatives not available");
     return ServiceResult::Success(200, {{"candidates", std::move(*result)}});
 }

--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -693,7 +693,8 @@ std::optional<nlohmann::json> TaskRuntime::GetRecipeEditorSummary(const std::str
 std::optional<nlohmann::json>
 TaskRuntime::QueryRecipeAlternatives(const std::string& owner, const std::string& id,
                                      const ChromaPrint3D::Lab& target_lab, int max_candidates,
-                                     int offset, const ChromaPrint3D::ModelPackage* model_pack) {
+                                     int offset, const ChromaPrint3D::ModelPackage* model_pack,
+                                     const std::string& recipe_pattern) {
     std::lock_guard<std::mutex> lock(task_mtx_);
     auto it = tasks_.find(id);
     if (it == tasks_.end() || it->second.snapshot.owner != owner) return std::nullopt;
@@ -718,8 +719,20 @@ TaskRuntime::QueryRecipeAlternatives(const std::string& owner, const std::string
             dbs, profile, match_config, model_pack, model_gate_c);
     }
 
-    auto candidates = ChromaPrint3D::FindAlternativeRecipes(target_lab, cp->recipe_search_cache,
-                                                            max_candidates, offset);
+    std::vector<ChromaPrint3D::RecipeCandidate> candidates;
+
+    if (!recipe_pattern.empty()) {
+        auto pattern =
+            ChromaPrint3D::ParseRecipePattern(recipe_pattern, cp->recipe_search_cache.Palette(),
+                                              cp->recipe_search_cache.ColorLayers());
+        if (!pattern.Empty()) {
+            candidates = ChromaPrint3D::FindRecipesByPattern(
+                pattern, target_lab, cp->recipe_search_cache, max_candidates, offset);
+        }
+    } else {
+        candidates = ChromaPrint3D::FindAlternativeRecipes(target_lab, cp->recipe_search_cache,
+                                                           max_candidates, offset);
+    }
 
     it->second.snapshot.completed_at = std::chrono::steady_clock::now();
 

--- a/web/backend/src/infrastructure/task_runtime.h
+++ b/web/backend/src/infrastructure/task_runtime.h
@@ -169,7 +169,8 @@ public:
     std::optional<nlohmann::json>
     QueryRecipeAlternatives(const std::string& owner, const std::string& id,
                             const ChromaPrint3D::Lab& target_lab, int max_candidates, int offset,
-                            const ChromaPrint3D::ModelPackage* model_pack);
+                            const ChromaPrint3D::ModelPackage* model_pack,
+                            const std::string& recipe_pattern = "");
 
     bool ReplaceRecipe(const std::string& owner, const std::string& id,
                        const std::vector<int>& target_region_ids,

--- a/web/frontend/src/api/recipeEditor.ts
+++ b/web/frontend/src/api/recipeEditor.ts
@@ -42,17 +42,22 @@ export async function fetchRecipeAlternatives(
   targetLab: LabColor,
   maxCandidates = 10,
   offset = 0,
+  recipePattern?: string,
 ): Promise<RecipeCandidate[]> {
+  const payload: Record<string, unknown> = {
+    target_lab: targetLab,
+    max_candidates: maxCandidates,
+    offset,
+  }
+  if (recipePattern) {
+    payload.recipe_pattern = recipePattern
+  }
   const data = await request<{ candidates: RecipeCandidate[] }>(
     `/api/v1/tasks/${taskId}/recipe-editor/alternatives`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        target_lab: targetLab,
-        max_candidates: maxCandidates,
-        offset,
-      }),
+      body: JSON.stringify(payload),
     },
   )
   return data.candidates

--- a/web/frontend/src/components/recipeEditor/RecipeCandidatePanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeCandidatePanel.vue
@@ -1,10 +1,22 @@
 <script setup lang="ts">
 import { computed, ref, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { NCard, NButton, NSpace, NText, NScrollbar, NSelect, NSpin, NColorPicker } from 'naive-ui'
+import {
+  NCard,
+  NButton,
+  NSpace,
+  NText,
+  NScrollbar,
+  NSelect,
+  NSpin,
+  NColorPicker,
+  NInput,
+  NTooltip,
+} from 'naive-ui'
 import type { RecipeCandidate, LabColor, PaletteChannel } from '../../types'
 import { fetchRecipeAlternatives } from '../../api/recipeEditor'
 import { hexToLab } from '../../utils/colorConvert'
+import { buildPaletteHint, validateRecipePattern } from '../../utils/recipePattern'
 import RecipeLayerBar from './RecipeLayerBar.vue'
 
 const props = defineProps<{
@@ -36,6 +48,40 @@ const effectiveTargetLab = computed<LabColor | null>(() => customTargetLab.value
 
 const PAGE_SIZE = 10
 
+// ── Recipe pattern search ────────────────────────────────────────────────────
+
+const patternInput = ref('')
+const activePattern = ref('')
+let patternDebounceTimer: ReturnType<typeof setTimeout> | null = null
+
+const paletteHint = computed(() => buildPaletteHint(props.palette))
+
+const patternValidationError = computed(() => {
+  if (!patternInput.value) return null
+  const badChar = validateRecipePattern(patternInput.value, props.palette)
+  if (badChar === null) return null
+  return t('recipeEditor.candidates.patternInvalidChar', { char: badChar })
+})
+
+watch(patternInput, (val) => {
+  if (patternDebounceTimer) clearTimeout(patternDebounceTimer)
+  patternDebounceTimer = setTimeout(() => {
+    const trimmed = val.trim()
+    if (trimmed && validateRecipePattern(trimmed, props.palette) !== null) return
+    activePattern.value = trimmed
+  }, 300)
+})
+
+function onPatternInput() {
+  if (patternInput.value) {
+    customColorHex.value = null
+    customTargetLab.value = null
+    pickerValue.value = props.targetHex ?? '#FFFFFF'
+  }
+}
+
+// ── Color picker / custom color ──────────────────────────────────────────────
+
 const sortOptions = computed(() => [
   { label: t('recipeEditor.candidates.sortDeltaE'), value: 'delta_e76' },
   { label: t('recipeEditor.candidates.sortLightness'), value: 'lightness_diff' },
@@ -52,6 +98,8 @@ const sortedCandidates = computed(() => {
 function applyCustomColor(hex: string) {
   customColorHex.value = hex
   customTargetLab.value = hexToLab(hex)
+  patternInput.value = ''
+  activePattern.value = ''
 }
 
 function handlePickerComplete(hex: string) {
@@ -77,6 +125,8 @@ async function pickColorFromScreen() {
   }
 }
 
+// ── Load candidates ──────────────────────────────────────────────────────────
+
 async function loadCandidates(append = false) {
   const lab = effectiveTargetLab.value
   if (!lab || !props.taskId) return
@@ -84,7 +134,8 @@ async function loadCandidates(append = false) {
   error.value = null
   try {
     const offset = append ? candidates.value.length : 0
-    const result = await fetchRecipeAlternatives(props.taskId, lab, PAGE_SIZE, offset)
+    const pattern = activePattern.value || undefined
+    const result = await fetchRecipeAlternatives(props.taskId, lab, PAGE_SIZE, offset, pattern)
     if (append) {
       candidates.value = [...candidates.value, ...result]
     } else {
@@ -133,7 +184,7 @@ watch(
 )
 
 watch(
-  [effectiveTargetLab, () => props.taskId],
+  [effectiveTargetLab, activePattern, () => props.taskId],
   () => {
     candidates.value = []
     hasMore.value = false
@@ -166,7 +217,7 @@ function handleSelect(candidate: RecipeCandidate) {
       </NSpace>
     </template>
     <div v-if="targetLab" class="candidate-toolbar">
-      <NSpace :size="8" align="center">
+      <NSpace :size="8" align="center" wrap>
         <NColorPicker
           v-model:value="pickerValue"
           size="small"
@@ -203,6 +254,26 @@ function handleSelect(candidate: RecipeCandidate) {
         <NButton v-if="customColorHex" size="tiny" quaternary @click="clearCustomColor">
           {{ t('recipeEditor.candidates.clearCustomColor') }}
         </NButton>
+        <NTooltip :delay="400">
+          <template #trigger>
+            <NInput
+              v-model:value="patternInput"
+              size="small"
+              :placeholder="t('recipeEditor.candidates.patternPlaceholder')"
+              :status="patternValidationError ? 'error' : undefined"
+              clearable
+              style="width: 110px"
+              @input="onPatternInput"
+            />
+          </template>
+          <div style="font-size: 12px; max-width: 260px">
+            <div>{{ t('recipeEditor.candidates.patternTooltip') }}</div>
+            <div style="margin-top: 4px; font-family: monospace">{{ paletteHint }}</div>
+            <div v-if="patternValidationError" style="margin-top: 4px; color: #e88080">
+              {{ patternValidationError }}
+            </div>
+          </div>
+        </NTooltip>
       </NSpace>
     </div>
     <div ref="scrollWrapperRef" class="candidate-scroll-wrapper">

--- a/web/frontend/src/components/recipeEditor/RecipeCandidatePanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeCandidatePanel.vue
@@ -67,7 +67,10 @@ watch(patternInput, (val) => {
   if (patternDebounceTimer) clearTimeout(patternDebounceTimer)
   patternDebounceTimer = setTimeout(() => {
     const trimmed = val.trim()
-    if (trimmed && validateRecipePattern(trimmed, props.palette) !== null) return
+    if (trimmed && validateRecipePattern(trimmed, props.palette) !== null) {
+      activePattern.value = ''
+      return
+    }
     activePattern.value = trimmed
   }, 300)
 })

--- a/web/frontend/src/locales/en.ts
+++ b/web/frontend/src/locales/en.ts
@@ -761,6 +761,10 @@ export default {
       metricH: 'Hue',
       eyeDropper: 'Pick color from screen',
       clearCustomColor: 'Use Selection Color',
+      patternPlaceholder: 'Layer pattern',
+      patternTooltip:
+        'Search by layer colors. Letter=color initial, ?=any layer, *=any layers, -=separator (optional)',
+      patternInvalidChar: 'Unrecognized character: {char}',
     },
   },
 }

--- a/web/frontend/src/locales/zh-CN.ts
+++ b/web/frontend/src/locales/zh-CN.ts
@@ -756,6 +756,9 @@ export default {
       metricH: '色调差',
       eyeDropper: '从屏幕取色',
       clearCustomColor: '使用选区颜色',
+      patternPlaceholder: '层色搜索',
+      patternTooltip: '按层颜色搜索配方。字母=颜色首字母，?=任意单层，*=任意多层，-=分隔符（可选）',
+      patternInvalidChar: '无法识别的字符：{char}',
     },
   },
 }

--- a/web/frontend/src/utils/recipePattern.ts
+++ b/web/frontend/src/utils/recipePattern.ts
@@ -49,7 +49,9 @@ export function validateRecipePattern(pattern: string, palette: PaletteChannel[]
       if (!letterMap.has(ch.toUpperCase())) {
         return ch
       }
+      continue
     }
+    return ch
   }
   return null
 }

--- a/web/frontend/src/utils/recipePattern.ts
+++ b/web/frontend/src/utils/recipePattern.ts
@@ -1,0 +1,55 @@
+import type { PaletteChannel } from '../types'
+
+/**
+ * Build a mapping from uppercase first-letter to palette channel indices.
+ * Multiple channels may share the same letter (e.g. "White" and "Warm White" → 'W').
+ */
+export function buildPaletteLetterMap(palette: PaletteChannel[]): Map<string, number[]> {
+  const map = new Map<string, number[]>()
+  for (let i = 0; i < palette.length; i++) {
+    const name = palette[i]?.color
+    if (!name) continue
+    const letter = name.charAt(0).toUpperCase()
+    const arr = map.get(letter)
+    if (arr) {
+      arr.push(i)
+    } else {
+      map.set(letter, [i])
+    }
+  }
+  return map
+}
+
+/**
+ * Build a human-readable palette hint string for tooltips (e.g. "W=White B=Black").
+ */
+export function buildPaletteHint(palette: PaletteChannel[]): string {
+  const seen = new Set<string>()
+  const parts: string[] = []
+  for (const ch of palette) {
+    if (!ch?.color) continue
+    const letter = ch.color.charAt(0).toUpperCase()
+    if (seen.has(letter)) continue
+    seen.add(letter)
+    parts.push(`${letter}=${ch.color}`)
+  }
+  return parts.join('  ')
+}
+
+/**
+ * Validate a recipe pattern string against the given palette.
+ * Returns null if valid, or an error message describing the first invalid character.
+ */
+export function validateRecipePattern(pattern: string, palette: PaletteChannel[]): string | null {
+  if (!pattern) return null
+  const letterMap = buildPaletteLetterMap(palette)
+  for (const ch of pattern) {
+    if (ch === '-' || ch === '?' || ch === '*') continue
+    if (/[a-zA-Z]/.test(ch)) {
+      if (!letterMap.has(ch.toUpperCase())) {
+        return ch
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

- 在配方编辑器替换候选面板新增按层颜色缩写模式搜索功能，支持 glob 风格语法（字母=颜色首字母，`?`=任意单层，`*`=任意多层，`-`=可选分隔符）
- 后端扩展 `POST .../recipe-editor/alternatives` 端点，新增可选 `recipe_pattern` 参数；有 pattern 时切换为全量扫描 + 模式匹配 + DeltaE partial_sort 策略
- 前端搜索框与取色器/色板互斥，300ms debounce，悬停时显示 palette 映射提示，非法字符实时校验

## Changes

### C++ core (`core/`)
- `recipe_alternatives.h`: 新增 `RecipePattern`、`PatternToken`、`ParseRecipePattern`、`FindRecipesByPattern`；`RecipeSearchCache` 增加 `Palette()` / `ColorLayers()` 访问器
- `recipe_alternatives.cpp`: glob 双指针回溯匹配算法、palette 字母映射、全量扫描 + `partial_sort` 排序、非法字符拒绝、超长 pattern 截断

### Backend API (`web/backend/`)
- `server_facade.cpp`: 解析可选 `recipe_pattern` body 参数
- `task_runtime.h/.cpp`: `QueryRecipeAlternatives` 新增 pattern 参数，按是否有 pattern 分发

### Frontend (`web/frontend/`)
- `recipeEditor.ts`: `fetchRecipeAlternatives` 增加可选 `recipePattern` 参数
- `RecipeCandidatePanel.vue`: 工具栏搜索输入框、debounce、互斥逻辑、无效 pattern 清空 activePattern
- `recipePattern.ts`: palette 映射、提示文本生成、前端校验（拒绝非法字符）
- `zh-CN.ts` / `en.ts`: 3 条 i18n 文案

### Docs
- `docs/agents/web/backend/README.md`: 标注 alternatives 端点支持 `recipe_pattern`

## Test plan

- [x] C++ 全量构建通过（cmake --build）
- [x] 134 个 core tests 全部通过
- [x] 前端 vue-tsc 类型检查通过
- [x] 前端 eslint 通过
- [x] 前端 production build 通过
- [ ] 手动验证：输入 `WWWWB` 精确匹配、`WW` 前缀匹配、`W*B` glob 匹配
- [ ] 手动验证：输入非法字符（数字、空格）显示红色提示且候选列表回退无过滤
- [ ] 手动验证：取色器与 pattern 输入互斥清除
- [ ] 手动验证：切换左侧配方时 pattern 保留

Made with [Cursor](https://cursor.com)