### PR TITLE
refactor(backend): 拆分 ServerFacade 为领域服务 + 轻量协调器

### DIFF
--- a/docs/agents/web/backend/README.md
+++ b/docs/agents/web/backend/README.md
@@ -49,9 +49,9 @@
 1. 在对应领域的 `*_service.{h,cpp}` 中定义并实现服务方法。
 2. 在 `ServerFacade` 中添加委托方法（如需保持 Controller 不直接依赖子服务）。
 3. 在 `ApiV1Controller` 声明路由与处理函数。
-3. 复用统一 envelope：`{ok,data}` / `{ok,error}`。
-4. 若涉及会话，确认 cookie/header/query 的 token 识别链路不被破坏。
-5. 同步更新 [README.md](../../../../README.md) 与 [docs/development.md](../../../development.md) 的接口说明。
+4. 复用统一 envelope：`{ok,data}` / `{ok,error}`。
+5. 若涉及会话，确认 cookie/header/query 的 token 识别链路不被破坏。
+6. 同步更新 [README.md](../../../../README.md) 与 [docs/development.md](../../../development.md) 的接口说明。
 
 ## Bambu Studio 预设参数
 

--- a/docs/agents/web/backend/README.md
+++ b/docs/agents/web/backend/README.md
@@ -14,8 +14,20 @@
   - 任务运行时：`task_runtime.*`
   - 数据加载：`data_repository.*`
   - 校准板缓存：`board_runtime_cache.*`
-- 应用层：`web/backend/src/application/server_facade.*`
-  - 聚合业务流程并返回统一 `ServiceResult`
+- 应用层：`web/backend/src/application/`
+  - 轻量协调器：`server_facade.*`（持有子服务实例，委托调用）
+  - 统一 DTO：`service_result.h`
+  - 领域服务：
+    - `color_db_service.*` — ColorDB 列表与会话库 CRUD
+    - `task_service.*` — 任务列表/查询/删除/artifact 下载
+    - `convert_service.*` — 光栅/矢量转换任务提交与请求构建
+    - `matting_vectorize_service.*` — 抠图与矢量化任务
+    - `recipe_editor_service.*` — 配方编辑器（摘要/候选/替换/生成/预测）
+    - `calibration_service.*` — 校准板生成/定位/ColorDB 构建
+  - 共享内核：
+    - `request_parsing.*` — 请求解析与校验工具
+    - `json_serialization.*` — JSON 序列化辅助函数
+    - `colordb_resolution.*` — ColorDB 解析与通道键归一化
 - 表现层：`web/backend/src/presentation/`
   - 路由与请求处理：`api_v1_controller.*`
   - 运行时注册：`backend_runtime.*`
@@ -26,7 +38,7 @@
 | 目标 | 入口文件 |
 |---|---|
 | 新增 API 路由 | `src/presentation/api_v1_controller.h/.cpp` |
-| 新增业务能力 | `src/application/server_facade.h/.cpp` |
+| 新增业务能力 | 对应领域的 `src/application/*_service.{h,cpp}`（非 `server_facade`） |
 | 新增服务启动参数 | `src/config/server_config.h/.cpp` + `server_main.cpp` |
 | 调整任务并发/TTL/内存预算 | `src/infrastructure/task_runtime.h/.cpp` |
 | 调整会话策略与 token 行为 | `src/infrastructure/session_store.h/.cpp` |
@@ -34,15 +46,16 @@
 
 ## API 修改建议流程
 
-1. 在 `ServerFacade` 定义并实现服务方法。
-2. 在 `ApiV1Controller` 声明路由与处理函数。
+1. 在对应领域的 `*_service.{h,cpp}` 中定义并实现服务方法。
+2. 在 `ServerFacade` 中添加委托方法（如需保持 Controller 不直接依赖子服务）。
+3. 在 `ApiV1Controller` 声明路由与处理函数。
 3. 复用统一 envelope：`{ok,data}` / `{ok,error}`。
 4. 若涉及会话，确认 cookie/header/query 的 token 识别链路不被破坏。
 5. 同步更新 [README.md](../../../../README.md) 与 [docs/development.md](../../../development.md) 的接口说明。
 
 ## Bambu Studio 预设参数
 
-校准板生成端点（`POST /api/v1/calibration/boards`、`POST /api/v1/calibration/boards/8color`）、定位端点（`POST /api/v1/calibration/locate`）和图像转换端点（`POST /api/v1/convert/raster`、`POST /api/v1/convert/vector`）支持 `nozzle_size` 与 `face_orientation` 参数；转换端点另外支持 `base_layers` 与 `double_sided`。后端在 `server_facade.cpp` 解析后传递给核心库：`face_orientation=facedown` 会触发导出几何绕 Y 轴旋转 180°，`base_layers` 可覆盖底板层数，`double_sided=true` 会启用双面镜像色层，并在预设选择阶段强制使用 `facedown` 预设文件。`flip_y` 仍保持图像/坐标系适配语义，不等价于 `face_orientation`。
+校准板生成端点（`POST /api/v1/calibration/boards`、`POST /api/v1/calibration/boards/8color`）、定位端点（`POST /api/v1/calibration/locate`）和图像转换端点（`POST /api/v1/convert/raster`、`POST /api/v1/convert/vector`）支持 `nozzle_size` 与 `face_orientation` 参数；转换端点另外支持 `base_layers` 与 `double_sided`。后端在 `convert_service.cpp` / `calibration_service.cpp` 解析后传递给核心库：`face_orientation=facedown` 会触发导出几何绕 Y 轴旋转 180°，`base_layers` 可覆盖底板层数，`double_sided=true` 会启用双面镜像色层，并在预设选择阶段强制使用 `facedown` 预设文件。`flip_y` 仍保持图像/坐标系适配语义，不等价于 `face_orientation`。
 
 ## 模型包元数据
 
@@ -62,7 +75,7 @@
 
 约束：仅支持 `dither=None` 的 Raster 流水线，唯一配方数 ≤128。
 
-核心实现：`task_runtime.h/.cpp`（`SubmitConvertRasterMatchOnly`、`GetRecipeEditorSummary`、`QueryRecipeAlternatives`、`ReplaceRecipe`、`SubmitGenerateModel`、`GetTaskPrintProfile`、`GetTaskColorDbNames`）、`server_facade.cpp`（`RecipeEditorSummary`、`RecipeEditorAlternatives`、`RecipeEditorReplace`、`RecipeEditorGenerate`、`RecipeEditorPredict`）。
+核心实现：`task_runtime.h/.cpp`（`SubmitConvertRasterMatchOnly`、`GetRecipeEditorSummary`、`QueryRecipeAlternatives`、`ReplaceRecipe`、`SubmitGenerateModel`、`GetTaskPrintProfile`、`GetTaskColorDbNames`）、`recipe_editor_service.cpp`（`RecipeEditorSummary`、`RecipeEditorAlternatives`、`RecipeEditorReplace`、`RecipeEditorGenerate`、`RecipeEditorPredict`）。
 
 ## 前向色彩模型
 

--- a/web/backend/CMakeLists.txt
+++ b/web/backend/CMakeLists.txt
@@ -54,6 +54,15 @@ set(CHROMAPRINT3D_BACKEND_LIBRARY_SOURCES
     src/infrastructure/spillable_artifact.cpp
     src/infrastructure/data_repository.cpp
     src/infrastructure/board_runtime_cache.cpp
+    src/application/request_parsing.cpp
+    src/application/json_serialization.cpp
+    src/application/colordb_resolution.cpp
+    src/application/color_db_service.cpp
+    src/application/task_service.cpp
+    src/application/calibration_service.cpp
+    src/application/convert_service.cpp
+    src/application/matting_vectorize_service.cpp
+    src/application/recipe_editor_service.cpp
     src/application/server_facade.cpp
     src/presentation/backend_runtime.cpp
     src/presentation/cors_advice.cpp

--- a/web/backend/src/application/calibration_service.cpp
+++ b/web/backend/src/application/calibration_service.cpp
@@ -12,6 +12,7 @@
 #include <spdlog/spdlog.h>
 
 #include <filesystem>
+#include <system_error>
 
 namespace chromaprint3d::backend {
 

--- a/web/backend/src/application/calibration_service.cpp
+++ b/web/backend/src/application/calibration_service.cpp
@@ -1,0 +1,356 @@
+#include "application/calibration_service.h"
+
+#include "application/json_serialization.h"
+#include "application/request_parsing.h"
+
+#include "infrastructure/task_runtime.h"
+
+#include "chromaprint3d/calib.h"
+#include "chromaprint3d/print_profile.h"
+#include "chromaprint3d/slicer_preset.h"
+
+#include <spdlog/spdlog.h>
+
+#include <filesystem>
+
+namespace chromaprint3d::backend {
+
+using json = nlohmann::json;
+using namespace ChromaPrint3D;
+
+CalibrationService::CalibrationService(const ServerConfig& cfg, DataRepository& data,
+                                       SessionStore& sessions, BoardRuntimeCache& boards)
+    : cfg_(cfg), data_(data), sessions_(sessions), boards_(boards) {}
+
+ServiceResult CalibrationService::GenerateBoard(const json& body) {
+    if (!body.contains("palette") || !body["palette"].is_array()) {
+        return ServiceResult::Error(400, "invalid_request", "Missing or invalid 'palette' array");
+    }
+    CalibrationBoardConfig cfg;
+    auto& palette_arr       = body["palette"];
+    cfg.recipe.num_channels = static_cast<int>(palette_arr.size());
+    if (cfg.recipe.num_channels < CalibrationRecipeSpec::kMinChannels ||
+        cfg.recipe.num_channels > CalibrationRecipeSpec::kMaxChannels) {
+        return ServiceResult::Error(400, "invalid_request", "palette size must be 2-8");
+    }
+    cfg.palette.resize(palette_arr.size());
+    for (size_t i = 0; i < palette_arr.size(); ++i) {
+        const auto& ch          = palette_arr[i];
+        cfg.palette[i].color    = ch.value("color", "");
+        cfg.palette[i].material = ch.value("material", "PLA Basic");
+    }
+    if (body.contains("color_layers")) cfg.recipe.color_layers = body["color_layers"].get<int>();
+    if (body.contains("layer_height_mm")) {
+        cfg.layer_height_mm = body["layer_height_mm"].get<float>();
+    }
+
+    std::string raw_nozzle = body.value("nozzle_size", "n04");
+    std::string raw_face   = body.value("face_orientation", "faceup");
+    NozzleSize nozzle      = ParseNozzleSize(raw_nozzle);
+    FaceOrientation face   = ParseFaceOrientation(raw_face);
+    spdlog::info("GenerateBoard: nozzle_size='{}' -> {}, face_orientation='{}' -> {}", raw_nozzle,
+                 NozzleSizeTag(nozzle), raw_face, FaceOrientationTag(face));
+
+    auto presets_path = std::filesystem::path(cfg_.data_dir) / "presets";
+    bool has_preset   = std::filesystem::is_directory(presets_path);
+
+    try {
+        const int num_ch   = cfg.recipe.num_channels;
+        const int c_layers = cfg.recipe.color_layers;
+
+        CalibrationBoardResult result;
+        auto cached = boards_.FindGeometry(num_ch, c_layers);
+
+        if (has_preset) {
+            FilamentConfig fil_config = FilamentConfig::LoadFromDir(presets_path.string());
+            PrintProfile profile;
+            profile.layer_height_mm  = cfg.layer_height_mm;
+            profile.palette          = cfg.palette;
+            profile.nozzle_size      = nozzle;
+            profile.face_orientation = face;
+            for (size_t i = 0; i < profile.palette.size(); ++i) {
+                auto& ch = profile.palette[i];
+                if (ch.hex_color.empty()) {
+                    ch.hex_color = fil_config.ResolveHexColor(ch.color, static_cast<int>(i));
+                }
+            }
+            cfg.palette = profile.palette;
+            auto preset = SlicerPreset::FromProfile(presets_path.string(), profile, &fil_config);
+
+            if (cached) {
+                result = BuildResultFromMeshes(*cached, cfg.palette, preset, face);
+            } else {
+                auto meshes = GenCalibrationBoardMeshes(cfg);
+                result      = BuildResultFromMeshes(meshes, cfg.palette, preset, face);
+                boards_.StoreGeometry(num_ch, c_layers, std::move(meshes));
+            }
+        } else {
+            if (cached) {
+                result = BuildResultFromMeshes(*cached, cfg.palette, face);
+            } else {
+                auto meshes = GenCalibrationBoardMeshes(cfg);
+                result      = BuildResultFromMeshes(meshes, cfg.palette, face);
+                boards_.StoreGeometry(num_ch, c_layers, std::move(meshes));
+            }
+        }
+
+        std::string meta_str = result.meta.ToJsonString();
+        std::string board_id = boards_.StoreBoard(std::move(result));
+        return ServiceResult::Success(200,
+                                      {{"board_id", board_id}, {"meta", json::parse(meta_str)}});
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(500, "generate_failed", e.what());
+    }
+}
+
+ServiceResult CalibrationService::Generate8ColorBoard(const json& body) {
+    if (!data_.RecipeStore().loaded) {
+        return ServiceResult::Error(503, "service_unavailable",
+                                    "8-color recipe data not available on server");
+    }
+    if (!body.contains("palette") || !body["palette"].is_array()) {
+        return ServiceResult::Error(400, "invalid_request", "Missing or invalid 'palette' array");
+    }
+    if (!body.contains("board_index") || !body["board_index"].is_number_integer()) {
+        return ServiceResult::Error(400, "invalid_request", "Missing or invalid 'board_index'");
+    }
+
+    auto& palette_arr = body["palette"];
+    const int num_ch  = static_cast<int>(palette_arr.size());
+    if (num_ch != data_.RecipeStore().num_channels) {
+        return ServiceResult::Error(400, "invalid_request",
+                                    "palette size must be " +
+                                        std::to_string(data_.RecipeStore().num_channels));
+    }
+
+    const int board_index = body["board_index"].get<int>();
+    const auto* board_set = data_.RecipeStore().FindBoard(board_index);
+    if (!board_set) {
+        return ServiceResult::Error(400, "invalid_request",
+                                    "Invalid board_index: " + std::to_string(board_index));
+    }
+
+    CalibrationBoardConfig cfg;
+    cfg.recipe.num_channels     = num_ch;
+    cfg.recipe.color_layers     = data_.RecipeStore().color_layers;
+    cfg.recipe.layer_order      = (data_.RecipeStore().layer_order == "Bottom2Top")
+                                      ? LayerOrder::Bottom2Top
+                                      : LayerOrder::Top2Bottom;
+    cfg.base_layers             = data_.RecipeStore().base_layers;
+    cfg.base_channel_idx        = data_.RecipeStore().base_channel_idx;
+    cfg.layer_height_mm         = data_.RecipeStore().layer_height_mm;
+    cfg.layout.line_width_mm    = data_.RecipeStore().layout.line_width_mm;
+    cfg.layout.resolution_scale = data_.RecipeStore().layout.resolution_scale;
+    cfg.layout.tile_factor      = data_.RecipeStore().layout.tile_factor;
+    cfg.layout.gap_factor       = data_.RecipeStore().layout.gap_factor;
+    cfg.layout.margin_factor    = data_.RecipeStore().layout.margin_factor;
+    cfg.palette.resize(palette_arr.size());
+    for (size_t i = 0; i < palette_arr.size(); ++i) {
+        const auto& ch          = palette_arr[i];
+        cfg.palette[i].color    = ch.value("color", "");
+        cfg.palette[i].material = ch.value("material", "PLA Basic");
+    }
+
+    std::string raw_nozzle = body.value("nozzle_size", "n04");
+    std::string raw_face   = body.value("face_orientation", "faceup");
+    NozzleSize nozzle      = ParseNozzleSize(raw_nozzle);
+    FaceOrientation face   = ParseFaceOrientation(raw_face);
+    spdlog::info("Generate8ColorBoard: nozzle_size='{}' -> {}, face_orientation='{}' -> {}",
+                 raw_nozzle, NozzleSizeTag(nozzle), raw_face, FaceOrientationTag(face));
+
+    auto presets_path = std::filesystem::path(cfg_.data_dir) / "presets";
+    bool has_preset   = std::filesystem::is_directory(presets_path);
+
+    try {
+        CalibrationBoardResult result;
+        auto cached = boards_.FindGeometry(num_ch, cfg.recipe.color_layers, board_index);
+
+        auto build_with_preset = [&](const CalibrationBoardMeshes& meshes_ref) {
+            if (has_preset) {
+                FilamentConfig fil_config = FilamentConfig::LoadFromDir(presets_path.string());
+                PrintProfile profile;
+                profile.layer_height_mm  = cfg.layer_height_mm;
+                profile.palette          = cfg.palette;
+                profile.nozzle_size      = nozzle;
+                profile.face_orientation = face;
+                for (size_t i = 0; i < profile.palette.size(); ++i) {
+                    auto& ch = profile.palette[i];
+                    if (ch.hex_color.empty()) {
+                        ch.hex_color = fil_config.ResolveHexColor(ch.color, static_cast<int>(i));
+                    }
+                }
+                cfg.palette = profile.palette;
+                auto preset =
+                    SlicerPreset::FromProfile(presets_path.string(), profile, &fil_config);
+                return BuildResultFromMeshes(meshes_ref, cfg.palette, preset, face);
+            }
+            return BuildResultFromMeshes(meshes_ref, cfg.palette, face);
+        };
+
+        if (cached) {
+            result = build_with_preset(*cached);
+        } else {
+            auto meta = BuildCalibrationBoardMetaCustom(cfg, board_set->grid_rows,
+                                                        board_set->grid_cols, board_set->recipes);
+            meta.name += "_board" + std::to_string(board_index);
+            auto meshes = GenCalibrationBoardMeshesFromMeta(std::move(meta));
+            result      = build_with_preset(meshes);
+            boards_.StoreGeometry(num_ch, cfg.recipe.color_layers, std::move(meshes), board_index);
+        }
+
+        std::string meta_str = result.meta.ToJsonString();
+        std::string board_id = boards_.StoreBoard(std::move(result));
+        return ServiceResult::Success(200,
+                                      {{"board_id", board_id}, {"meta", json::parse(meta_str)}});
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(500, "generate_failed", e.what());
+    }
+}
+
+ServiceResult CalibrationService::DownloadBoardModel(const std::string& board_id,
+                                                     TaskArtifact& out) {
+    auto board = boards_.FindBoard(board_id);
+    if (!board) return ServiceResult::Error(404, "not_found", "Board not found or expired");
+    std::string filename = board->meta.name.empty() ? "calibration_board" : board->meta.name;
+    filename += ".3mf";
+
+    constexpr const char* kModelContentType =
+        "application/vnd.ms-package.3dmanufacturing-3dmodel+xml";
+    if (board->has_file_backed_model()) {
+        const auto& fpath = board->model_3mf_path;
+        std::error_code ec;
+        bool exists      = std::filesystem::exists(fpath, ec);
+        auto actual_size = exists ? std::filesystem::file_size(fpath, ec) : 0ULL;
+        spdlog::debug("DownloadBoardModel: board={}, path={}, exists={}, actual_size={}, "
+                      "expected_size={}",
+                      board_id, fpath.string(), exists, actual_size, board->expected_file_size);
+        if (!exists) {
+            spdlog::error("DownloadBoardModel: file missing for board {}: {}", board_id,
+                          fpath.string());
+            return ServiceResult::Error(404, "not_found", "Board model file missing from disk");
+        }
+        if (board->expected_file_size > 0 && actual_size != board->expected_file_size) {
+            spdlog::error("DownloadBoardModel: file size mismatch for board {}: expected={}, "
+                          "actual={}",
+                          board_id, board->expected_file_size, actual_size);
+            return ServiceResult::Error(500, "corrupt_file",
+                                        "Board model file is incomplete or corrupt");
+        }
+        out = TaskArtifact{{}, fpath, kModelContentType, std::move(filename)};
+        return ServiceResult::Success(200, json::object());
+    }
+    if (board->model_3mf.empty()) {
+        return ServiceResult::Error(404, "not_found", "Board model not available");
+    }
+    out = TaskArtifact{std::move(board->model_3mf), {}, kModelContentType, std::move(filename)};
+    return ServiceResult::Success(200, json::object());
+}
+
+ServiceResult CalibrationService::DownloadBoardMeta(const std::string& board_id,
+                                                    TaskArtifact& out) {
+    auto board = boards_.FindBoard(board_id);
+    if (!board) return ServiceResult::Error(404, "not_found", "Board not found or expired");
+    std::string filename =
+        board->meta.name.empty() ? "calibration_board_meta" : board->meta.name + "_meta";
+    filename += ".json";
+    auto meta_json = board->meta.ToJsonString();
+    std::vector<uint8_t> bytes(meta_json.begin(), meta_json.end());
+    TaskArtifact artifact;
+    artifact.bytes        = std::move(bytes);
+    artifact.content_type = "application/json";
+    artifact.filename     = std::move(filename);
+    out                   = std::move(artifact);
+    return ServiceResult::Success(200, json::object());
+}
+
+ServiceResult CalibrationService::LocateBoard(const std::vector<uint8_t>& image,
+                                              const std::string& meta_json) {
+    auto valid = ValidateDecodedImage(image, cfg_.max_pixels_per_image);
+    if (!valid.ok) return valid;
+
+    CalibrationBoardMeta meta;
+    try {
+        meta = CalibrationBoardMeta::FromJsonString(meta_json);
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(400, "invalid_meta",
+                                    "Invalid meta JSON: " + std::string(e.what()));
+    }
+
+    try {
+        auto result      = LocateCalibrationBoard(image, meta);
+        json corners_arr = json::array();
+        for (const auto& c : result.corners) { corners_arr.push_back(json::array({c[0], c[1]})); }
+        json out            = json::object();
+        out["corners"]      = std::move(corners_arr);
+        out["image_width"]  = result.image_width;
+        out["image_height"] = result.image_height;
+        return ServiceResult::Success(200, std::move(out));
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(422, "locate_failed", e.what());
+    }
+}
+
+ServiceResult CalibrationService::BuildColorDb(const std::string& owner,
+                                               const std::vector<uint8_t>& image,
+                                               const std::string& meta_json,
+                                               const std::string& db_name,
+                                               const std::string& corners_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto valid = ValidateDecodedImage(image, cfg_.max_pixels_per_image);
+    if (!valid.ok) return valid;
+    if (!SessionStore::IsValidDbName(db_name)) {
+        return ServiceResult::Error(400, "invalid_name",
+                                    "Invalid ColorDB name ([a-zA-Z0-9_], length 1-64)");
+    }
+    if (data_.ColorDbCache().FindByName(db_name)) {
+        return ServiceResult::Error(409, "name_conflict", "Name conflicts with global database");
+    }
+
+    CalibrationBoardMeta meta;
+    try {
+        meta = CalibrationBoardMeta::FromJsonString(meta_json);
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(400, "invalid_meta",
+                                    "Invalid meta JSON: " + std::string(e.what()));
+    }
+
+    std::optional<std::array<std::array<float, 2>, 4>> corners_opt;
+    if (!corners_json.empty()) {
+        try {
+            auto j = json::parse(corners_json);
+            if (!j.is_array() || j.size() != 4) {
+                return ServiceResult::Error(400, "invalid_corners",
+                                            "corners must be an array of 4 [x,y] pairs");
+            }
+            std::array<std::array<float, 2>, 4> pts;
+            for (size_t i = 0; i < 4; ++i) {
+                if (!j[i].is_array() || j[i].size() != 2) {
+                    return ServiceResult::Error(400, "invalid_corners",
+                                                "Each corner must be [x, y]");
+                }
+                pts[i] = {j[i][0].get<float>(), j[i][1].get<float>()};
+            }
+            corners_opt = pts;
+        } catch (const json::exception& e) {
+            return ServiceResult::Error(400, "invalid_corners",
+                                        "Failed to parse corners: " + std::string(e.what()));
+        }
+    }
+
+    try {
+        ColorDB db = corners_opt ? GenColorDBFromBuffer(image, meta, *corners_opt)
+                                 : GenColorDBFromBuffer(image, meta);
+        db.name    = db_name;
+        std::string err;
+        if (!sessions_.PutSessionDb(owner, db, &err)) {
+            return ServiceResult::Error(429, "session_limit", err);
+        }
+        auto out      = ColorDbBuildResultToJson(db);
+        out["source"] = "session";
+        return ServiceResult::Success(200, std::move(out));
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(500, "build_failed", e.what());
+    }
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/calibration_service.h
+++ b/web/backend/src/application/calibration_service.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "application/service_result.h"
+#include "config/server_config.h"
+#include "infrastructure/board_runtime_cache.h"
+#include "infrastructure/data_repository.h"
+#include "infrastructure/session_store.h"
+#include "infrastructure/task_runtime.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <vector>
+
+namespace chromaprint3d::backend {
+
+class CalibrationService {
+public:
+    CalibrationService(const ServerConfig& cfg, DataRepository& data, SessionStore& sessions,
+                       BoardRuntimeCache& boards);
+
+    ServiceResult GenerateBoard(const nlohmann::json& body);
+    ServiceResult Generate8ColorBoard(const nlohmann::json& body);
+    ServiceResult DownloadBoardModel(const std::string& board_id, TaskArtifact& out);
+    ServiceResult DownloadBoardMeta(const std::string& board_id, TaskArtifact& out);
+    ServiceResult LocateBoard(const std::vector<uint8_t>& image, const std::string& meta_json);
+    ServiceResult BuildColorDb(const std::string& owner, const std::vector<uint8_t>& image,
+                               const std::string& meta_json, const std::string& db_name,
+                               const std::string& corners_json = "");
+
+private:
+    const ServerConfig& cfg_;
+    DataRepository& data_;
+    SessionStore& sessions_;
+    BoardRuntimeCache& boards_;
+};
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/color_db_service.cpp
+++ b/web/backend/src/application/color_db_service.cpp
@@ -1,0 +1,95 @@
+#include "application/color_db_service.h"
+
+#include "application/json_serialization.h"
+
+#include "chromaprint3d/color_db.h"
+
+#include <nlohmann/json.hpp>
+
+namespace chromaprint3d::backend {
+
+using json = nlohmann::json;
+
+ColorDbService::ColorDbService(DataRepository& data, SessionStore& sessions)
+    : data_(data), sessions_(sessions) {}
+
+ServiceResult ColorDbService::ListDatabases(const std::optional<std::string>& session_token) {
+    json arr = json::array();
+    for (const auto& entry : data_.ColorDbCache().databases) {
+        auto j      = ColorDbInfoToJson(entry.db, entry.material_type, entry.vendor);
+        j["source"] = "global";
+        arr.push_back(std::move(j));
+    }
+    if (session_token && !session_token->empty()) {
+        auto dbs = sessions_.ListSessionDbs(*session_token);
+        for (const auto& db : dbs) {
+            auto j      = ColorDbInfoToJson(db);
+            j["source"] = "session";
+            arr.push_back(std::move(j));
+        }
+    }
+    return ServiceResult::Success(200, {{"databases", std::move(arr)}});
+}
+
+ServiceResult ColorDbService::ListSessionDatabases(const std::string& token) {
+    if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    json arr = json::array();
+    for (const auto& db : sessions_.ListSessionDbs(token)) {
+        auto j      = ColorDbInfoToJson(db);
+        j["source"] = "session";
+        arr.push_back(std::move(j));
+    }
+    return ServiceResult::Success(200, {{"databases", std::move(arr)}});
+}
+
+ServiceResult
+ColorDbService::UploadSessionDatabase(const std::string& token, const std::string& json_content,
+                                      const std::optional<std::string>& override_name) {
+    if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+
+    ChromaPrint3D::ColorDB db;
+    try {
+        db = ChromaPrint3D::ColorDB::FromJsonString(json_content);
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(400, "invalid_colordb",
+                                    "Invalid ColorDB JSON: " + std::string(e.what()));
+    }
+    if (override_name && !override_name->empty()) db.name = *override_name;
+    if (!SessionStore::IsValidDbName(db.name)) {
+        return ServiceResult::Error(400, "invalid_name",
+                                    "ColorDB name must be [a-zA-Z0-9_], length 1-64");
+    }
+    if (data_.ColorDbCache().FindByName(db.name)) {
+        return ServiceResult::Error(409, "name_conflict", "Name conflicts with global database");
+    }
+    std::string err;
+    if (!sessions_.PutSessionDb(token, db, &err)) {
+        return ServiceResult::Error(429, "session_limit", err);
+    }
+    auto out      = ColorDbInfoToJson(db);
+    out["source"] = "session";
+    return ServiceResult::Success(200, std::move(out));
+}
+
+ServiceResult ColorDbService::DeleteSessionDatabase(const std::string& token,
+                                                    const std::string& name) {
+    if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto existing = sessions_.GetSessionDb(token, name);
+    if (!existing) return ServiceResult::Error(404, "not_found", "ColorDB not found in session");
+    sessions_.RemoveSessionDb(token, name);
+    return ServiceResult::Success(200, {{"deleted", true}});
+}
+
+ServiceResult ColorDbService::DownloadSessionDatabase(const std::string& token,
+                                                      const std::string& name,
+                                                      std::string& json_out,
+                                                      std::string& filename_out) {
+    if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto existing = sessions_.GetSessionDb(token, name);
+    if (!existing) return ServiceResult::Error(404, "not_found", "ColorDB not found in session");
+    json_out     = existing->ToJsonString();
+    filename_out = name + ".json";
+    return ServiceResult::Success(200, json::object());
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/color_db_service.h
+++ b/web/backend/src/application/color_db_service.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "application/service_result.h"
+#include "infrastructure/data_repository.h"
+#include "infrastructure/session_store.h"
+
+#include <optional>
+#include <string>
+
+namespace chromaprint3d::backend {
+
+class ColorDbService {
+public:
+    explicit ColorDbService(DataRepository& data, SessionStore& sessions);
+
+    ServiceResult ListDatabases(const std::optional<std::string>& session_token);
+    ServiceResult ListSessionDatabases(const std::string& token);
+    ServiceResult UploadSessionDatabase(const std::string& token, const std::string& json_content,
+                                        const std::optional<std::string>& override_name);
+    ServiceResult DeleteSessionDatabase(const std::string& token, const std::string& name);
+    ServiceResult DownloadSessionDatabase(const std::string& token, const std::string& name,
+                                          std::string& json_out, std::string& filename_out);
+
+private:
+    DataRepository& data_;
+    SessionStore& sessions_;
+};
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/colordb_resolution.cpp
+++ b/web/backend/src/application/colordb_resolution.cpp
@@ -1,0 +1,136 @@
+#include "application/colordb_resolution.h"
+
+#include <cctype>
+#include <unordered_set>
+
+namespace chromaprint3d::backend {
+
+using json = nlohmann::json;
+using namespace ChromaPrint3D;
+
+namespace {
+
+std::string NormalizeLabel(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (unsigned char c : s) {
+        if (std::isalnum(c)) { out.push_back(static_cast<char>(std::tolower(c))); }
+    }
+    return out;
+}
+
+} // namespace
+
+std::string NormalizeChannelKey(const Channel& ch) {
+    return NormalizeLabel(ch.color) + "|" + NormalizeLabel(ch.material);
+}
+
+std::vector<std::string> BuildProfileChannelKeys(const std::vector<const ColorDB*>& dbs) {
+    std::unordered_set<std::string> keys;
+    for (const auto* db : dbs) {
+        for (const auto& ch : db->palette) { keys.insert(NormalizeChannelKey(ch)); }
+    }
+    return {keys.begin(), keys.end()};
+}
+
+ServiceResult ResolveSelectedColorDbs(const json& params,
+                                      const std::optional<SessionSnapshot>& session,
+                                      const DataRepository& data,
+                                      std::vector<const ColorDB*>& out_dbs,
+                                      std::vector<std::shared_ptr<const ColorDB>>& session_owned,
+                                      std::string& common_vendor, std::string& common_material) {
+    out_dbs.clear();
+    common_vendor.clear();
+    common_material.clear();
+
+    struct DbWithMeta {
+        const ColorDB* db;
+        std::string vendor;
+        std::string material_type;
+    };
+
+    std::vector<DbWithMeta> selected;
+
+    if (params.contains("db_names") && params["db_names"].is_array()) {
+        selected.reserve(params["db_names"].size());
+        for (const auto& name_val : params["db_names"]) {
+            if (!name_val.is_string()) {
+                return ServiceResult::Error(400, "invalid_params",
+                                            "db_names must be an array of strings");
+            }
+            const std::string name = name_val.get<std::string>();
+            const ColorDB* db      = nullptr;
+            std::string vendor, material;
+            if (const auto* entry = data.ColorDbCache().FindEntryByName(name)) {
+                db       = &entry->db;
+                vendor   = entry->vendor;
+                material = entry->material_type;
+            }
+            if (!db && session) {
+                auto it = session->color_dbs.find(name);
+                if (it != session->color_dbs.end()) {
+                    auto copy = std::make_shared<const ColorDB>(it->second);
+                    session_owned.push_back(copy);
+                    db = copy.get();
+                }
+            }
+            if (!db) {
+                return ServiceResult::Error(400, "invalid_params", "ColorDB not found: " + name);
+            }
+            selected.push_back({db, vendor, material});
+        }
+        if (selected.empty()) {
+            return ServiceResult::Error(400, "invalid_params", "No valid ColorDB names provided");
+        }
+    } else {
+        selected.reserve(data.ColorDbCache().databases.size());
+        for (const auto& entry : data.ColorDbCache().databases) {
+            selected.push_back({&entry.db, entry.vendor, entry.material_type});
+        }
+    }
+
+    out_dbs.reserve(selected.size());
+    for (const auto& s : selected) { out_dbs.push_back(s.db); }
+
+    if (!selected.empty()) {
+        const auto& first_v = selected.front().vendor;
+        const auto& first_m = selected.front().material_type;
+        bool all_same       = !first_v.empty() && !first_m.empty();
+        for (size_t i = 1; i < selected.size() && all_same; ++i) {
+            if (selected[i].vendor != first_v || selected[i].material_type != first_m) {
+                all_same = false;
+            }
+        }
+        if (all_same) {
+            common_vendor   = first_v;
+            common_material = first_m;
+        }
+    }
+
+    return ServiceResult::Success(200, json::object());
+}
+
+void ResolveTaskVendorMaterial(const std::vector<std::string>& db_names, const DataRepository& data,
+                               std::string& common_vendor, std::string& common_material) {
+    common_vendor.clear();
+    common_material.clear();
+
+    bool all_same = true;
+    for (const auto& name : db_names) {
+        const auto* entry = data.ColorDbCache().FindEntryByName(name);
+        if (!entry) continue;
+        if (common_vendor.empty()) {
+            common_vendor   = entry->vendor;
+            common_material = entry->material_type;
+        } else if (entry->vendor != common_vendor || entry->material_type != common_material) {
+            all_same = false;
+            break;
+        }
+    }
+    if (!all_same) {
+        common_vendor.clear();
+        common_material.clear();
+    }
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/colordb_resolution.h
+++ b/web/backend/src/application/colordb_resolution.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "application/service_result.h"
+#include "infrastructure/data_repository.h"
+#include "infrastructure/session_store.h"
+
+#include "chromaprint3d/color_db.h"
+
+#include <nlohmann/json.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace chromaprint3d::backend {
+
+std::string NormalizeChannelKey(const ChromaPrint3D::Channel& ch);
+std::vector<std::string>
+BuildProfileChannelKeys(const std::vector<const ChromaPrint3D::ColorDB*>& dbs);
+
+ServiceResult
+ResolveSelectedColorDbs(const nlohmann::json& params, const std::optional<SessionSnapshot>& session,
+                        const DataRepository& data,
+                        std::vector<const ChromaPrint3D::ColorDB*>& out_dbs,
+                        std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>>& session_owned,
+                        std::string& common_vendor, std::string& common_material);
+
+void ResolveTaskVendorMaterial(const std::vector<std::string>& db_names, const DataRepository& data,
+                               std::string& common_vendor, std::string& common_material);
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/convert_service.cpp
+++ b/web/backend/src/application/convert_service.cpp
@@ -1,0 +1,462 @@
+#include "application/convert_service.h"
+
+#include "chromaprint3d/pipeline.h"
+#include "chromaprint3d/shape_width_analyzer.h"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <stdexcept>
+
+namespace chromaprint3d::backend {
+
+using json = nlohmann::json;
+using namespace ChromaPrint3D;
+
+ConvertService::ConvertService(const ServerConfig& cfg, DataRepository& data,
+                               SessionStore& sessions, TaskRuntime& tasks)
+    : cfg_(cfg), data_(data), sessions_(sessions), tasks_(tasks) {}
+
+ServiceResult ConvertService::SubmitConvertRaster(const std::string& owner,
+                                                  const std::vector<uint8_t>& image,
+                                                  const std::string& image_name,
+                                                  const std::optional<std::string>& params_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto accept = tasks_.CanAccept(owner);
+    if (!accept.ok) {
+        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
+    }
+    auto valid = ValidateDecodedImage(image, cfg_.max_pixels_per_image);
+    if (!valid.ok) return valid;
+
+    json params;
+    auto parsed = ParseJsonObject(params_json, params);
+    if (!parsed.ok) return parsed;
+
+    auto session = sessions_.Snapshot(owner);
+
+    ConvertRasterRequest req;
+    auto built = BuildRasterRequest(params, image, image_name, session, req);
+    if (!built.ok) return built;
+
+    auto submit = tasks_.SubmitConvertRaster(owner, std::move(req), StripExtension(image_name));
+    if (!submit.ok) {
+        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
+    }
+    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "convert"}});
+}
+
+ServiceResult ConvertService::SubmitConvertVector(const std::string& owner,
+                                                  const std::vector<uint8_t>& svg,
+                                                  const std::string& svg_name,
+                                                  const std::optional<std::string>& params_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto accept = tasks_.CanAccept(owner);
+    if (!accept.ok) {
+        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
+    }
+
+    json params;
+    auto parsed = ParseJsonObject(params_json, params);
+    if (!parsed.ok) return parsed;
+    auto session = sessions_.Snapshot(owner);
+
+    ConvertVectorRequest req;
+    auto built = BuildVectorRequest(params, svg, svg_name, session, req);
+    if (!built.ok) return built;
+
+    auto submit = tasks_.SubmitConvertVector(owner, std::move(req), StripExtension(svg_name));
+    if (!submit.ok) {
+        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
+    }
+    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "convert"}});
+}
+
+ServiceResult ConvertService::AnalyzeVectorWidth(const std::vector<uint8_t>& svg,
+                                                 const std::optional<std::string>& params_json) {
+    if (svg.empty()) { return ServiceResult::Error(400, "invalid_request", "SVG buffer is empty"); }
+
+    json params;
+    auto parsed = ParseJsonObject(params_json, params);
+    if (!parsed.ok) return parsed;
+
+    float min_area       = params.value("min_area_mm2", 1.0f);
+    float min_area_ratio = params.value("min_area_ratio", 0.001f);
+    float raster_res     = params.value("raster_px_per_mm", 10.0f);
+
+    VectorProcConfig vpc;
+    vpc.flip_y = params.value("flip_y", false);
+
+    try {
+        VectorProc vproc(vpc);
+        auto vpr = vproc.RunFromBuffer(svg, "analyze");
+
+        float total_area         = vpr.width_mm * vpr.height_mm;
+        float effective_min_area = std::max(min_area, min_area_ratio * total_area);
+        auto analysis            = AnalyzeShapeWidths(vpr, effective_min_area, raster_res);
+
+        json shapes_json = json::array();
+        for (const auto& s : analysis.shapes) {
+            uint8_t r8, g8, b8;
+            s.color.ToRgb255(r8, g8, b8);
+            char hex[8];
+            std::snprintf(hex, sizeof(hex), "#%02X%02X%02X", r8, g8, b8);
+
+            shapes_json.push_back({
+                {"index", s.index},
+                {"color", std::string(hex)},
+                {"area_mm2", std::round(s.area_mm2 * 100.0f) / 100.0f},
+                {"min_width_mm", std::round(s.min_width_mm * 1000.0f) / 1000.0f},
+                {"median_width_mm", std::round(s.median_width_mm * 1000.0f) / 1000.0f},
+            });
+        }
+
+        return ServiceResult::Success(
+            200, {
+                     {"image_width_mm", analysis.image_width_mm},
+                     {"image_height_mm", analysis.image_height_mm},
+                     {"total_shapes", analysis.total_shapes},
+                     {"filtered_count", analysis.filtered_count},
+                     {"min_area_threshold_mm2", analysis.min_area_threshold_mm2},
+                     {"shapes", shapes_json},
+                 });
+    } catch (const std::exception& e) {
+        spdlog::error("AnalyzeVectorWidth failed: {}", e.what());
+        return ServiceResult::Error(500, "analysis_failed", e.what());
+    }
+}
+
+ServiceResult ConvertService::SubmitConvertRasterMatchOnly(
+    const std::string& owner, const std::vector<uint8_t>& image, const std::string& image_name,
+    const std::optional<std::string>& params_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto accept = tasks_.CanAccept(owner);
+    if (!accept.ok) {
+        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
+    }
+    auto valid = ValidateDecodedImage(image, cfg_.max_pixels_per_image);
+    if (!valid.ok) return valid;
+
+    json params;
+    auto parsed = ParseJsonObject(params_json, params);
+    if (!parsed.ok) return parsed;
+
+    auto session = sessions_.Snapshot(owner);
+
+    ConvertRasterRequest req;
+    auto built = BuildRasterRequest(params, image, image_name, session, req);
+    if (!built.ok) return built;
+
+    if (req.dither != ChromaPrint3D::DitherMethod::None) {
+        return ServiceResult::Error(400, "invalid_request", "Recipe editing requires dither=None");
+    }
+
+    auto submit =
+        tasks_.SubmitConvertRasterMatchOnly(owner, std::move(req), StripExtension(image_name));
+    if (!submit.ok) {
+        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
+    }
+    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "convert"}});
+}
+
+ServiceResult ConvertService::SubmitConvertVectorMatchOnly(
+    const std::string& owner, const std::vector<uint8_t>& svg, const std::string& svg_name,
+    const std::optional<std::string>& params_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto accept = tasks_.CanAccept(owner);
+    if (!accept.ok) {
+        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
+    }
+
+    json params;
+    auto parsed = ParseJsonObject(params_json, params);
+    if (!parsed.ok) return parsed;
+    auto session = sessions_.Snapshot(owner);
+
+    ConvertVectorRequest req;
+    auto built = BuildVectorRequest(params, svg, svg_name, session, req);
+    if (!built.ok) return built;
+
+    auto submit =
+        tasks_.SubmitConvertVectorMatchOnly(owner, std::move(req), StripExtension(svg_name));
+    if (!submit.ok) {
+        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
+    }
+    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "convert"}});
+}
+
+ServiceResult ConvertService::BuildRasterRequest(const json& params,
+                                                 const std::vector<uint8_t>& image,
+                                                 const std::string& image_name,
+                                                 const std::optional<SessionSnapshot>& session,
+                                                 ConvertRasterRequest& out) const {
+    out.image_buffer = image;
+    out.image_name   = image_name;
+
+    auto presets_path = std::filesystem::path(cfg_.data_dir) / "presets";
+    if (std::filesystem::is_directory(presets_path)) { out.preset_dir = presets_path.string(); }
+
+    std::string common_vendor, common_material;
+    auto selected = ResolveSelectedColorDbs(params, session, data_, out.preloaded_dbs,
+                                            out.session_owned_dbs, common_vendor, common_material);
+    if (!selected.ok) return selected;
+
+    if (!common_vendor.empty() && !common_material.empty()) {
+        auto profile_keys = BuildProfileChannelKeys(out.preloaded_dbs);
+        out.preloaded_model_pack =
+            data_.ModelPackRegistry().Select(common_vendor, common_material, profile_keys);
+    }
+
+    try {
+        if (params.contains("scale")) out.scale = params["scale"].get<float>();
+        if (params.contains("max_width")) out.max_width = params["max_width"].get<int>();
+        if (params.contains("max_height")) out.max_height = params["max_height"].get<int>();
+        if (params.contains("target_width_mm")) {
+            out.target_width_mm = params["target_width_mm"].get<float>();
+        }
+        if (params.contains("target_height_mm")) {
+            out.target_height_mm = params["target_height_mm"].get<float>();
+        }
+        if (params.contains("color_layers")) {
+            out.color_layers = params["color_layers"].get<int>();
+        }
+        if (params.contains("print_mode")) {
+            const std::string pm = params["print_mode"].get<std::string>();
+            if (pm == "0.08x5" || pm == "0p08x5") {
+                out.color_layers    = 5;
+                out.layer_height_mm = 0.08f;
+            } else if (pm == "0.04x10" || pm == "0p04x10") {
+                out.color_layers    = 10;
+                out.layer_height_mm = 0.04f;
+            }
+        }
+        if (params.contains("color_space")) {
+            out.color_space = ParseColorSpace(params["color_space"].get<std::string>());
+        }
+        if (params.contains("k_candidates")) out.k_candidates = params["k_candidates"].get<int>();
+        if (params.contains("cluster_method")) {
+            out.cluster_method = ParseClusterMethod(params["cluster_method"].get<std::string>());
+        }
+        if (params.contains("cluster_count"))
+            out.cluster_count = params["cluster_count"].get<int>();
+        if (params.contains("slic_target_superpixels")) {
+            out.slic_target_superpixels = params["slic_target_superpixels"].get<int>();
+        }
+        if (params.contains("slic_compactness")) {
+            out.slic_compactness = params["slic_compactness"].get<float>();
+        }
+        if (params.contains("slic_iterations")) {
+            out.slic_iterations = params["slic_iterations"].get<int>();
+        }
+        if (params.contains("slic_min_region_ratio")) {
+            out.slic_min_region_ratio = params["slic_min_region_ratio"].get<float>();
+        }
+        if (params.contains("dither")) {
+            std::string d = params["dither"].get<std::string>();
+            if (d == "blue_noise") {
+                out.dither = DitherMethod::BlueNoise;
+            } else if (d == "floyd_steinberg") {
+                out.dither = DitherMethod::FloydSteinberg;
+            } else if (d == "none") {
+                out.dither = DitherMethod::None;
+            } else {
+                throw std::runtime_error("Invalid dither method: " + d);
+            }
+        }
+        if (params.contains("dither_strength")) {
+            out.dither_strength = params["dither_strength"].get<float>();
+        }
+        if (params.contains("allowed_channels") && params["allowed_channels"].is_array()) {
+            for (const auto& ch : params["allowed_channels"]) {
+                std::string color    = ch.value("color", "");
+                std::string material = ch.value("material", "");
+                if (!color.empty()) out.allowed_channel_keys.push_back(color + "|" + material);
+            }
+        }
+        if (params.contains("model_enable")) out.model_enable = params["model_enable"].get<bool>();
+        if (params.contains("model_only")) out.model_only = params["model_only"].get<bool>();
+        if (params.contains("model_threshold")) {
+            out.model_threshold = params["model_threshold"].get<float>();
+        }
+        if (params.contains("model_margin")) out.model_margin = params["model_margin"].get<float>();
+        if (params.contains("flip_y")) out.flip_y = params["flip_y"].get<bool>();
+        if (params.contains("pixel_mm")) out.pixel_mm = params["pixel_mm"].get<float>();
+        if (params.contains("layer_height_mm")) {
+            out.layer_height_mm = params["layer_height_mm"].get<float>();
+        }
+        if (params.contains("base_layers")) out.base_layers = params["base_layers"].get<int>();
+        if (params.contains("double_sided")) out.double_sided = params["double_sided"].get<bool>();
+        if (params.contains("transparent_layer_mm")) {
+            out.transparent_layer_mm = params["transparent_layer_mm"].get<float>();
+        }
+        if (params.contains("generate_preview")) {
+            out.generate_preview = params["generate_preview"].get<bool>();
+        }
+        if (params.contains("generate_source_mask")) {
+            out.generate_source_mask = params["generate_source_mask"].get<bool>();
+        }
+        if (params.contains("nozzle_size")) {
+            out.nozzle_size = ParseNozzleSize(params["nozzle_size"].get<std::string>());
+        }
+        if (params.contains("face_orientation")) {
+            out.face_orientation =
+                ParseFaceOrientation(params["face_orientation"].get<std::string>());
+        }
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(400, "invalid_params", e.what());
+    }
+
+    if (out.color_layers < 1 || out.color_layers > 20) {
+        return ServiceResult::Error(400, "invalid_params", "color_layers must be between 1 and 20");
+    }
+    if (out.scale <= 0.0f) return ServiceResult::Error(400, "invalid_params", "scale must be > 0");
+    if (out.max_width < 0 || out.max_height < 0) {
+        return ServiceResult::Error(400, "invalid_params", "max dimensions must be >= 0");
+    }
+    if (out.k_candidates < 1) {
+        return ServiceResult::Error(400, "invalid_params", "k_candidates must be >= 1");
+    }
+    if (out.cluster_count < 0) {
+        return ServiceResult::Error(400, "invalid_params", "cluster_count must be >= 0");
+    }
+    if (out.slic_target_superpixels < 0) {
+        return ServiceResult::Error(400, "invalid_params", "slic_target_superpixels must be >= 0");
+    }
+    if (out.slic_compactness <= 0.0f) {
+        return ServiceResult::Error(400, "invalid_params", "slic_compactness must be > 0");
+    }
+    if (out.slic_iterations < 1) {
+        return ServiceResult::Error(400, "invalid_params", "slic_iterations must be >= 1");
+    }
+    if (out.slic_min_region_ratio < 0.0f || out.slic_min_region_ratio > 1.0f) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "slic_min_region_ratio must be in [0,1]");
+    }
+    if (out.dither_strength < 0.0f || out.dither_strength > 1.0f) {
+        return ServiceResult::Error(400, "invalid_params", "dither_strength must be in [0,1]");
+    }
+    if (out.base_layers < -1) {
+        return ServiceResult::Error(400, "invalid_params", "base_layers must be >= -1");
+    }
+    if (out.transparent_layer_mm < 0.0f) {
+        return ServiceResult::Error(400, "invalid_params", "transparent_layer_mm must be >= 0");
+    }
+    if (out.cluster_method == ClusterMethod::Slic && out.dither != DitherMethod::None) {
+        out.dither = DitherMethod::None;
+    }
+
+    return ServiceResult::Success(200, json::object());
+}
+
+ServiceResult ConvertService::BuildVectorRequest(const json& params,
+                                                 const std::vector<uint8_t>& svg,
+                                                 const std::string& svg_name,
+                                                 const std::optional<SessionSnapshot>& session,
+                                                 ConvertVectorRequest& out) const {
+    out.svg_buffer = svg;
+    out.svg_name   = svg_name;
+
+    auto vpresets = std::filesystem::path(cfg_.data_dir) / "presets";
+    if (std::filesystem::is_directory(vpresets)) { out.preset_dir = vpresets.string(); }
+
+    std::string vec_common_vendor, vec_common_material;
+    auto selected =
+        ResolveSelectedColorDbs(params, session, data_, out.preloaded_dbs, out.session_owned_dbs,
+                                vec_common_vendor, vec_common_material);
+    if (!selected.ok) return selected;
+
+    if (!vec_common_vendor.empty() && !vec_common_material.empty()) {
+        auto profile_keys = BuildProfileChannelKeys(out.preloaded_dbs);
+        out.preloaded_model_pack =
+            data_.ModelPackRegistry().Select(vec_common_vendor, vec_common_material, profile_keys);
+    }
+
+    try {
+        if (params.contains("target_width_mm")) {
+            out.target_width_mm = params["target_width_mm"].get<float>();
+        }
+        if (params.contains("target_height_mm")) {
+            out.target_height_mm = params["target_height_mm"].get<float>();
+        }
+        if (params.contains("color_layers")) {
+            out.color_layers = params["color_layers"].get<int>();
+        }
+        if (params.contains("print_mode")) {
+            const std::string pm = params["print_mode"].get<std::string>();
+            if (pm == "0.08x5" || pm == "0p08x5") {
+                out.color_layers    = 5;
+                out.layer_height_mm = 0.08f;
+            } else if (pm == "0.04x10" || pm == "0p04x10") {
+                out.color_layers    = 10;
+                out.layer_height_mm = 0.04f;
+            }
+        }
+        if (params.contains("color_space")) {
+            out.color_space = ParseColorSpace(params["color_space"].get<std::string>());
+        }
+        if (params.contains("k_candidates")) out.k_candidates = params["k_candidates"].get<int>();
+        if (params.contains("model_enable")) out.model_enable = params["model_enable"].get<bool>();
+        if (params.contains("model_only")) out.model_only = params["model_only"].get<bool>();
+        if (params.contains("model_threshold")) {
+            out.model_threshold = params["model_threshold"].get<float>();
+        }
+        if (params.contains("model_margin")) out.model_margin = params["model_margin"].get<float>();
+        if (params.contains("flip_y")) out.flip_y = params["flip_y"].get<bool>();
+        if (params.contains("layer_height_mm")) {
+            out.layer_height_mm = params["layer_height_mm"].get<float>();
+        }
+        if (params.contains("base_layers")) out.base_layers = params["base_layers"].get<int>();
+        if (params.contains("double_sided")) out.double_sided = params["double_sided"].get<bool>();
+        if (params.contains("transparent_layer_mm")) {
+            out.transparent_layer_mm = params["transparent_layer_mm"].get<float>();
+        }
+        if (params.contains("tessellation_tolerance_mm")) {
+            out.tessellation_tolerance_mm = params["tessellation_tolerance_mm"].get<float>();
+        }
+        if (params.contains("gradient_pixel_mm")) {
+            out.gradient_pixel_mm = params["gradient_pixel_mm"].get<float>();
+        }
+        if (params.contains("allowed_channels") && params["allowed_channels"].is_array()) {
+            for (const auto& ch : params["allowed_channels"]) {
+                std::string color    = ch.value("color", "");
+                std::string material = ch.value("material", "");
+                if (!color.empty()) out.allowed_channel_keys.push_back(color + "|" + material);
+            }
+        }
+        if (params.contains("generate_preview")) {
+            out.generate_preview = params["generate_preview"].get<bool>();
+        }
+        if (params.contains("generate_source_mask")) {
+            out.generate_source_mask = params["generate_source_mask"].get<bool>();
+        }
+        if (params.contains("nozzle_size")) {
+            out.nozzle_size = ParseNozzleSize(params["nozzle_size"].get<std::string>());
+        }
+        if (params.contains("face_orientation")) {
+            out.face_orientation =
+                ParseFaceOrientation(params["face_orientation"].get<std::string>());
+        }
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(400, "invalid_params", e.what());
+    }
+
+    if (out.color_layers < 1 || out.color_layers > 20) {
+        return ServiceResult::Error(400, "invalid_params", "color_layers must be between 1 and 20");
+    }
+    if (out.k_candidates < 1) {
+        return ServiceResult::Error(400, "invalid_params", "k_candidates must be >= 1");
+    }
+    if (out.base_layers < -1) {
+        return ServiceResult::Error(400, "invalid_params", "base_layers must be >= -1");
+    }
+    if (out.transparent_layer_mm < 0.0f) {
+        return ServiceResult::Error(400, "invalid_params", "transparent_layer_mm must be >= 0");
+    }
+
+    return ServiceResult::Success(200, json::object());
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/convert_service.h
+++ b/web/backend/src/application/convert_service.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "application/service_result.h"
+#include "application/request_parsing.h"
+#include "application/colordb_resolution.h"
+#include "config/server_config.h"
+#include "infrastructure/data_repository.h"
+#include "infrastructure/session_store.h"
+#include "infrastructure/task_runtime.h"
+#include "chromaprint3d/pipeline.h"
+
+#include <nlohmann/json.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace chromaprint3d::backend {
+
+class ConvertService {
+public:
+    ConvertService(const ServerConfig& cfg, DataRepository& data, SessionStore& sessions,
+                   TaskRuntime& tasks);
+
+    ServiceResult SubmitConvertRaster(const std::string& owner, const std::vector<uint8_t>& image,
+                                      const std::string& image_name,
+                                      const std::optional<std::string>& params_json);
+    ServiceResult SubmitConvertVector(const std::string& owner, const std::vector<uint8_t>& svg,
+                                      const std::string& svg_name,
+                                      const std::optional<std::string>& params_json);
+    ServiceResult AnalyzeVectorWidth(const std::vector<uint8_t>& svg,
+                                     const std::optional<std::string>& params_json);
+    ServiceResult SubmitConvertRasterMatchOnly(const std::string& owner,
+                                               const std::vector<uint8_t>& image,
+                                               const std::string& image_name,
+                                               const std::optional<std::string>& params_json);
+    ServiceResult SubmitConvertVectorMatchOnly(const std::string& owner,
+                                               const std::vector<uint8_t>& svg,
+                                               const std::string& svg_name,
+                                               const std::optional<std::string>& params_json);
+
+private:
+    ServiceResult BuildRasterRequest(const nlohmann::json& params,
+                                     const std::vector<uint8_t>& image,
+                                     const std::string& image_name,
+                                     const std::optional<SessionSnapshot>& session,
+                                     ChromaPrint3D::ConvertRasterRequest& out) const;
+    ServiceResult BuildVectorRequest(const nlohmann::json& params, const std::vector<uint8_t>& svg,
+                                     const std::string& svg_name,
+                                     const std::optional<SessionSnapshot>& session,
+                                     ChromaPrint3D::ConvertVectorRequest& out) const;
+
+    const ServerConfig& cfg_;
+    DataRepository& data_;
+    SessionStore& sessions_;
+    TaskRuntime& tasks_;
+};
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/json_serialization.cpp
+++ b/web/backend/src/application/json_serialization.cpp
@@ -1,0 +1,211 @@
+#include "application/json_serialization.h"
+
+#include "chromaprint3d/print_profile.h"
+#include "chromaprint3d/slicer_preset.h"
+
+#include <cstdio>
+
+namespace chromaprint3d::backend {
+
+using json = nlohmann::json;
+using namespace ChromaPrint3D;
+
+const char* ClusterMethodToString(ClusterMethod method) {
+    switch (method) {
+    case ClusterMethod::Slic:
+        return "slic";
+    case ClusterMethod::KMeans:
+        return "kmeans";
+    }
+    return "slic";
+}
+
+const char* LayerOrderToString(LayerOrder order) {
+    return order == LayerOrder::Bottom2Top ? "Bottom2Top" : "Top2Bottom";
+}
+
+const char* ConvertStageToString(ConvertStage stage) {
+    switch (stage) {
+    case ConvertStage::LoadingResources:
+        return "loading_resources";
+    case ConvertStage::Preprocessing:
+        return "preprocessing";
+    case ConvertStage::Matching:
+        return "matching";
+    case ConvertStage::BuildingModel:
+        return "building_model";
+    case ConvertStage::Exporting:
+        return "exporting";
+    }
+    return "unknown";
+}
+
+json LayerPreviewsToJson(const LayerPreviewResult& layer_previews) {
+    json palette = json::array();
+    for (const auto& channel : layer_previews.palette) {
+        palette.push_back({
+            {"channel_idx", channel.channel_idx},
+            {"color", channel.color},
+            {"material", channel.material},
+        });
+    }
+
+    json artifacts = json::array();
+    for (std::size_t i = 0; i < layer_previews.layer_pngs.size(); ++i) {
+        artifacts.push_back("layer-preview-" + std::to_string(i));
+    }
+
+    return {
+        {"enabled", !layer_previews.layer_pngs.empty()},
+        {"layers", layer_previews.layers},
+        {"width", layer_previews.width},
+        {"height", layer_previews.height},
+        {"layer_order", LayerOrderToString(layer_previews.layer_order)},
+        {"palette", std::move(palette)},
+        {"artifacts", std::move(artifacts)},
+    };
+}
+
+json ColorDbInfoToJson(const ColorDB& db, const std::string& material_type,
+                       const std::string& vendor) {
+    static const auto builtin_fil = FilamentConfig::BuiltinDefaults();
+    json palette                  = json::array();
+    for (size_t i = 0; i < db.palette.size(); ++i) {
+        const auto& ch = db.palette[i];
+        json entry     = {{"color", ch.color}, {"material", ch.material}};
+        if (!ch.hex_color.empty()) {
+            entry["hex_color"] = ch.hex_color;
+        } else {
+            auto resolved = builtin_fil.ResolveHexColor(ch.color, static_cast<int>(i));
+            if (!resolved.empty()) entry["hex_color"] = resolved;
+        }
+        palette.push_back(std::move(entry));
+    }
+    return {
+        {"name", db.name},
+        {"num_channels", db.NumChannels()},
+        {"num_entries", db.entries.size()},
+        {"max_color_layers", db.max_color_layers},
+        {"base_layers", db.base_layers},
+        {"layer_height_mm", db.layer_height_mm},
+        {"line_width_mm", db.line_width_mm},
+        {"material_type", material_type},
+        {"vendor", vendor},
+        {"palette", std::move(palette)},
+    };
+}
+
+json ColorDbBuildResultToJson(const ColorDB& db) {
+    auto out = ColorDbInfoToJson(db);
+
+    json entries = json::array();
+    for (const auto& entry : db.entries) {
+        Rgb rgb    = entry.lab.ToRgb();
+        uint8_t r8 = 0, g8 = 0, b8 = 0;
+        rgb.ToRgb255(r8, g8, b8);
+        char hex_buf[8];
+        std::snprintf(hex_buf, sizeof(hex_buf), "#%02X%02X%02X", r8, g8, b8);
+
+        json recipe_arr = json::array();
+        for (uint8_t v : entry.recipe) { recipe_arr.push_back(static_cast<int>(v)); }
+
+        entries.push_back({
+            {"lab", {entry.lab.x, entry.lab.y, entry.lab.z}},
+            {"hex", std::string(hex_buf)},
+            {"recipe", std::move(recipe_arr)},
+        });
+    }
+    out["entries"] = std::move(entries);
+    return out;
+}
+
+json TaskToJson(const TaskSnapshot& task) {
+    json j;
+    j["id"]     = task.id;
+    j["kind"]   = TaskKindToString(task.kind);
+    j["status"] = TaskStatusToString(task.status);
+    j["created_at_ms"] =
+        std::chrono::duration_cast<std::chrono::milliseconds>(task.created_at.time_since_epoch())
+            .count();
+    j["error"] = task.error.empty() ? json(nullptr) : json(task.error);
+
+    if (auto cp = std::get_if<ConvertTaskPayload>(&task.payload)) {
+        j["stage"]      = ConvertStageToString(cp->stage);
+        j["progress"]   = cp->progress;
+        j["match_only"] = cp->match_only;
+        if (!cp->generate_error.empty()) { j["generate_error"] = cp->generate_error; }
+        if (!cp->result.warnings.empty()) { j["warnings"] = cp->result.warnings; }
+        if (task.status == RuntimeTaskStatus::Completed) {
+            j["result"] = {
+                {"input_width", cp->result.input_width},
+                {"input_height", cp->result.input_height},
+                {"resolved_pixel_mm", cp->result.resolved_pixel_mm},
+                {"physical_width_mm", cp->result.physical_width_mm},
+                {"physical_height_mm", cp->result.physical_height_mm},
+                {"stats",
+                 {{"clusters_total", cp->result.stats.clusters_total},
+                  {"db_only", cp->result.stats.db_only},
+                  {"model_fallback", cp->result.stats.model_fallback},
+                  {"model_queries", cp->result.stats.model_queries},
+                  {"avg_db_de", cp->result.stats.avg_db_de},
+                  {"avg_model_de", cp->result.stats.avg_model_de}}},
+                {"has_3mf", !cp->result.model_3mf.empty() || cp->has_3mf_on_disk},
+                {"has_preview", !cp->result.preview_png.empty()},
+                {"has_source_mask", !cp->result.source_mask_png.empty()},
+                {"has_region_map",
+                 !cp->region_map_binary.empty() || cp->raster_region_map.has_value()},
+                {"layer_previews", LayerPreviewsToJson(cp->result.layer_previews)},
+            };
+        } else {
+            j["result"] = nullptr;
+        }
+        return j;
+    }
+
+    if (auto mp = std::get_if<MattingTaskPayload>(&task.payload)) {
+        j["method"] = mp->method;
+        if (task.status == RuntimeTaskStatus::Completed) {
+            j["width"]     = mp->width;
+            j["height"]    = mp->height;
+            j["has_alpha"] = mp->has_alpha;
+            j["timing"]    = {
+                {"preprocess_ms", mp->timing.preprocess_ms},
+                {"inference_ms", mp->timing.inference_ms},
+                {"postprocess_ms", mp->timing.postprocess_ms},
+                {"decode_ms", mp->decode_ms},
+                {"encode_ms", mp->encode_ms},
+                {"provider_ms", mp->timing.total_ms},
+                {"pipeline_ms", mp->pipeline_ms},
+            };
+        } else {
+            j["width"]     = 0;
+            j["height"]    = 0;
+            j["has_alpha"] = false;
+            j["timing"]    = nullptr;
+        }
+        return j;
+    }
+
+    auto* vp        = std::get_if<VectorizeTaskPayload>(&task.payload);
+    j["timing"]     = nullptr;
+    j["width"]      = 0;
+    j["height"]     = 0;
+    j["num_shapes"] = 0;
+    j["svg_size"]   = 0;
+    if (vp && task.status == RuntimeTaskStatus::Completed) {
+        const auto svg_size      = vp->svg_bytes > 0 ? vp->svg_bytes : vp->svg_content.size();
+        j["width"]               = vp->width;
+        j["height"]              = vp->height;
+        j["num_shapes"]          = vp->num_shapes;
+        j["svg_size"]            = svg_size;
+        j["resolved_num_colors"] = vp->resolved_num_colors;
+        j["timing"]              = {
+            {"decode_ms", vp->decode_ms},
+            {"vectorize_ms", vp->vectorize_ms},
+            {"pipeline_ms", vp->pipeline_ms},
+        };
+    }
+    return j;
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/json_serialization.h
+++ b/web/backend/src/application/json_serialization.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "infrastructure/task_runtime.h"
+
+#include "chromaprint3d/color_db.h"
+#include "chromaprint3d/pipeline.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <vector>
+
+namespace chromaprint3d::backend {
+
+const char* ClusterMethodToString(ChromaPrint3D::ClusterMethod method);
+const char* LayerOrderToString(ChromaPrint3D::LayerOrder order);
+const char* ConvertStageToString(ChromaPrint3D::ConvertStage stage);
+
+nlohmann::json LayerPreviewsToJson(const ChromaPrint3D::LayerPreviewResult& layer_previews);
+
+nlohmann::json ColorDbInfoToJson(const ChromaPrint3D::ColorDB& db,
+                                 const std::string& material_type = "",
+                                 const std::string& vendor        = "");
+nlohmann::json ColorDbBuildResultToJson(const ChromaPrint3D::ColorDB& db);
+
+nlohmann::json TaskToJson(const TaskSnapshot& task);
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/matting_vectorize_service.cpp
+++ b/web/backend/src/application/matting_vectorize_service.cpp
@@ -1,0 +1,329 @@
+#include "application/matting_vectorize_service.h"
+
+#include "chromaprint3d/matting_postprocess.h"
+
+#include <neroued/vectorizer/vectorizer.h>
+#include <spdlog/spdlog.h>
+
+namespace chromaprint3d::backend {
+
+using json             = nlohmann::json;
+using VectorizerConfig = neroued::vectorizer::VectorizerConfig;
+
+MattingVectorizeService::MattingVectorizeService(const ServerConfig& cfg, DataRepository& data,
+                                                 TaskRuntime& tasks)
+    : cfg_(cfg), data_(data), tasks_(tasks) {}
+
+ServiceResult MattingVectorizeService::SubmitMatting(const std::string& owner,
+                                                     const std::vector<uint8_t>& image,
+                                                     const std::string& image_name,
+                                                     const std::string& method) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto accept = tasks_.CanAccept(owner);
+    if (!accept.ok) {
+        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
+    }
+    auto valid = ValidateDecodedImage(image, cfg_.max_pixels_per_image);
+    if (!valid.ok) return valid;
+
+    if (!data_.MattingRegistry().Has(method)) {
+        return ServiceResult::Error(400, "invalid_method", "Unknown matting method: " + method);
+    }
+    auto submit = tasks_.SubmitMatting(owner, image, method, StripExtension(image_name),
+                                       data_.MattingRegistry());
+    if (!submit.ok) {
+        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
+    }
+    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "matting"}});
+}
+
+ServiceResult MattingVectorizeService::PostprocessMatting(const std::string& owner,
+                                                          const std::string& task_id,
+                                                          const std::string& body_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+
+    json body;
+    try {
+        body = json::parse(body_json);
+    } catch (const json::parse_error& e) {
+        return ServiceResult::Error(400, "invalid_json",
+                                    std::string("JSON parse error: ") + e.what());
+    }
+    if (!body.is_object()) {
+        return ServiceResult::Error(400, "invalid_json", "Expected JSON object");
+    }
+
+    ChromaPrint3D::MattingPostprocessParams params;
+    if (body.contains("threshold")) params.threshold = body["threshold"].get<float>();
+    if (body.contains("morph_close_size"))
+        params.morph_close_size = body["morph_close_size"].get<int>();
+    if (body.contains("morph_close_iterations"))
+        params.morph_close_iterations = body["morph_close_iterations"].get<int>();
+    if (body.contains("min_region_area"))
+        params.min_region_area = body["min_region_area"].get<int>();
+    if (body.contains("reframe")) {
+        const auto& rf = body["reframe"];
+        if (!rf.is_object()) {
+            return ServiceResult::Error(400, "invalid_params", "reframe must be an object");
+        }
+        if (rf.contains("enabled")) params.reframe_enabled = rf["enabled"].get<bool>();
+        if (rf.contains("padding_px")) params.reframe_padding_px = rf["padding_px"].get<int>();
+    }
+    if (body.contains("outline") && body["outline"].is_object()) {
+        const auto& ol = body["outline"];
+        if (ol.contains("enabled")) params.outline_enabled = ol["enabled"].get<bool>();
+        if (ol.contains("width")) params.outline_width = ol["width"].get<int>();
+        if (ol.contains("color") && ol["color"].is_array() && ol["color"].size() == 3) {
+            params.outline_color = {ol["color"][0].get<uint8_t>(), ol["color"][1].get<uint8_t>(),
+                                    ol["color"][2].get<uint8_t>()};
+        }
+        if (ol.contains("mode")) {
+            auto mode_str = ol["mode"].get<std::string>();
+            if (mode_str == "inner")
+                params.outline_mode = ChromaPrint3D::OutlineMode::Inner;
+            else if (mode_str == "outer")
+                params.outline_mode = ChromaPrint3D::OutlineMode::Outer;
+            else
+                params.outline_mode = ChromaPrint3D::OutlineMode::Center;
+        }
+    }
+    if (params.reframe_padding_px < 0 || params.reframe_padding_px > 4096) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "reframe.padding_px must be in [0,4096]");
+    }
+
+    int status          = 500;
+    std::string message = "Unknown error";
+    bool ok             = tasks_.PostprocessMatting(owner, task_id, params, status, message);
+    if (!ok) return ServiceResult::Error(status, "postprocess_failed", message);
+
+    json artifacts = json::array({"processed-mask", "processed-foreground"});
+    if (params.outline_enabled) artifacts.push_back("outline");
+
+    return ServiceResult::Success(200, {{"artifacts", std::move(artifacts)}});
+}
+
+ServiceResult MattingVectorizeService::SubmitVectorize(
+    const std::string& owner, const std::vector<uint8_t>& image, const std::string& image_name,
+    const std::optional<std::string>& params_json) {
+    const auto params_bytes = params_json.has_value() ? params_json->size() : 0U;
+    spdlog::info("SubmitVectorize requested: image='{}', bytes={}, params_bytes={}, owner_len={}",
+                 image_name, image.size(), params_bytes, owner.size());
+    if (owner.empty()) {
+        spdlog::warn("SubmitVectorize rejected: no session");
+        return ServiceResult::Error(401, "unauthorized", "No session");
+    }
+    auto accept = tasks_.CanAccept(owner);
+    if (!accept.ok) {
+        spdlog::warn("SubmitVectorize rejected by queue gate: status={}, reason={}",
+                     accept.status_code, accept.message);
+        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
+    }
+    auto valid = ValidateDecodedImage(image, cfg_.max_pixels_per_image);
+    if (!valid.ok) {
+        spdlog::warn("SubmitVectorize rejected: invalid image, status={}, reason={}",
+                     valid.status_code, valid.message);
+        return valid;
+    }
+
+    json params;
+    auto parsed = ParseJsonObject(params_json, params);
+    if (!parsed.ok) {
+        spdlog::warn("SubmitVectorize rejected: invalid params json, status={}, reason={}",
+                     parsed.status_code, parsed.message);
+        return parsed;
+    }
+
+    VectorizerConfig cfg;
+    auto built = BuildVectorizeConfig(params, cfg);
+    if (!built.ok) {
+        spdlog::warn("SubmitVectorize rejected: invalid vectorize config, status={}, reason={}",
+                     built.status_code, built.message);
+        return built;
+    }
+    spdlog::debug(
+        "SubmitVectorize config: num_colors={}, min_region_area={}, curve_fit_error={:.3f}, "
+        "corner_angle_threshold={:.1f}, smoothing_spatial={:.1f}, smoothing_color={:.1f}, "
+        "upscale_short_edge={}, max_working_pixels={}, slic_region_size={}, "
+        "edge_sensitivity={:.2f}, refine_passes={}, max_merge_color_dist={:.1f}, "
+        "svg_enable_stroke={}, svg_stroke_width={:.2f}",
+        cfg.num_colors, cfg.min_region_area, cfg.curve_fit_error, cfg.corner_angle_threshold,
+        cfg.smoothing_spatial, cfg.smoothing_color, cfg.upscale_short_edge, cfg.max_working_pixels,
+        cfg.slic_region_size, cfg.edge_sensitivity, cfg.refine_passes, cfg.max_merge_color_dist,
+        cfg.svg_enable_stroke, cfg.svg_stroke_width);
+
+    auto submit = tasks_.SubmitVectorize(owner, image, cfg, StripExtension(image_name));
+    if (!submit.ok) {
+        spdlog::warn("SubmitVectorize failed to enqueue: status={}, reason={}", submit.status_code,
+                     submit.message);
+        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
+    }
+    spdlog::info("SubmitVectorize accepted: task_id={}, image='{}'", submit.task_id, image_name);
+    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "vectorize"}});
+}
+
+ServiceResult MattingVectorizeService::BuildVectorizeConfig(const json& params,
+                                                            VectorizerConfig& out) const {
+    out = VectorizerConfig{};
+    spdlog::debug("BuildVectorizeConfig: params keys={}", params.size());
+    try {
+        if (params.contains("num_colors")) out.num_colors = params["num_colors"].get<int>();
+        if (params.contains("min_region_area")) {
+            out.min_region_area = params["min_region_area"].get<int>();
+        }
+        if (params.contains("curve_fit_error")) {
+            out.curve_fit_error = params["curve_fit_error"].get<float>();
+        }
+        if (params.contains("corner_angle_threshold")) {
+            out.corner_angle_threshold = params["corner_angle_threshold"].get<float>();
+        }
+        if (params.contains("smoothing_spatial")) {
+            out.smoothing_spatial = params["smoothing_spatial"].get<float>();
+        }
+        if (params.contains("smoothing_color")) {
+            out.smoothing_color = params["smoothing_color"].get<float>();
+        }
+        if (params.contains("upscale_short_edge")) {
+            out.upscale_short_edge = params["upscale_short_edge"].get<int>();
+        }
+        if (params.contains("max_working_pixels")) {
+            out.max_working_pixels = params["max_working_pixels"].get<int>();
+        }
+        if (params.contains("slic_region_size")) {
+            out.slic_region_size = params["slic_region_size"].get<int>();
+        }
+        if (params.contains("edge_sensitivity")) {
+            out.edge_sensitivity = params["edge_sensitivity"].get<float>();
+        }
+        if (params.contains("refine_passes")) {
+            out.refine_passes = params["refine_passes"].get<int>();
+        }
+        if (params.contains("max_merge_color_dist")) {
+            out.max_merge_color_dist = params["max_merge_color_dist"].get<float>();
+        }
+        if (params.contains("thin_line_max_radius")) {
+            out.thin_line_max_radius = params["thin_line_max_radius"].get<float>();
+        }
+        if (params.contains("min_contour_area")) {
+            out.min_contour_area = params["min_contour_area"].get<float>();
+        }
+        if (params.contains("min_hole_area"))
+            out.min_hole_area = params["min_hole_area"].get<float>();
+        if (params.contains("contour_simplify")) {
+            out.contour_simplify = params["contour_simplify"].get<float>();
+        }
+        if (params.contains("enable_coverage_fix")) {
+            out.enable_coverage_fix = params["enable_coverage_fix"].get<bool>();
+        }
+        if (params.contains("min_coverage_ratio")) {
+            out.min_coverage_ratio = params["min_coverage_ratio"].get<float>();
+        }
+        if (params.contains("svg_enable_stroke")) {
+            out.svg_enable_stroke = params["svg_enable_stroke"].get<bool>();
+        }
+        if (params.contains("svg_stroke_width")) {
+            out.svg_stroke_width = params["svg_stroke_width"].get<float>();
+        }
+        if (params.contains("smoothness")) { out.smoothness = params["smoothness"].get<float>(); }
+        if (params.contains("detail_level")) {
+            out.detail_level = params["detail_level"].get<float>();
+        }
+        if (params.contains("merge_segment_tolerance")) {
+            out.merge_segment_tolerance = params["merge_segment_tolerance"].get<float>();
+        }
+        if (params.contains("enable_antialias_detect")) {
+            out.enable_antialias_detect = params["enable_antialias_detect"].get<bool>();
+        }
+        if (params.contains("aa_tolerance")) {
+            out.aa_tolerance = params["aa_tolerance"].get<float>();
+        }
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(400, "invalid_params", e.what());
+    }
+
+    if (out.num_colors != 0 && (out.num_colors < 2 || out.num_colors > 256)) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "num_colors must be 0 (auto) or [2,256]");
+    }
+    if (out.curve_fit_error < 0.1f || out.curve_fit_error > 5.0f) {
+        return ServiceResult::Error(400, "invalid_params", "curve_fit_error must be in [0.1,5]");
+    }
+    if (out.corner_angle_threshold < 90.0f || out.corner_angle_threshold > 175.0f) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "corner_angle_threshold must be in [90,175]");
+    }
+    if (out.smoothing_spatial < 0.0f || out.smoothing_spatial > 50.0f) {
+        return ServiceResult::Error(400, "invalid_params", "smoothing_spatial must be in [0,50]");
+    }
+    if (out.smoothing_color < 0.0f || out.smoothing_color > 80.0f) {
+        return ServiceResult::Error(400, "invalid_params", "smoothing_color must be in [0,80]");
+    }
+    if (out.upscale_short_edge < 0 || out.upscale_short_edge > 2000) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "upscale_short_edge must be in [0,2000]");
+    }
+    if (out.max_working_pixels < 0 || out.max_working_pixels > 100000000) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "max_working_pixels must be in [0,100000000]");
+    }
+    if (out.slic_region_size < 0 || out.slic_region_size > 100) {
+        return ServiceResult::Error(400, "invalid_params", "slic_region_size must be in [0,100]");
+    }
+    if (out.edge_sensitivity < 0.0f || out.edge_sensitivity > 1.0f) {
+        return ServiceResult::Error(400, "invalid_params", "edge_sensitivity must be in [0,1]");
+    }
+    if (out.refine_passes < 0 || out.refine_passes > 20) {
+        return ServiceResult::Error(400, "invalid_params", "refine_passes must be in [0,20]");
+    }
+    if (out.max_merge_color_dist < 0.0f || out.max_merge_color_dist > 2000.0f) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "max_merge_color_dist must be in [0,2000]");
+    }
+    if (out.thin_line_max_radius < 0.5f || out.thin_line_max_radius > 10.0f) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "thin_line_max_radius must be in [0.5,10]");
+    }
+    if (out.min_region_area < 0 || out.min_contour_area < 0.0f || out.min_hole_area < 0.0f) {
+        return ServiceResult::Error(400, "invalid_params", "area options must be >= 0");
+    }
+    if (out.contour_simplify < 0.0f || out.contour_simplify > 10.0f) {
+        return ServiceResult::Error(400, "invalid_params", "contour_simplify must be in [0,10]");
+    }
+    if (out.min_coverage_ratio < 0.0f || out.min_coverage_ratio > 1.0f) {
+        return ServiceResult::Error(400, "invalid_params", "min_coverage_ratio must be in [0,1]");
+    }
+    if (out.svg_stroke_width < 0.0f || out.svg_stroke_width > 20.0f) {
+        return ServiceResult::Error(400, "invalid_params", "svg_stroke_width must be in [0,20]");
+    }
+    if (out.smoothness < 0.0f || out.smoothness > 1.0f) {
+        return ServiceResult::Error(400, "invalid_params", "smoothness must be in [0,1]");
+    }
+    if (out.detail_level > 1.0f) {
+        return ServiceResult::Error(400, "invalid_params", "detail_level must be <= 1");
+    }
+    if (out.merge_segment_tolerance < 0.0f || out.merge_segment_tolerance > 0.5f) {
+        return ServiceResult::Error(400, "invalid_params",
+                                    "merge_segment_tolerance must be in [0,0.5]");
+    }
+    if (out.aa_tolerance < 1.0f || out.aa_tolerance > 50.0f) {
+        return ServiceResult::Error(400, "invalid_params", "aa_tolerance must be in [1,50]");
+    }
+    spdlog::debug(
+        "BuildVectorizeConfig resolved: num_colors={}, min_region_area={}, curve_fit_error={:.3f}, "
+        "corner_angle_threshold={:.1f}, smoothing_spatial={:.1f}, smoothing_color={:.1f}, "
+        "upscale_short_edge={}, max_working_pixels={}, slic_region_size={}, "
+        "edge_sensitivity={:.2f}, refine_passes={}, max_merge_color_dist={:.1f}, "
+        "thin_line_max_radius={:.2f}, "
+        "min_contour_area={:.2f}, min_hole_area={:.2f}, contour_simplify={:.2f}, "
+        "enable_coverage_fix={}, min_coverage_ratio={:.4f}, "
+        "svg_enable_stroke={}, svg_stroke_width={:.2f}",
+        out.num_colors, out.min_region_area, out.curve_fit_error, out.corner_angle_threshold,
+        out.smoothing_spatial, out.smoothing_color, out.upscale_short_edge, out.max_working_pixels,
+        out.slic_region_size, out.edge_sensitivity, out.refine_passes, out.max_merge_color_dist,
+        out.thin_line_max_radius, out.min_contour_area, out.min_hole_area, out.contour_simplify,
+        out.enable_coverage_fix, out.min_coverage_ratio, out.svg_enable_stroke,
+        out.svg_stroke_width);
+    return ServiceResult::Success(200, json::object());
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/matting_vectorize_service.h
+++ b/web/backend/src/application/matting_vectorize_service.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "application/service_result.h"
+#include "application/request_parsing.h"
+#include "config/server_config.h"
+#include "infrastructure/data_repository.h"
+#include "infrastructure/task_runtime.h"
+
+#include <nlohmann/json.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace neroued::vectorizer {
+struct VectorizerConfig;
+}
+
+namespace chromaprint3d::backend {
+
+class MattingVectorizeService {
+public:
+    MattingVectorizeService(const ServerConfig& cfg, DataRepository& data, TaskRuntime& tasks);
+
+    ServiceResult SubmitMatting(const std::string& owner, const std::vector<uint8_t>& image,
+                                const std::string& image_name, const std::string& method);
+    ServiceResult PostprocessMatting(const std::string& owner, const std::string& task_id,
+                                     const std::string& body_json);
+    ServiceResult SubmitVectorize(const std::string& owner, const std::vector<uint8_t>& image,
+                                  const std::string& image_name,
+                                  const std::optional<std::string>& params_json);
+
+private:
+    ServiceResult BuildVectorizeConfig(const nlohmann::json& params,
+                                       neroued::vectorizer::VectorizerConfig& out) const;
+
+    const ServerConfig& cfg_;
+    DataRepository& data_;
+    TaskRuntime& tasks_;
+};
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/recipe_editor_service.cpp
+++ b/web/backend/src/application/recipe_editor_service.cpp
@@ -1,0 +1,201 @@
+#include "application/recipe_editor_service.h"
+
+#include "application/colordb_resolution.h"
+
+#include "chromaprint3d/forward_color_model.h"
+#include "chromaprint3d/print_profile.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace chromaprint3d::backend {
+
+using json = nlohmann::json;
+
+RecipeEditorService::RecipeEditorService(DataRepository& data, TaskRuntime& tasks)
+    : data_(data), tasks_(tasks) {}
+
+ServiceResult RecipeEditorService::RecipeEditorSummary(const std::string& owner,
+                                                       const std::string& task_id) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto summary = tasks_.GetRecipeEditorSummary(owner, task_id);
+    if (!summary) return ServiceResult::Error(404, "not_found", "Summary not available");
+    return ServiceResult::Success(200, std::move(*summary));
+}
+
+ServiceResult RecipeEditorService::RecipeEditorAlternatives(const std::string& owner,
+                                                            const std::string& task_id,
+                                                            const std::string& body_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+
+    json body;
+    try {
+        body = json::parse(body_json);
+    } catch (...) { return ServiceResult::Error(400, "invalid_request", "Invalid JSON body"); }
+
+    if (!body.contains("target_lab") || !body["target_lab"].is_object()) {
+        return ServiceResult::Error(400, "invalid_request", "Missing target_lab");
+    }
+    const auto& tlab = body["target_lab"];
+    ChromaPrint3D::Lab target(tlab.value("L", 0.0f), tlab.value("a", 0.0f), tlab.value("b", 0.0f));
+
+    int max_candidates = body.value("max_candidates", 10);
+    int offset         = body.value("offset", 0);
+
+    std::string recipe_pattern = body.value("recipe_pattern", std::string{});
+
+    const ChromaPrint3D::ModelPackage* model_pack = nullptr;
+    if (!data_.ModelPackRegistry().Empty()) {
+        model_pack = &data_.ModelPackRegistry().All().front();
+    }
+
+    auto result = tasks_.QueryRecipeAlternatives(owner, task_id, target, max_candidates, offset,
+                                                 model_pack, recipe_pattern);
+    if (!result) return ServiceResult::Error(404, "not_found", "Alternatives not available");
+    return ServiceResult::Success(200, {{"candidates", std::move(*result)}});
+}
+
+ServiceResult RecipeEditorService::RecipeEditorReplace(const std::string& owner,
+                                                       const std::string& task_id,
+                                                       const std::string& body_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+
+    json body;
+    try {
+        body = json::parse(body_json);
+    } catch (...) { return ServiceResult::Error(400, "invalid_request", "Invalid JSON body"); }
+
+    if (!body.contains("region_ids") || !body["region_ids"].is_array()) {
+        return ServiceResult::Error(400, "invalid_request", "Missing region_ids array");
+    }
+    if (!body.contains("new_recipe") || !body["new_recipe"].is_array()) {
+        return ServiceResult::Error(400, "invalid_request", "Missing new_recipe array");
+    }
+    if (!body.contains("new_mapped_lab") || !body["new_mapped_lab"].is_object()) {
+        return ServiceResult::Error(400, "invalid_request", "Missing new_mapped_lab");
+    }
+
+    std::vector<int> region_ids;
+    for (const auto& v : body["region_ids"]) { region_ids.push_back(v.get<int>()); }
+
+    std::vector<uint8_t> new_recipe;
+    for (const auto& v : body["new_recipe"]) { new_recipe.push_back(v.get<uint8_t>()); }
+
+    const auto& lab_obj = body["new_mapped_lab"];
+    ChromaPrint3D::Lab new_mapped(lab_obj.value("L", 0.0f), lab_obj.value("a", 0.0f),
+                                  lab_obj.value("b", 0.0f));
+
+    bool new_from_model = body.value("from_model", false);
+
+    int status          = 500;
+    std::string message = "Unknown error";
+    json out_summary;
+    bool ok = tasks_.ReplaceRecipe(owner, task_id, region_ids, new_recipe, new_mapped,
+                                   new_from_model, status, message, out_summary);
+    if (!ok) return ServiceResult::Error(status, "replace_failed", message);
+    return ServiceResult::Success(200, std::move(out_summary));
+}
+
+ServiceResult RecipeEditorService::RecipeEditorGenerate(const std::string& owner,
+                                                        const std::string& task_id) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+
+    auto submit = tasks_.SubmitGenerateModel(owner, task_id);
+    if (!submit.ok) {
+        return ServiceResult::Error(submit.status_code, "generate_failed", submit.message);
+    }
+    return ServiceResult::Success(202, {{"task_id", submit.task_id}});
+}
+
+ServiceResult RecipeEditorService::RecipeEditorPredict(const std::string& owner,
+                                                       const std::string& task_id,
+                                                       const std::string& body_json) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+
+    json body;
+    try {
+        body = json::parse(body_json);
+    } catch (...) { return ServiceResult::Error(400, "invalid_json", "Cannot parse request body"); }
+    if (!body.contains("recipe") || !body["recipe"].is_array()) {
+        return ServiceResult::Error(400, "invalid_params", "Missing recipe array");
+    }
+
+    std::vector<int> palette_recipe;
+    for (const auto& v : body["recipe"]) {
+        if (!v.is_number_integer()) {
+            return ServiceResult::Error(400, "invalid_params", "Recipe must be array of integers");
+        }
+        palette_recipe.push_back(v.get<int>());
+    }
+    if (palette_recipe.empty()) {
+        return ServiceResult::Error(400, "invalid_params", "Recipe cannot be empty");
+    }
+
+    auto profile_opt = tasks_.GetTaskPrintProfile(owner, task_id);
+    if (!profile_opt) {
+        return ServiceResult::Error(404, "not_found", "Task not found or not in recipe-edit mode");
+    }
+    const auto& profile = *profile_opt;
+
+    std::string common_vendor, common_material;
+    auto db_names_opt = tasks_.GetTaskColorDbNames(owner, task_id);
+    if (db_names_opt) {
+        ResolveTaskVendorMaterial(*db_names_opt, data_, common_vendor, common_material);
+    }
+
+    std::vector<std::string> profile_channel_keys;
+    for (const auto& ch : profile.palette) {
+        profile_channel_keys.push_back(NormalizeChannelKey(ch));
+    }
+
+    const auto* model =
+        data_.ForwardModels().Select(common_vendor, common_material, profile_channel_keys);
+    if (!model) {
+        return ServiceResult::Error(501, "no_forward_model",
+                                    "No forward model available for this task's material scope");
+    }
+
+    std::vector<int> stage_recipe;
+    stage_recipe.reserve(palette_recipe.size());
+    for (int pidx : palette_recipe) {
+        if (pidx < 0 || pidx >= static_cast<int>(profile.palette.size())) {
+            return ServiceResult::Error(400, "invalid_params",
+                                        "Recipe channel index out of palette range");
+        }
+        int stage_idx = model->MapChannelByName(profile.palette[pidx].color);
+        if (stage_idx < 0) {
+            return ServiceResult::Error(400, "channel_mapping_failed",
+                                        "Cannot map palette channel '" +
+                                            profile.palette[pidx].color +
+                                            "' to forward model stage channel");
+        }
+        stage_recipe.push_back(stage_idx);
+    }
+
+    int base_stage_idx = 0;
+    if (profile.base_channel_idx >= 0 &&
+        profile.base_channel_idx < static_cast<int>(profile.palette.size())) {
+        int mapped = model->MapChannelByName(profile.palette[profile.base_channel_idx].color);
+        if (mapped >= 0) base_stage_idx = mapped;
+    }
+
+    ChromaPrint3D::PredictionConfig cfg;
+    cfg.layer_height_mm  = profile.layer_height_mm;
+    cfg.base_channel_idx = base_stage_idx;
+    cfg.layer_order      = profile.layer_order;
+    cfg.substrate_idx    = model->ResolveSubstrateIdx(base_stage_idx);
+
+    ChromaPrint3D::Lab predicted = model->PredictLab(stage_recipe, cfg);
+
+    uint8_t r8, g8, b8;
+    predicted.ToRgb().ToRgb255(r8, g8, b8);
+    char hex[8];
+    std::snprintf(hex, sizeof(hex), "#%02X%02X%02X", r8, g8, b8);
+
+    return ServiceResult::Success(
+        200, {{"predicted_lab", {{"L", predicted.l()}, {"a", predicted.a()}, {"b", predicted.b()}}},
+              {"hex", std::string(hex)},
+              {"from_model", true}});
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/recipe_editor_service.cpp
+++ b/web/backend/src/application/recipe_editor_service.cpp
@@ -5,6 +5,8 @@
 #include "chromaprint3d/forward_color_model.h"
 #include "chromaprint3d/print_profile.h"
 
+#include <nlohmann/json.hpp>
+
 #include <cstdio>
 #include <vector>
 

--- a/web/backend/src/application/recipe_editor_service.h
+++ b/web/backend/src/application/recipe_editor_service.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "application/service_result.h"
+
+#include "infrastructure/data_repository.h"
+#include "infrastructure/task_runtime.h"
+
+#include <string>
+
+namespace chromaprint3d::backend {
+
+class RecipeEditorService {
+public:
+    RecipeEditorService(DataRepository& data, TaskRuntime& tasks);
+
+    ServiceResult RecipeEditorSummary(const std::string& owner, const std::string& task_id);
+    ServiceResult RecipeEditorAlternatives(const std::string& owner, const std::string& task_id,
+                                           const std::string& body_json);
+    ServiceResult RecipeEditorReplace(const std::string& owner, const std::string& task_id,
+                                      const std::string& body_json);
+    ServiceResult RecipeEditorGenerate(const std::string& owner, const std::string& task_id);
+    ServiceResult RecipeEditorPredict(const std::string& owner, const std::string& task_id,
+                                      const std::string& body_json);
+
+private:
+    DataRepository& data_;
+    TaskRuntime& tasks_;
+};
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/request_parsing.cpp
+++ b/web/backend/src/application/request_parsing.cpp
@@ -1,0 +1,74 @@
+#include "application/request_parsing.h"
+
+#include "chromaprint3d/image_io.h"
+#include "chromaprint3d/pipeline.h"
+
+#include <opencv2/imgcodecs.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+
+namespace chromaprint3d::backend {
+
+using json = nlohmann::json;
+using namespace ChromaPrint3D;
+
+std::string ToLowerAscii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+std::string StripExtension(const std::string& filename) {
+    auto dot = filename.rfind('.');
+    if (dot == std::string::npos) return filename;
+    return filename.substr(0, dot);
+}
+
+ColorSpace ParseColorSpace(const std::string& value) {
+    const std::string lowered = ToLowerAscii(value);
+    if (lowered == "lab") return ColorSpace::Lab;
+    if (lowered == "rgb") return ColorSpace::Rgb;
+    throw std::runtime_error("Invalid color_space: " + value);
+}
+
+ClusterMethod ParseClusterMethod(const std::string& value) {
+    const std::string lowered = ToLowerAscii(value);
+    if (lowered == "slic") return ClusterMethod::Slic;
+    if (lowered == "kmeans" || lowered == "k_means" || lowered == "k-means") {
+        return ClusterMethod::KMeans;
+    }
+    throw std::runtime_error("Invalid cluster_method: " + value);
+}
+
+ServiceResult ParseJsonObject(const std::optional<std::string>& raw, json& out) {
+    out = json::object();
+    if (!raw || raw->empty()) return ServiceResult::Success(200, json::object());
+    try {
+        out = json::parse(*raw);
+        if (!out.is_object()) {
+            return ServiceResult::Error(400, "invalid_json", "Expected JSON object");
+        }
+        return ServiceResult::Success(200, json::object());
+    } catch (const std::exception& e) {
+        return ServiceResult::Error(400, "invalid_json", std::string("Invalid JSON: ") + e.what());
+    }
+}
+
+ServiceResult ValidateDecodedImage(const std::vector<uint8_t>& image, std::int64_t max_pixels) {
+    cv::Mat decoded;
+    try {
+        decoded = DecodeImageWithIcc(image);
+    } catch (...) { return ServiceResult::Error(400, "invalid_image", "Failed to decode image"); }
+    if (decoded.empty())
+        return ServiceResult::Error(400, "invalid_image", "Failed to decode image");
+    std::int64_t pixels = static_cast<std::int64_t>(decoded.cols) * decoded.rows;
+    if (pixels > max_pixels) {
+        return ServiceResult::Error(413, "image_too_large",
+                                    "Decoded image exceeds max pixels limit");
+    }
+    return ServiceResult::Success(200, json::object());
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/request_parsing.h
+++ b/web/backend/src/application/request_parsing.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "application/service_result.h"
+
+#include <nlohmann/json.hpp>
+
+#include "chromaprint3d/common.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace chromaprint3d::backend {
+
+std::string ToLowerAscii(std::string value);
+std::string StripExtension(const std::string& filename);
+ChromaPrint3D::ColorSpace ParseColorSpace(const std::string& value);
+ChromaPrint3D::ClusterMethod ParseClusterMethod(const std::string& value);
+ServiceResult ParseJsonObject(const std::optional<std::string>& raw, nlohmann::json& out);
+ServiceResult ValidateDecodedImage(const std::vector<uint8_t>& image, std::int64_t max_pixels);
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -1,21 +1,9 @@
 #include "application/server_facade.h"
 
-#include "chromaprint3d/calib.h"
-#include "chromaprint3d/image_io.h"
+#include "application/json_serialization.h"
+
 #include "chromaprint3d/pipeline.h"
-#include "chromaprint3d/print_profile.h"
-#include "chromaprint3d/shape_width_analyzer.h"
-#include "chromaprint3d/slicer_preset.h"
 #include "chromaprint3d/version.h"
-
-#include <opencv2/imgcodecs.hpp>
-#include <spdlog/spdlog.h>
-
-#include <algorithm>
-#include <cctype>
-#include <filesystem>
-#include <stdexcept>
-#include <unordered_set>
 
 namespace chromaprint3d::backend {
 
@@ -23,122 +11,19 @@ using json = nlohmann::json;
 using namespace ChromaPrint3D;
 using neroued::vectorizer::VectorizerConfig;
 
-namespace {
-
-std::string ToLowerAscii(std::string value) {
-    std::transform(value.begin(), value.end(), value.begin(),
-                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return value;
-}
-
-ColorSpace ParseColorSpace(const std::string& value) {
-    const std::string lowered = ToLowerAscii(value);
-    if (lowered == "lab") return ColorSpace::Lab;
-    if (lowered == "rgb") return ColorSpace::Rgb;
-    throw std::runtime_error("Invalid color_space: " + value);
-}
-
-ClusterMethod ParseClusterMethod(const std::string& value) {
-    const std::string lowered = ToLowerAscii(value);
-    if (lowered == "slic") return ClusterMethod::Slic;
-    if (lowered == "kmeans" || lowered == "k_means" || lowered == "k-means") {
-        return ClusterMethod::KMeans;
-    }
-    throw std::runtime_error("Invalid cluster_method: " + value);
-}
-
-const char* ClusterMethodToString(ClusterMethod method) {
-    switch (method) {
-    case ClusterMethod::Slic:
-        return "slic";
-    case ClusterMethod::KMeans:
-        return "kmeans";
-    }
-    return "slic";
-}
-
-std::string StripExtension(const std::string& filename) {
-    auto dot = filename.rfind('.');
-    if (dot == std::string::npos) return filename;
-    return filename.substr(0, dot);
-}
-
-const char* LayerOrderToString(LayerOrder order) {
-    return order == LayerOrder::Bottom2Top ? "Bottom2Top" : "Top2Bottom";
-}
-
-json LayerPreviewsToJson(const LayerPreviewResult& layer_previews) {
-    json palette = json::array();
-    for (const auto& channel : layer_previews.palette) {
-        palette.push_back({
-            {"channel_idx", channel.channel_idx},
-            {"color", channel.color},
-            {"material", channel.material},
-        });
-    }
-
-    json artifacts = json::array();
-    for (std::size_t i = 0; i < layer_previews.layer_pngs.size(); ++i) {
-        artifacts.push_back("layer-preview-" + std::to_string(i));
-    }
-
-    return {
-        {"enabled", !layer_previews.layer_pngs.empty()},
-        {"layers", layer_previews.layers},
-        {"width", layer_previews.width},
-        {"height", layer_previews.height},
-        {"layer_order", LayerOrderToString(layer_previews.layer_order)},
-        {"palette", std::move(palette)},
-        {"artifacts", std::move(artifacts)},
-    };
-}
-
-std::string NormalizeLabel(const std::string& s) {
-    std::string out;
-    out.reserve(s.size());
-    for (unsigned char c : s) {
-        if (std::isalnum(c)) { out.push_back(static_cast<char>(std::tolower(c))); }
-    }
-    return out;
-}
-
-std::string NormalizeChannelKey(const Channel& ch) {
-    return NormalizeLabel(ch.color) + "|" + NormalizeLabel(ch.material);
-}
-
-std::vector<std::string> BuildProfileChannelKeys(const std::vector<const ColorDB*>& dbs) {
-    std::unordered_set<std::string> keys;
-    for (const auto* db : dbs) {
-        for (const auto& ch : db->palette) { keys.insert(NormalizeChannelKey(ch)); }
-    }
-    return {keys.begin(), keys.end()};
-}
-
-} // namespace
-
-ServiceResult ServiceResult::Success(int status, json d) {
-    ServiceResult r;
-    r.ok          = true;
-    r.status_code = status;
-    r.data        = std::move(d);
-    return r;
-}
-
-ServiceResult ServiceResult::Error(int status, std::string c, std::string m) {
-    ServiceResult r;
-    r.ok          = false;
-    r.status_code = status;
-    r.code        = std::move(c);
-    r.message     = std::move(m);
-    return r;
-}
+// ---------------------------------------------------------------------------
+// Construction & session
+// ---------------------------------------------------------------------------
 
 ServerFacade::ServerFacade(ServerConfig cfg)
     : cfg_(std::move(cfg)), data_(cfg_),
       sessions_(cfg_.session_ttl_seconds, cfg_.max_session_colordbs),
       tasks_(cfg_.max_tasks, cfg_.max_task_queue, cfg_.task_ttl_seconds, cfg_.max_tasks_per_owner,
              cfg_.max_task_result_mb * 1024 * 1024, cfg_.data_dir),
-      boards_(cfg_.board_cache_ttl, cfg_.data_dir) {}
+      boards_(cfg_.board_cache_ttl, cfg_.data_dir), color_db_svc_(data_, sessions_),
+      task_svc_(tasks_), convert_svc_(cfg_, data_, sessions_, tasks_),
+      matting_svc_(cfg_, data_, tasks_), recipe_svc_(data_, tasks_),
+      calib_svc_(cfg_, data_, sessions_, boards_) {}
 
 std::string ServerFacade::EnsureSession(const std::optional<std::string>& existing_token,
                                         bool* created) {
@@ -148,6 +33,10 @@ std::string ServerFacade::EnsureSession(const std::optional<std::string>& existi
 std::optional<SessionSnapshot> ServerFacade::SessionSnapshotByToken(const std::string& token) {
     return sessions_.Snapshot(token);
 }
+
+// ---------------------------------------------------------------------------
+// Cross-domain queries (kept in facade)
+// ---------------------------------------------------------------------------
 
 ServiceResult ServerFacade::Health() const {
     return ServiceResult::Success(200, {
@@ -224,634 +113,6 @@ ServiceResult ServerFacade::VectorizeDefaults() const {
                                        });
 }
 
-ServiceResult ServerFacade::ListDatabases(const std::optional<std::string>& session_token) {
-    json arr = json::array();
-    for (const auto& entry : data_.ColorDbCache().databases) {
-        auto j      = ColorDbInfoToJson(entry.db, entry.material_type, entry.vendor);
-        j["source"] = "global";
-        arr.push_back(std::move(j));
-    }
-    if (session_token && !session_token->empty()) {
-        auto dbs = sessions_.ListSessionDbs(*session_token);
-        for (const auto& db : dbs) {
-            auto j      = ColorDbInfoToJson(db);
-            j["source"] = "session";
-            arr.push_back(std::move(j));
-        }
-    }
-    return ServiceResult::Success(200, {{"databases", std::move(arr)}});
-}
-
-ServiceResult ServerFacade::ListSessionDatabases(const std::string& token) {
-    if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    json arr = json::array();
-    for (const auto& db : sessions_.ListSessionDbs(token)) {
-        auto j      = ColorDbInfoToJson(db);
-        j["source"] = "session";
-        arr.push_back(std::move(j));
-    }
-    return ServiceResult::Success(200, {{"databases", std::move(arr)}});
-}
-
-ServiceResult ServerFacade::UploadSessionDatabase(const std::string& token,
-                                                  const std::string& json_content,
-                                                  const std::optional<std::string>& override_name) {
-    if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-
-    ColorDB db;
-    try {
-        db = ColorDB::FromJsonString(json_content);
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(400, "invalid_colordb",
-                                    "Invalid ColorDB JSON: " + std::string(e.what()));
-    }
-    if (override_name && !override_name->empty()) db.name = *override_name;
-    if (!SessionStore::IsValidDbName(db.name)) {
-        return ServiceResult::Error(400, "invalid_name",
-                                    "ColorDB name must be [a-zA-Z0-9_], length 1-64");
-    }
-    if (data_.ColorDbCache().FindByName(db.name)) {
-        return ServiceResult::Error(409, "name_conflict", "Name conflicts with global database");
-    }
-    std::string err;
-    if (!sessions_.PutSessionDb(token, db, &err)) {
-        return ServiceResult::Error(429, "session_limit", err);
-    }
-    auto out      = ColorDbInfoToJson(db);
-    out["source"] = "session";
-    return ServiceResult::Success(200, std::move(out));
-}
-
-ServiceResult ServerFacade::DeleteSessionDatabase(const std::string& token,
-                                                  const std::string& name) {
-    if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto existing = sessions_.GetSessionDb(token, name);
-    if (!existing) return ServiceResult::Error(404, "not_found", "ColorDB not found in session");
-    sessions_.RemoveSessionDb(token, name);
-    return ServiceResult::Success(200, {{"deleted", true}});
-}
-
-ServiceResult ServerFacade::DownloadSessionDatabase(const std::string& token,
-                                                    const std::string& name, std::string& json_out,
-                                                    std::string& filename_out) {
-    if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto existing = sessions_.GetSessionDb(token, name);
-    if (!existing) return ServiceResult::Error(404, "not_found", "ColorDB not found in session");
-    json_out     = existing->ToJsonString();
-    filename_out = name + ".json";
-    return ServiceResult::Success(200, json::object());
-}
-
-ServiceResult ServerFacade::SubmitConvertRaster(const std::string& owner,
-                                                const std::vector<uint8_t>& image,
-                                                const std::string& image_name,
-                                                const std::optional<std::string>& params_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto accept = tasks_.CanAccept(owner);
-    if (!accept.ok) {
-        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
-    }
-    auto valid = ValidateDecodedImage(image);
-    if (!valid.ok) return valid;
-
-    json params;
-    auto parsed = ParseJsonObject(params_json, params);
-    if (!parsed.ok) return parsed;
-
-    auto session = sessions_.Snapshot(owner);
-
-    ConvertRasterRequest req;
-    auto built = BuildRasterRequest(params, image, image_name, session, req);
-    if (!built.ok) return built;
-
-    auto submit = tasks_.SubmitConvertRaster(owner, std::move(req), StripExtension(image_name));
-    if (!submit.ok) {
-        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
-    }
-    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "convert"}});
-}
-
-ServiceResult ServerFacade::SubmitConvertVector(const std::string& owner,
-                                                const std::vector<uint8_t>& svg,
-                                                const std::string& svg_name,
-                                                const std::optional<std::string>& params_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto accept = tasks_.CanAccept(owner);
-    if (!accept.ok) {
-        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
-    }
-
-    json params;
-    auto parsed = ParseJsonObject(params_json, params);
-    if (!parsed.ok) return parsed;
-    auto session = sessions_.Snapshot(owner);
-
-    ConvertVectorRequest req;
-    auto built = BuildVectorRequest(params, svg, svg_name, session, req);
-    if (!built.ok) return built;
-
-    auto submit = tasks_.SubmitConvertVector(owner, std::move(req), StripExtension(svg_name));
-    if (!submit.ok) {
-        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
-    }
-    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "convert"}});
-}
-
-ServiceResult ServerFacade::AnalyzeVectorWidth(const std::vector<uint8_t>& svg,
-                                               const std::optional<std::string>& params_json) {
-    if (svg.empty()) { return ServiceResult::Error(400, "invalid_request", "SVG buffer is empty"); }
-
-    json params;
-    auto parsed = ParseJsonObject(params_json, params);
-    if (!parsed.ok) return parsed;
-
-    float min_area       = params.value("min_area_mm2", 1.0f);
-    float min_area_ratio = params.value("min_area_ratio", 0.001f);
-    float raster_res     = params.value("raster_px_per_mm", 10.0f);
-
-    VectorProcConfig vpc;
-    vpc.flip_y = params.value("flip_y", false);
-
-    try {
-        VectorProc vproc(vpc);
-        auto vpr = vproc.RunFromBuffer(svg, "analyze");
-
-        float total_area         = vpr.width_mm * vpr.height_mm;
-        float effective_min_area = std::max(min_area, min_area_ratio * total_area);
-        auto analysis            = AnalyzeShapeWidths(vpr, effective_min_area, raster_res);
-
-        json shapes_json = json::array();
-        for (const auto& s : analysis.shapes) {
-            uint8_t r8, g8, b8;
-            s.color.ToRgb255(r8, g8, b8);
-            char hex[8];
-            std::snprintf(hex, sizeof(hex), "#%02X%02X%02X", r8, g8, b8);
-
-            shapes_json.push_back({
-                {"index", s.index},
-                {"color", std::string(hex)},
-                {"area_mm2", std::round(s.area_mm2 * 100.0f) / 100.0f},
-                {"min_width_mm", std::round(s.min_width_mm * 1000.0f) / 1000.0f},
-                {"median_width_mm", std::round(s.median_width_mm * 1000.0f) / 1000.0f},
-            });
-        }
-
-        return ServiceResult::Success(
-            200, {
-                     {"image_width_mm", analysis.image_width_mm},
-                     {"image_height_mm", analysis.image_height_mm},
-                     {"total_shapes", analysis.total_shapes},
-                     {"filtered_count", analysis.filtered_count},
-                     {"min_area_threshold_mm2", analysis.min_area_threshold_mm2},
-                     {"shapes", shapes_json},
-                 });
-    } catch (const std::exception& e) {
-        spdlog::error("AnalyzeVectorWidth failed: {}", e.what());
-        return ServiceResult::Error(500, "analysis_failed", e.what());
-    }
-}
-
-ServiceResult ServerFacade::SubmitMatting(const std::string& owner,
-                                          const std::vector<uint8_t>& image,
-                                          const std::string& image_name,
-                                          const std::string& method) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto accept = tasks_.CanAccept(owner);
-    if (!accept.ok) {
-        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
-    }
-    auto valid = ValidateDecodedImage(image);
-    if (!valid.ok) return valid;
-
-    if (!data_.MattingRegistry().Has(method)) {
-        return ServiceResult::Error(400, "invalid_method", "Unknown matting method: " + method);
-    }
-    auto submit = tasks_.SubmitMatting(owner, image, method, StripExtension(image_name),
-                                       data_.MattingRegistry());
-    if (!submit.ok) {
-        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
-    }
-    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "matting"}});
-}
-
-ServiceResult ServerFacade::PostprocessMatting(const std::string& owner, const std::string& task_id,
-                                               const std::string& body_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-
-    json body;
-    try {
-        body = json::parse(body_json);
-    } catch (const json::parse_error& e) {
-        return ServiceResult::Error(400, "invalid_json",
-                                    std::string("JSON parse error: ") + e.what());
-    }
-    if (!body.is_object()) {
-        return ServiceResult::Error(400, "invalid_json", "Expected JSON object");
-    }
-
-    ChromaPrint3D::MattingPostprocessParams params;
-    if (body.contains("threshold")) params.threshold = body["threshold"].get<float>();
-    if (body.contains("morph_close_size"))
-        params.morph_close_size = body["morph_close_size"].get<int>();
-    if (body.contains("morph_close_iterations"))
-        params.morph_close_iterations = body["morph_close_iterations"].get<int>();
-    if (body.contains("min_region_area"))
-        params.min_region_area = body["min_region_area"].get<int>();
-    if (body.contains("reframe")) {
-        const auto& rf = body["reframe"];
-        if (!rf.is_object()) {
-            return ServiceResult::Error(400, "invalid_params", "reframe must be an object");
-        }
-        if (rf.contains("enabled")) params.reframe_enabled = rf["enabled"].get<bool>();
-        if (rf.contains("padding_px")) params.reframe_padding_px = rf["padding_px"].get<int>();
-    }
-    if (body.contains("outline") && body["outline"].is_object()) {
-        const auto& ol = body["outline"];
-        if (ol.contains("enabled")) params.outline_enabled = ol["enabled"].get<bool>();
-        if (ol.contains("width")) params.outline_width = ol["width"].get<int>();
-        if (ol.contains("color") && ol["color"].is_array() && ol["color"].size() == 3) {
-            params.outline_color = {ol["color"][0].get<uint8_t>(), ol["color"][1].get<uint8_t>(),
-                                    ol["color"][2].get<uint8_t>()};
-        }
-        if (ol.contains("mode")) {
-            auto mode_str = ol["mode"].get<std::string>();
-            if (mode_str == "inner")
-                params.outline_mode = ChromaPrint3D::OutlineMode::Inner;
-            else if (mode_str == "outer")
-                params.outline_mode = ChromaPrint3D::OutlineMode::Outer;
-            else
-                params.outline_mode = ChromaPrint3D::OutlineMode::Center;
-        }
-    }
-    if (params.reframe_padding_px < 0 || params.reframe_padding_px > 4096) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "reframe.padding_px must be in [0,4096]");
-    }
-
-    int status          = 500;
-    std::string message = "Unknown error";
-    bool ok             = tasks_.PostprocessMatting(owner, task_id, params, status, message);
-    if (!ok) return ServiceResult::Error(status, "postprocess_failed", message);
-
-    json artifacts = json::array({"processed-mask", "processed-foreground"});
-    if (params.outline_enabled) artifacts.push_back("outline");
-
-    return ServiceResult::Success(200, {{"artifacts", std::move(artifacts)}});
-}
-
-ServiceResult ServerFacade::SubmitVectorize(const std::string& owner,
-                                            const std::vector<uint8_t>& image,
-                                            const std::string& image_name,
-                                            const std::optional<std::string>& params_json) {
-    const auto params_bytes = params_json.has_value() ? params_json->size() : 0U;
-    spdlog::info("SubmitVectorize requested: image='{}', bytes={}, params_bytes={}, owner_len={}",
-                 image_name, image.size(), params_bytes, owner.size());
-    if (owner.empty()) {
-        spdlog::warn("SubmitVectorize rejected: no session");
-        return ServiceResult::Error(401, "unauthorized", "No session");
-    }
-    auto accept = tasks_.CanAccept(owner);
-    if (!accept.ok) {
-        spdlog::warn("SubmitVectorize rejected by queue gate: status={}, reason={}",
-                     accept.status_code, accept.message);
-        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
-    }
-    auto valid = ValidateDecodedImage(image);
-    if (!valid.ok) {
-        spdlog::warn("SubmitVectorize rejected: invalid image, status={}, reason={}",
-                     valid.status_code, valid.message);
-        return valid;
-    }
-
-    json params;
-    auto parsed = ParseJsonObject(params_json, params);
-    if (!parsed.ok) {
-        spdlog::warn("SubmitVectorize rejected: invalid params json, status={}, reason={}",
-                     parsed.status_code, parsed.message);
-        return parsed;
-    }
-
-    VectorizerConfig cfg;
-    auto built = BuildVectorizeConfig(params, cfg);
-    if (!built.ok) {
-        spdlog::warn("SubmitVectorize rejected: invalid vectorize config, status={}, reason={}",
-                     built.status_code, built.message);
-        return built;
-    }
-    spdlog::debug(
-        "SubmitVectorize config: num_colors={}, min_region_area={}, curve_fit_error={:.3f}, "
-        "corner_angle_threshold={:.1f}, smoothing_spatial={:.1f}, smoothing_color={:.1f}, "
-        "upscale_short_edge={}, max_working_pixels={}, slic_region_size={}, "
-        "edge_sensitivity={:.2f}, refine_passes={}, max_merge_color_dist={:.1f}, "
-        "svg_enable_stroke={}, svg_stroke_width={:.2f}",
-        cfg.num_colors, cfg.min_region_area, cfg.curve_fit_error, cfg.corner_angle_threshold,
-        cfg.smoothing_spatial, cfg.smoothing_color, cfg.upscale_short_edge, cfg.max_working_pixels,
-        cfg.slic_region_size, cfg.edge_sensitivity, cfg.refine_passes, cfg.max_merge_color_dist,
-        cfg.svg_enable_stroke, cfg.svg_stroke_width);
-
-    auto submit = tasks_.SubmitVectorize(owner, image, cfg, StripExtension(image_name));
-    if (!submit.ok) {
-        spdlog::warn("SubmitVectorize failed to enqueue: status={}, reason={}", submit.status_code,
-                     submit.message);
-        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
-    }
-    spdlog::info("SubmitVectorize accepted: task_id={}, image='{}'", submit.task_id, image_name);
-    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "vectorize"}});
-}
-
-ServiceResult ServerFacade::SubmitConvertRasterMatchOnly(
-    const std::string& owner, const std::vector<uint8_t>& image, const std::string& image_name,
-    const std::optional<std::string>& params_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto accept = tasks_.CanAccept(owner);
-    if (!accept.ok) {
-        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
-    }
-    auto valid = ValidateDecodedImage(image);
-    if (!valid.ok) return valid;
-
-    json params;
-    auto parsed = ParseJsonObject(params_json, params);
-    if (!parsed.ok) return parsed;
-
-    auto session = sessions_.Snapshot(owner);
-
-    ConvertRasterRequest req;
-    auto built = BuildRasterRequest(params, image, image_name, session, req);
-    if (!built.ok) return built;
-
-    if (req.dither != ChromaPrint3D::DitherMethod::None) {
-        return ServiceResult::Error(400, "invalid_request", "Recipe editing requires dither=None");
-    }
-
-    auto submit =
-        tasks_.SubmitConvertRasterMatchOnly(owner, std::move(req), StripExtension(image_name));
-    if (!submit.ok) {
-        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
-    }
-    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "convert"}});
-}
-
-ServiceResult ServerFacade::SubmitConvertVectorMatchOnly(
-    const std::string& owner, const std::vector<uint8_t>& svg, const std::string& svg_name,
-    const std::optional<std::string>& params_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto accept = tasks_.CanAccept(owner);
-    if (!accept.ok) {
-        return ServiceResult::Error(accept.status_code, "queue_rejected", accept.message);
-    }
-
-    json params;
-    auto parsed = ParseJsonObject(params_json, params);
-    if (!parsed.ok) return parsed;
-    auto session = sessions_.Snapshot(owner);
-
-    ConvertVectorRequest req;
-    auto built = BuildVectorRequest(params, svg, svg_name, session, req);
-    if (!built.ok) return built;
-
-    auto submit =
-        tasks_.SubmitConvertVectorMatchOnly(owner, std::move(req), StripExtension(svg_name));
-    if (!submit.ok) {
-        return ServiceResult::Error(submit.status_code, "submit_failed", submit.message);
-    }
-    return ServiceResult::Success(202, {{"task_id", submit.task_id}, {"kind", "convert"}});
-}
-
-ServiceResult ServerFacade::RecipeEditorSummary(const std::string& owner,
-                                                const std::string& task_id) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto summary = tasks_.GetRecipeEditorSummary(owner, task_id);
-    if (!summary) return ServiceResult::Error(404, "not_found", "Summary not available");
-    return ServiceResult::Success(200, std::move(*summary));
-}
-
-ServiceResult ServerFacade::RecipeEditorAlternatives(const std::string& owner,
-                                                     const std::string& task_id,
-                                                     const std::string& body_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-
-    json body;
-    try {
-        body = json::parse(body_json);
-    } catch (...) { return ServiceResult::Error(400, "invalid_request", "Invalid JSON body"); }
-
-    if (!body.contains("target_lab") || !body["target_lab"].is_object()) {
-        return ServiceResult::Error(400, "invalid_request", "Missing target_lab");
-    }
-    const auto& tlab = body["target_lab"];
-    ChromaPrint3D::Lab target(tlab.value("L", 0.0f), tlab.value("a", 0.0f), tlab.value("b", 0.0f));
-
-    int max_candidates = body.value("max_candidates", 10);
-    int offset         = body.value("offset", 0);
-
-    std::string recipe_pattern = body.value("recipe_pattern", std::string{});
-
-    const ChromaPrint3D::ModelPackage* model_pack = nullptr;
-    if (!data_.ModelPackRegistry().Empty()) {
-        // For recipe alternatives, pick the first available pack as a best-effort match.
-        // A more precise selection would require per-task vendor/material tracking.
-        model_pack = &data_.ModelPackRegistry().All().front();
-    }
-
-    auto result = tasks_.QueryRecipeAlternatives(owner, task_id, target, max_candidates, offset,
-                                                 model_pack, recipe_pattern);
-    if (!result) return ServiceResult::Error(404, "not_found", "Alternatives not available");
-    return ServiceResult::Success(200, {{"candidates", std::move(*result)}});
-}
-
-ServiceResult ServerFacade::RecipeEditorReplace(const std::string& owner,
-                                                const std::string& task_id,
-                                                const std::string& body_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-
-    json body;
-    try {
-        body = json::parse(body_json);
-    } catch (...) { return ServiceResult::Error(400, "invalid_request", "Invalid JSON body"); }
-
-    if (!body.contains("region_ids") || !body["region_ids"].is_array()) {
-        return ServiceResult::Error(400, "invalid_request", "Missing region_ids array");
-    }
-    if (!body.contains("new_recipe") || !body["new_recipe"].is_array()) {
-        return ServiceResult::Error(400, "invalid_request", "Missing new_recipe array");
-    }
-    if (!body.contains("new_mapped_lab") || !body["new_mapped_lab"].is_object()) {
-        return ServiceResult::Error(400, "invalid_request", "Missing new_mapped_lab");
-    }
-
-    std::vector<int> region_ids;
-    for (const auto& v : body["region_ids"]) { region_ids.push_back(v.get<int>()); }
-
-    std::vector<uint8_t> new_recipe;
-    for (const auto& v : body["new_recipe"]) { new_recipe.push_back(v.get<uint8_t>()); }
-
-    const auto& lab_obj = body["new_mapped_lab"];
-    ChromaPrint3D::Lab new_mapped(lab_obj.value("L", 0.0f), lab_obj.value("a", 0.0f),
-                                  lab_obj.value("b", 0.0f));
-
-    bool new_from_model = body.value("from_model", false);
-
-    int status          = 500;
-    std::string message = "Unknown error";
-    json out_summary;
-    bool ok = tasks_.ReplaceRecipe(owner, task_id, region_ids, new_recipe, new_mapped,
-                                   new_from_model, status, message, out_summary);
-    if (!ok) return ServiceResult::Error(status, "replace_failed", message);
-    return ServiceResult::Success(200, std::move(out_summary));
-}
-
-ServiceResult ServerFacade::RecipeEditorGenerate(const std::string& owner,
-                                                 const std::string& task_id) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-
-    auto submit = tasks_.SubmitGenerateModel(owner, task_id);
-    if (!submit.ok) {
-        return ServiceResult::Error(submit.status_code, "generate_failed", submit.message);
-    }
-    return ServiceResult::Success(202, {{"task_id", submit.task_id}});
-}
-
-ServiceResult ServerFacade::RecipeEditorPredict(const std::string& owner,
-                                                const std::string& task_id,
-                                                const std::string& body_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-
-    json body;
-    try {
-        body = json::parse(body_json);
-    } catch (...) { return ServiceResult::Error(400, "invalid_json", "Cannot parse request body"); }
-    if (!body.contains("recipe") || !body["recipe"].is_array()) {
-        return ServiceResult::Error(400, "invalid_params", "Missing recipe array");
-    }
-
-    std::vector<int> palette_recipe;
-    for (const auto& v : body["recipe"]) {
-        if (!v.is_number_integer()) {
-            return ServiceResult::Error(400, "invalid_params", "Recipe must be array of integers");
-        }
-        palette_recipe.push_back(v.get<int>());
-    }
-    if (palette_recipe.empty()) {
-        return ServiceResult::Error(400, "invalid_params", "Recipe cannot be empty");
-    }
-
-    auto profile_opt = tasks_.GetTaskPrintProfile(owner, task_id);
-    if (!profile_opt) {
-        return ServiceResult::Error(404, "not_found", "Task not found or not in recipe-edit mode");
-    }
-    const auto& profile = *profile_opt;
-
-    auto db_names_opt = tasks_.GetTaskColorDbNames(owner, task_id);
-    std::string common_vendor, common_material;
-    if (db_names_opt) {
-        bool all_same = true;
-        for (const auto& name : *db_names_opt) {
-            const auto* entry = data_.ColorDbCache().FindEntryByName(name);
-            if (!entry) continue;
-            if (common_vendor.empty()) {
-                common_vendor   = entry->vendor;
-                common_material = entry->material_type;
-            } else if (entry->vendor != common_vendor || entry->material_type != common_material) {
-                all_same = false;
-                break;
-            }
-        }
-        if (!all_same) {
-            common_vendor.clear();
-            common_material.clear();
-        }
-    }
-
-    std::vector<std::string> profile_channel_keys;
-    for (const auto& ch : profile.palette) {
-        profile_channel_keys.push_back(NormalizeChannelKey(ch));
-    }
-
-    const auto* model =
-        data_.ForwardModels().Select(common_vendor, common_material, profile_channel_keys);
-    if (!model) {
-        return ServiceResult::Error(501, "no_forward_model",
-                                    "No forward model available for this task's material scope");
-    }
-
-    std::vector<int> stage_recipe;
-    stage_recipe.reserve(palette_recipe.size());
-    for (int pidx : palette_recipe) {
-        if (pidx < 0 || pidx >= static_cast<int>(profile.palette.size())) {
-            return ServiceResult::Error(400, "invalid_params",
-                                        "Recipe channel index out of palette range");
-        }
-        int stage_idx = model->MapChannelByName(profile.palette[pidx].color);
-        if (stage_idx < 0) {
-            return ServiceResult::Error(400, "channel_mapping_failed",
-                                        "Cannot map palette channel '" +
-                                            profile.palette[pidx].color +
-                                            "' to forward model stage channel");
-        }
-        stage_recipe.push_back(stage_idx);
-    }
-
-    int base_stage_idx = 0;
-    if (profile.base_channel_idx >= 0 &&
-        profile.base_channel_idx < static_cast<int>(profile.palette.size())) {
-        int mapped = model->MapChannelByName(profile.palette[profile.base_channel_idx].color);
-        if (mapped >= 0) base_stage_idx = mapped;
-    }
-
-    ChromaPrint3D::PredictionConfig cfg;
-    cfg.layer_height_mm  = profile.layer_height_mm;
-    cfg.base_channel_idx = base_stage_idx;
-    cfg.layer_order      = profile.layer_order;
-    cfg.substrate_idx    = model->ResolveSubstrateIdx(base_stage_idx);
-
-    ChromaPrint3D::Lab predicted = model->PredictLab(stage_recipe, cfg);
-
-    uint8_t r8, g8, b8;
-    predicted.ToRgb().ToRgb255(r8, g8, b8);
-    char hex[8];
-    std::snprintf(hex, sizeof(hex), "#%02X%02X%02X", r8, g8, b8);
-
-    return ServiceResult::Success(
-        200, {{"predicted_lab", {{"L", predicted.l()}, {"a", predicted.a()}, {"b", predicted.b()}}},
-              {"hex", std::string(hex)},
-              {"from_model", true}});
-}
-
-ServiceResult ServerFacade::ListTasks(const std::string& owner) const {
-    if (owner.empty()) return ServiceResult::Success(200, {{"tasks", json::array()}});
-    json tasks = json::array();
-    for (const auto& t : tasks_.ListTasks(owner)) tasks.push_back(TaskToJson(t));
-    return ServiceResult::Success(200, {{"tasks", std::move(tasks)}});
-}
-
-ServiceResult ServerFacade::GetTask(const std::string& owner, const std::string& id) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto task = tasks_.FindTask(owner, id);
-    if (!task) return ServiceResult::Error(404, "not_found", "Task not found");
-    return ServiceResult::Success(200, TaskToJson(*task));
-}
-
-ServiceResult ServerFacade::DeleteTask(const std::string& owner, const std::string& id) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    int status          = 500;
-    std::string message = "Unknown error";
-    bool ok             = tasks_.DeleteTask(owner, id, status, message);
-    if (!ok) return ServiceResult::Error(status, "delete_failed", message);
-    return ServiceResult::Success(200, {{"deleted", true}});
-}
-
-ServiceResult ServerFacade::DownloadTaskArtifact(const std::string& owner, const std::string& id,
-                                                 const std::string& artifact, TaskArtifact& out) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    int status          = 500;
-    std::string message = "Unknown error";
-    auto data           = tasks_.LoadArtifact(owner, id, artifact, status, message);
-    if (!data) return ServiceResult::Error(status, "artifact_error", message);
-    out = std::move(*data);
-    return ServiceResult::Success(200, json::object());
-}
-
 json ServerFacade::GetModelPackInfo() const {
     json packs = json::array();
     for (const auto& pack : data_.ModelPackRegistry().All()) {
@@ -888,1029 +149,176 @@ ServiceResult ServerFacade::MattingMethods() const {
     return ServiceResult::Success(200, {{"methods", std::move(arr)}});
 }
 
+// ---------------------------------------------------------------------------
+// ColorDB delegation
+// ---------------------------------------------------------------------------
+
+ServiceResult ServerFacade::ListDatabases(const std::optional<std::string>& session_token) {
+    return color_db_svc_.ListDatabases(session_token);
+}
+
+ServiceResult ServerFacade::ListSessionDatabases(const std::string& token) {
+    return color_db_svc_.ListSessionDatabases(token);
+}
+
+ServiceResult ServerFacade::UploadSessionDatabase(const std::string& token,
+                                                  const std::string& json_content,
+                                                  const std::optional<std::string>& override_name) {
+    return color_db_svc_.UploadSessionDatabase(token, json_content, override_name);
+}
+
+ServiceResult ServerFacade::DeleteSessionDatabase(const std::string& token,
+                                                  const std::string& name) {
+    return color_db_svc_.DeleteSessionDatabase(token, name);
+}
+
+ServiceResult ServerFacade::DownloadSessionDatabase(const std::string& token,
+                                                    const std::string& name, std::string& json_out,
+                                                    std::string& filename_out) {
+    return color_db_svc_.DownloadSessionDatabase(token, name, json_out, filename_out);
+}
+
+// ---------------------------------------------------------------------------
+// Convert delegation
+// ---------------------------------------------------------------------------
+
+ServiceResult ServerFacade::SubmitConvertRaster(const std::string& owner,
+                                                const std::vector<uint8_t>& image,
+                                                const std::string& image_name,
+                                                const std::optional<std::string>& params_json) {
+    return convert_svc_.SubmitConvertRaster(owner, image, image_name, params_json);
+}
+
+ServiceResult ServerFacade::SubmitConvertVector(const std::string& owner,
+                                                const std::vector<uint8_t>& svg,
+                                                const std::string& svg_name,
+                                                const std::optional<std::string>& params_json) {
+    return convert_svc_.SubmitConvertVector(owner, svg, svg_name, params_json);
+}
+
+ServiceResult ServerFacade::AnalyzeVectorWidth(const std::vector<uint8_t>& svg,
+                                               const std::optional<std::string>& params_json) {
+    return convert_svc_.AnalyzeVectorWidth(svg, params_json);
+}
+
+ServiceResult ServerFacade::SubmitConvertRasterMatchOnly(
+    const std::string& owner, const std::vector<uint8_t>& image, const std::string& image_name,
+    const std::optional<std::string>& params_json) {
+    return convert_svc_.SubmitConvertRasterMatchOnly(owner, image, image_name, params_json);
+}
+
+ServiceResult ServerFacade::SubmitConvertVectorMatchOnly(
+    const std::string& owner, const std::vector<uint8_t>& svg, const std::string& svg_name,
+    const std::optional<std::string>& params_json) {
+    return convert_svc_.SubmitConvertVectorMatchOnly(owner, svg, svg_name, params_json);
+}
+
+// ---------------------------------------------------------------------------
+// Matting & vectorize delegation
+// ---------------------------------------------------------------------------
+
+ServiceResult ServerFacade::SubmitMatting(const std::string& owner,
+                                          const std::vector<uint8_t>& image,
+                                          const std::string& image_name,
+                                          const std::string& method) {
+    return matting_svc_.SubmitMatting(owner, image, image_name, method);
+}
+
+ServiceResult ServerFacade::PostprocessMatting(const std::string& owner, const std::string& task_id,
+                                               const std::string& body_json) {
+    return matting_svc_.PostprocessMatting(owner, task_id, body_json);
+}
+
+ServiceResult ServerFacade::SubmitVectorize(const std::string& owner,
+                                            const std::vector<uint8_t>& image,
+                                            const std::string& image_name,
+                                            const std::optional<std::string>& params_json) {
+    return matting_svc_.SubmitVectorize(owner, image, image_name, params_json);
+}
+
+// ---------------------------------------------------------------------------
+// Recipe editor delegation
+// ---------------------------------------------------------------------------
+
+ServiceResult ServerFacade::RecipeEditorSummary(const std::string& owner,
+                                                const std::string& task_id) {
+    return recipe_svc_.RecipeEditorSummary(owner, task_id);
+}
+
+ServiceResult ServerFacade::RecipeEditorAlternatives(const std::string& owner,
+                                                     const std::string& task_id,
+                                                     const std::string& body_json) {
+    return recipe_svc_.RecipeEditorAlternatives(owner, task_id, body_json);
+}
+
+ServiceResult ServerFacade::RecipeEditorReplace(const std::string& owner,
+                                                const std::string& task_id,
+                                                const std::string& body_json) {
+    return recipe_svc_.RecipeEditorReplace(owner, task_id, body_json);
+}
+
+ServiceResult ServerFacade::RecipeEditorGenerate(const std::string& owner,
+                                                 const std::string& task_id) {
+    return recipe_svc_.RecipeEditorGenerate(owner, task_id);
+}
+
+ServiceResult ServerFacade::RecipeEditorPredict(const std::string& owner,
+                                                const std::string& task_id,
+                                                const std::string& body_json) {
+    return recipe_svc_.RecipeEditorPredict(owner, task_id, body_json);
+}
+
+// ---------------------------------------------------------------------------
+// Task delegation
+// ---------------------------------------------------------------------------
+
+ServiceResult ServerFacade::ListTasks(const std::string& owner) const {
+    return task_svc_.ListTasks(owner);
+}
+
+ServiceResult ServerFacade::GetTask(const std::string& owner, const std::string& id) {
+    return task_svc_.GetTask(owner, id);
+}
+
+ServiceResult ServerFacade::DeleteTask(const std::string& owner, const std::string& id) {
+    return task_svc_.DeleteTask(owner, id);
+}
+
+ServiceResult ServerFacade::DownloadTaskArtifact(const std::string& owner, const std::string& id,
+                                                 const std::string& artifact, TaskArtifact& out) {
+    return task_svc_.DownloadTaskArtifact(owner, id, artifact, out);
+}
+
+// ---------------------------------------------------------------------------
+// Calibration delegation
+// ---------------------------------------------------------------------------
+
 ServiceResult ServerFacade::GenerateBoard(const json& body) {
-    if (!body.contains("palette") || !body["palette"].is_array()) {
-        return ServiceResult::Error(400, "invalid_request", "Missing or invalid 'palette' array");
-    }
-    CalibrationBoardConfig cfg;
-    auto& palette_arr       = body["palette"];
-    cfg.recipe.num_channels = static_cast<int>(palette_arr.size());
-    if (cfg.recipe.num_channels < CalibrationRecipeSpec::kMinChannels ||
-        cfg.recipe.num_channels > CalibrationRecipeSpec::kMaxChannels) {
-        return ServiceResult::Error(400, "invalid_request", "palette size must be 2-8");
-    }
-    cfg.palette.resize(palette_arr.size());
-    for (size_t i = 0; i < palette_arr.size(); ++i) {
-        const auto& ch          = palette_arr[i];
-        cfg.palette[i].color    = ch.value("color", "");
-        cfg.palette[i].material = ch.value("material", "PLA Basic");
-    }
-    if (body.contains("color_layers")) cfg.recipe.color_layers = body["color_layers"].get<int>();
-    if (body.contains("layer_height_mm")) {
-        cfg.layer_height_mm = body["layer_height_mm"].get<float>();
-    }
-
-    std::string raw_nozzle = body.value("nozzle_size", "n04");
-    std::string raw_face   = body.value("face_orientation", "faceup");
-    NozzleSize nozzle      = ParseNozzleSize(raw_nozzle);
-    FaceOrientation face   = ParseFaceOrientation(raw_face);
-    spdlog::info("GenerateBoard: nozzle_size='{}' -> {}, face_orientation='{}' -> {}", raw_nozzle,
-                 NozzleSizeTag(nozzle), raw_face, FaceOrientationTag(face));
-
-    auto presets_path = std::filesystem::path(cfg_.data_dir) / "presets";
-    bool has_preset   = std::filesystem::is_directory(presets_path);
-
-    try {
-        const int num_ch   = cfg.recipe.num_channels;
-        const int c_layers = cfg.recipe.color_layers;
-
-        CalibrationBoardResult result;
-        auto cached = boards_.FindGeometry(num_ch, c_layers);
-
-        if (has_preset) {
-            FilamentConfig fil_config = FilamentConfig::LoadFromDir(presets_path.string());
-            PrintProfile profile;
-            profile.layer_height_mm  = cfg.layer_height_mm;
-            profile.palette          = cfg.palette;
-            profile.nozzle_size      = nozzle;
-            profile.face_orientation = face;
-            for (size_t i = 0; i < profile.palette.size(); ++i) {
-                auto& ch = profile.palette[i];
-                if (ch.hex_color.empty()) {
-                    ch.hex_color = fil_config.ResolveHexColor(ch.color, static_cast<int>(i));
-                }
-            }
-            cfg.palette = profile.palette;
-            auto preset = SlicerPreset::FromProfile(presets_path.string(), profile, &fil_config);
-
-            if (cached) {
-                result = BuildResultFromMeshes(*cached, cfg.palette, preset, face);
-            } else {
-                auto meshes = GenCalibrationBoardMeshes(cfg);
-                result      = BuildResultFromMeshes(meshes, cfg.palette, preset, face);
-                boards_.StoreGeometry(num_ch, c_layers, std::move(meshes));
-            }
-        } else {
-            if (cached) {
-                result = BuildResultFromMeshes(*cached, cfg.palette, face);
-            } else {
-                auto meshes = GenCalibrationBoardMeshes(cfg);
-                result      = BuildResultFromMeshes(meshes, cfg.palette, face);
-                boards_.StoreGeometry(num_ch, c_layers, std::move(meshes));
-            }
-        }
-
-        std::string meta_str = result.meta.ToJsonString();
-        std::string board_id = boards_.StoreBoard(std::move(result));
-        return ServiceResult::Success(200,
-                                      {{"board_id", board_id}, {"meta", json::parse(meta_str)}});
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(500, "generate_failed", e.what());
-    }
+    return calib_svc_.GenerateBoard(body);
 }
 
 ServiceResult ServerFacade::Generate8ColorBoard(const json& body) {
-    if (!data_.RecipeStore().loaded) {
-        return ServiceResult::Error(503, "service_unavailable",
-                                    "8-color recipe data not available on server");
-    }
-    if (!body.contains("palette") || !body["palette"].is_array()) {
-        return ServiceResult::Error(400, "invalid_request", "Missing or invalid 'palette' array");
-    }
-    if (!body.contains("board_index") || !body["board_index"].is_number_integer()) {
-        return ServiceResult::Error(400, "invalid_request", "Missing or invalid 'board_index'");
-    }
-
-    auto& palette_arr = body["palette"];
-    const int num_ch  = static_cast<int>(palette_arr.size());
-    if (num_ch != data_.RecipeStore().num_channels) {
-        return ServiceResult::Error(400, "invalid_request",
-                                    "palette size must be " +
-                                        std::to_string(data_.RecipeStore().num_channels));
-    }
-
-    const int board_index = body["board_index"].get<int>();
-    const auto* board_set = data_.RecipeStore().FindBoard(board_index);
-    if (!board_set) {
-        return ServiceResult::Error(400, "invalid_request",
-                                    "Invalid board_index: " + std::to_string(board_index));
-    }
-
-    CalibrationBoardConfig cfg;
-    cfg.recipe.num_channels     = num_ch;
-    cfg.recipe.color_layers     = data_.RecipeStore().color_layers;
-    cfg.recipe.layer_order      = (data_.RecipeStore().layer_order == "Bottom2Top")
-                                      ? LayerOrder::Bottom2Top
-                                      : LayerOrder::Top2Bottom;
-    cfg.base_layers             = data_.RecipeStore().base_layers;
-    cfg.base_channel_idx        = data_.RecipeStore().base_channel_idx;
-    cfg.layer_height_mm         = data_.RecipeStore().layer_height_mm;
-    cfg.layout.line_width_mm    = data_.RecipeStore().layout.line_width_mm;
-    cfg.layout.resolution_scale = data_.RecipeStore().layout.resolution_scale;
-    cfg.layout.tile_factor      = data_.RecipeStore().layout.tile_factor;
-    cfg.layout.gap_factor       = data_.RecipeStore().layout.gap_factor;
-    cfg.layout.margin_factor    = data_.RecipeStore().layout.margin_factor;
-    cfg.palette.resize(palette_arr.size());
-    for (size_t i = 0; i < palette_arr.size(); ++i) {
-        const auto& ch          = palette_arr[i];
-        cfg.palette[i].color    = ch.value("color", "");
-        cfg.palette[i].material = ch.value("material", "PLA Basic");
-    }
-
-    std::string raw_nozzle = body.value("nozzle_size", "n04");
-    std::string raw_face   = body.value("face_orientation", "faceup");
-    NozzleSize nozzle      = ParseNozzleSize(raw_nozzle);
-    FaceOrientation face   = ParseFaceOrientation(raw_face);
-    spdlog::info("Generate8ColorBoard: nozzle_size='{}' -> {}, face_orientation='{}' -> {}",
-                 raw_nozzle, NozzleSizeTag(nozzle), raw_face, FaceOrientationTag(face));
-
-    auto presets_path = std::filesystem::path(cfg_.data_dir) / "presets";
-    bool has_preset   = std::filesystem::is_directory(presets_path);
-
-    try {
-        CalibrationBoardResult result;
-        auto cached = boards_.FindGeometry(num_ch, cfg.recipe.color_layers, board_index);
-
-        auto build_with_preset = [&](const CalibrationBoardMeshes& meshes_ref) {
-            if (has_preset) {
-                FilamentConfig fil_config = FilamentConfig::LoadFromDir(presets_path.string());
-                PrintProfile profile;
-                profile.layer_height_mm  = cfg.layer_height_mm;
-                profile.palette          = cfg.palette;
-                profile.nozzle_size      = nozzle;
-                profile.face_orientation = face;
-                for (size_t i = 0; i < profile.palette.size(); ++i) {
-                    auto& ch = profile.palette[i];
-                    if (ch.hex_color.empty()) {
-                        ch.hex_color = fil_config.ResolveHexColor(ch.color, static_cast<int>(i));
-                    }
-                }
-                cfg.palette = profile.palette;
-                auto preset =
-                    SlicerPreset::FromProfile(presets_path.string(), profile, &fil_config);
-                return BuildResultFromMeshes(meshes_ref, cfg.palette, preset, face);
-            }
-            return BuildResultFromMeshes(meshes_ref, cfg.palette, face);
-        };
-
-        if (cached) {
-            result = build_with_preset(*cached);
-        } else {
-            auto meta = BuildCalibrationBoardMetaCustom(cfg, board_set->grid_rows,
-                                                        board_set->grid_cols, board_set->recipes);
-            meta.name += "_board" + std::to_string(board_index);
-            auto meshes = GenCalibrationBoardMeshesFromMeta(std::move(meta));
-            result      = build_with_preset(meshes);
-            boards_.StoreGeometry(num_ch, cfg.recipe.color_layers, std::move(meshes), board_index);
-        }
-
-        std::string meta_str = result.meta.ToJsonString();
-        std::string board_id = boards_.StoreBoard(std::move(result));
-        return ServiceResult::Success(200,
-                                      {{"board_id", board_id}, {"meta", json::parse(meta_str)}});
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(500, "generate_failed", e.what());
-    }
+    return calib_svc_.Generate8ColorBoard(body);
 }
 
 ServiceResult ServerFacade::DownloadBoardModel(const std::string& board_id, TaskArtifact& out) {
-    auto board = boards_.FindBoard(board_id);
-    if (!board) return ServiceResult::Error(404, "not_found", "Board not found or expired");
-    std::string filename = board->meta.name.empty() ? "calibration_board" : board->meta.name;
-    filename += ".3mf";
-
-    constexpr const char* kModelContentType =
-        "application/vnd.ms-package.3dmanufacturing-3dmodel+xml";
-    if (board->has_file_backed_model()) {
-        const auto& fpath = board->model_3mf_path;
-        std::error_code ec;
-        bool exists      = std::filesystem::exists(fpath, ec);
-        auto actual_size = exists ? std::filesystem::file_size(fpath, ec) : 0ULL;
-        spdlog::debug("DownloadBoardModel: board={}, path={}, exists={}, actual_size={}, "
-                      "expected_size={}",
-                      board_id, fpath.string(), exists, actual_size, board->expected_file_size);
-        if (!exists) {
-            spdlog::error("DownloadBoardModel: file missing for board {}: {}", board_id,
-                          fpath.string());
-            return ServiceResult::Error(404, "not_found", "Board model file missing from disk");
-        }
-        if (board->expected_file_size > 0 && actual_size != board->expected_file_size) {
-            spdlog::error("DownloadBoardModel: file size mismatch for board {}: expected={}, "
-                          "actual={}",
-                          board_id, board->expected_file_size, actual_size);
-            return ServiceResult::Error(500, "corrupt_file",
-                                        "Board model file is incomplete or corrupt");
-        }
-        out = TaskArtifact{{}, fpath, kModelContentType, std::move(filename)};
-        return ServiceResult::Success(200, json::object());
-    }
-    if (board->model_3mf.empty()) {
-        return ServiceResult::Error(404, "not_found", "Board model not available");
-    }
-    out = TaskArtifact{std::move(board->model_3mf), {}, kModelContentType, std::move(filename)};
-    return ServiceResult::Success(200, json::object());
+    return calib_svc_.DownloadBoardModel(board_id, out);
 }
 
 ServiceResult ServerFacade::DownloadBoardMeta(const std::string& board_id, TaskArtifact& out) {
-    auto board = boards_.FindBoard(board_id);
-    if (!board) return ServiceResult::Error(404, "not_found", "Board not found or expired");
-    std::string filename =
-        board->meta.name.empty() ? "calibration_board_meta" : board->meta.name + "_meta";
-    filename += ".json";
-    auto meta_json = board->meta.ToJsonString();
-    std::vector<uint8_t> bytes(meta_json.begin(), meta_json.end());
-    TaskArtifact artifact;
-    artifact.bytes        = std::move(bytes);
-    artifact.content_type = "application/json";
-    artifact.filename     = std::move(filename);
-    out                   = std::move(artifact);
-    return ServiceResult::Success(200, json::object());
+    return calib_svc_.DownloadBoardMeta(board_id, out);
 }
 
 ServiceResult ServerFacade::LocateBoard(const std::vector<uint8_t>& image,
                                         const std::string& meta_json) {
-    auto valid = ValidateDecodedImage(image);
-    if (!valid.ok) return valid;
-
-    CalibrationBoardMeta meta;
-    try {
-        meta = CalibrationBoardMeta::FromJsonString(meta_json);
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(400, "invalid_meta",
-                                    "Invalid meta JSON: " + std::string(e.what()));
-    }
-
-    try {
-        auto result      = LocateCalibrationBoard(image, meta);
-        json corners_arr = json::array();
-        for (const auto& c : result.corners) { corners_arr.push_back(json::array({c[0], c[1]})); }
-        json out            = json::object();
-        out["corners"]      = std::move(corners_arr);
-        out["image_width"]  = result.image_width;
-        out["image_height"] = result.image_height;
-        return ServiceResult::Success(200, std::move(out));
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(422, "locate_failed", e.what());
-    }
+    return calib_svc_.LocateBoard(image, meta_json);
 }
 
 ServiceResult ServerFacade::BuildColorDb(const std::string& owner,
                                          const std::vector<uint8_t>& image,
                                          const std::string& meta_json, const std::string& db_name,
                                          const std::string& corners_json) {
-    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
-    auto valid = ValidateDecodedImage(image);
-    if (!valid.ok) return valid;
-    if (!SessionStore::IsValidDbName(db_name)) {
-        return ServiceResult::Error(400, "invalid_name",
-                                    "Invalid ColorDB name ([a-zA-Z0-9_], length 1-64)");
-    }
-    if (data_.ColorDbCache().FindByName(db_name)) {
-        return ServiceResult::Error(409, "name_conflict", "Name conflicts with global database");
-    }
-
-    CalibrationBoardMeta meta;
-    try {
-        meta = CalibrationBoardMeta::FromJsonString(meta_json);
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(400, "invalid_meta",
-                                    "Invalid meta JSON: " + std::string(e.what()));
-    }
-
-    std::optional<std::array<std::array<float, 2>, 4>> corners_opt;
-    if (!corners_json.empty()) {
-        try {
-            auto j = json::parse(corners_json);
-            if (!j.is_array() || j.size() != 4) {
-                return ServiceResult::Error(400, "invalid_corners",
-                                            "corners must be an array of 4 [x,y] pairs");
-            }
-            std::array<std::array<float, 2>, 4> pts;
-            for (size_t i = 0; i < 4; ++i) {
-                if (!j[i].is_array() || j[i].size() != 2) {
-                    return ServiceResult::Error(400, "invalid_corners",
-                                                "Each corner must be [x, y]");
-                }
-                pts[i] = {j[i][0].get<float>(), j[i][1].get<float>()};
-            }
-            corners_opt = pts;
-        } catch (const json::exception& e) {
-            return ServiceResult::Error(400, "invalid_corners",
-                                        "Failed to parse corners: " + std::string(e.what()));
-        }
-    }
-
-    try {
-        ColorDB db = corners_opt ? GenColorDBFromBuffer(image, meta, *corners_opt)
-                                 : GenColorDBFromBuffer(image, meta);
-        db.name    = db_name;
-        std::string err;
-        if (!sessions_.PutSessionDb(owner, db, &err)) {
-            return ServiceResult::Error(429, "session_limit", err);
-        }
-        auto out      = ColorDbBuildResultToJson(db);
-        out["source"] = "session";
-        return ServiceResult::Success(200, std::move(out));
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(500, "build_failed", e.what());
-    }
-}
-
-json ServerFacade::ColorDbInfoToJson(const ColorDB& db, const std::string& material_type,
-                                     const std::string& vendor) {
-    static const auto builtin_fil = FilamentConfig::BuiltinDefaults();
-    json palette                  = json::array();
-    for (size_t i = 0; i < db.palette.size(); ++i) {
-        const auto& ch = db.palette[i];
-        json entry     = {{"color", ch.color}, {"material", ch.material}};
-        if (!ch.hex_color.empty()) {
-            entry["hex_color"] = ch.hex_color;
-        } else {
-            auto resolved = builtin_fil.ResolveHexColor(ch.color, static_cast<int>(i));
-            if (!resolved.empty()) entry["hex_color"] = resolved;
-        }
-        palette.push_back(std::move(entry));
-    }
-    return {
-        {"name", db.name},
-        {"num_channels", db.NumChannels()},
-        {"num_entries", db.entries.size()},
-        {"max_color_layers", db.max_color_layers},
-        {"base_layers", db.base_layers},
-        {"layer_height_mm", db.layer_height_mm},
-        {"line_width_mm", db.line_width_mm},
-        {"material_type", material_type},
-        {"vendor", vendor},
-        {"palette", std::move(palette)},
-    };
-}
-
-json ServerFacade::ColorDbBuildResultToJson(const ColorDB& db) {
-    auto out = ColorDbInfoToJson(db);
-
-    json entries = json::array();
-    for (const auto& entry : db.entries) {
-        ChromaPrint3D::Rgb rgb = entry.lab.ToRgb();
-        uint8_t r8 = 0, g8 = 0, b8 = 0;
-        rgb.ToRgb255(r8, g8, b8);
-        char hex_buf[8];
-        std::snprintf(hex_buf, sizeof(hex_buf), "#%02X%02X%02X", r8, g8, b8);
-
-        json recipe_arr = json::array();
-        for (uint8_t v : entry.recipe) { recipe_arr.push_back(static_cast<int>(v)); }
-
-        entries.push_back({
-            {"lab", {entry.lab.x, entry.lab.y, entry.lab.z}},
-            {"hex", std::string(hex_buf)},
-            {"recipe", std::move(recipe_arr)},
-        });
-    }
-    out["entries"] = std::move(entries);
-    return out;
-}
-
-json ServerFacade::TaskToJson(const TaskSnapshot& task) {
-    json j;
-    j["id"]     = task.id;
-    j["kind"]   = TaskKindToString(task.kind);
-    j["status"] = TaskStatusToString(task.status);
-    j["created_at_ms"] =
-        std::chrono::duration_cast<std::chrono::milliseconds>(task.created_at.time_since_epoch())
-            .count();
-    j["error"] = task.error.empty() ? json(nullptr) : json(task.error);
-
-    if (auto cp = std::get_if<ConvertTaskPayload>(&task.payload)) {
-        j["stage"]      = ConvertStageToString(cp->stage);
-        j["progress"]   = cp->progress;
-        j["match_only"] = cp->match_only;
-        if (!cp->generate_error.empty()) { j["generate_error"] = cp->generate_error; }
-        if (!cp->result.warnings.empty()) { j["warnings"] = cp->result.warnings; }
-        if (task.status == RuntimeTaskStatus::Completed) {
-            j["result"] = {
-                {"input_width", cp->result.input_width},
-                {"input_height", cp->result.input_height},
-                {"resolved_pixel_mm", cp->result.resolved_pixel_mm},
-                {"physical_width_mm", cp->result.physical_width_mm},
-                {"physical_height_mm", cp->result.physical_height_mm},
-                {"stats",
-                 {{"clusters_total", cp->result.stats.clusters_total},
-                  {"db_only", cp->result.stats.db_only},
-                  {"model_fallback", cp->result.stats.model_fallback},
-                  {"model_queries", cp->result.stats.model_queries},
-                  {"avg_db_de", cp->result.stats.avg_db_de},
-                  {"avg_model_de", cp->result.stats.avg_model_de}}},
-                {"has_3mf", !cp->result.model_3mf.empty() || cp->has_3mf_on_disk},
-                {"has_preview", !cp->result.preview_png.empty()},
-                {"has_source_mask", !cp->result.source_mask_png.empty()},
-                {"has_region_map",
-                 !cp->region_map_binary.empty() || cp->raster_region_map.has_value()},
-                {"layer_previews", LayerPreviewsToJson(cp->result.layer_previews)},
-            };
-        } else {
-            j["result"] = nullptr;
-        }
-        return j;
-    }
-
-    if (auto mp = std::get_if<MattingTaskPayload>(&task.payload)) {
-        j["method"] = mp->method;
-        if (task.status == RuntimeTaskStatus::Completed) {
-            j["width"]     = mp->width;
-            j["height"]    = mp->height;
-            j["has_alpha"] = mp->has_alpha;
-            j["timing"]    = {
-                {"preprocess_ms", mp->timing.preprocess_ms},
-                {"inference_ms", mp->timing.inference_ms},
-                {"postprocess_ms", mp->timing.postprocess_ms},
-                {"decode_ms", mp->decode_ms},
-                {"encode_ms", mp->encode_ms},
-                {"provider_ms", mp->timing.total_ms},
-                {"pipeline_ms", mp->pipeline_ms},
-            };
-        } else {
-            j["width"]     = 0;
-            j["height"]    = 0;
-            j["has_alpha"] = false;
-            j["timing"]    = nullptr;
-        }
-        return j;
-    }
-
-    auto* vp        = std::get_if<VectorizeTaskPayload>(&task.payload);
-    j["timing"]     = nullptr;
-    j["width"]      = 0;
-    j["height"]     = 0;
-    j["num_shapes"] = 0;
-    j["svg_size"]   = 0;
-    if (vp && task.status == RuntimeTaskStatus::Completed) {
-        const auto svg_size      = vp->svg_bytes > 0 ? vp->svg_bytes : vp->svg_content.size();
-        j["width"]               = vp->width;
-        j["height"]              = vp->height;
-        j["num_shapes"]          = vp->num_shapes;
-        j["svg_size"]            = svg_size;
-        j["resolved_num_colors"] = vp->resolved_num_colors;
-        j["timing"]              = {
-            {"decode_ms", vp->decode_ms},
-            {"vectorize_ms", vp->vectorize_ms},
-            {"pipeline_ms", vp->pipeline_ms},
-        };
-    }
-    return j;
-}
-
-const char* ServerFacade::ConvertStageToString(ConvertStage stage) {
-    switch (stage) {
-    case ConvertStage::LoadingResources:
-        return "loading_resources";
-    case ConvertStage::Preprocessing:
-        return "preprocessing";
-    case ConvertStage::Matching:
-        return "matching";
-    case ConvertStage::BuildingModel:
-        return "building_model";
-    case ConvertStage::Exporting:
-        return "exporting";
-    }
-    return "unknown";
-}
-
-ServiceResult ServerFacade::ParseJsonObject(const std::optional<std::string>& raw,
-                                            json& out) const {
-    out = json::object();
-    if (!raw || raw->empty()) return ServiceResult::Success(200, json::object());
-    try {
-        out = json::parse(*raw);
-        if (!out.is_object()) {
-            return ServiceResult::Error(400, "invalid_json", "Expected JSON object");
-        }
-        return ServiceResult::Success(200, json::object());
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(400, "invalid_json", std::string("Invalid JSON: ") + e.what());
-    }
-}
-
-ServiceResult ServerFacade::ValidateDecodedImage(const std::vector<uint8_t>& image) const {
-    cv::Mat decoded;
-    try {
-        decoded = ChromaPrint3D::DecodeImageWithIcc(image);
-    } catch (...) { return ServiceResult::Error(400, "invalid_image", "Failed to decode image"); }
-    if (decoded.empty())
-        return ServiceResult::Error(400, "invalid_image", "Failed to decode image");
-    std::int64_t pixels = static_cast<std::int64_t>(decoded.cols) * decoded.rows;
-    if (pixels > cfg_.max_pixels_per_image) {
-        return ServiceResult::Error(413, "image_too_large",
-                                    "Decoded image exceeds max pixels limit");
-    }
-    return ServiceResult::Success(200, json::object());
-}
-
-ServiceResult ServerFacade::ResolveSelectedColorDbs(
-    const json& params, const std::optional<SessionSnapshot>& session,
-    std::vector<const ColorDB*>& out_dbs,
-    std::vector<std::shared_ptr<const ColorDB>>& session_owned, std::string& common_vendor,
-    std::string& common_material) const {
-    out_dbs.clear();
-    common_vendor.clear();
-    common_material.clear();
-
-    struct DbWithMeta {
-        const ColorDB* db;
-        std::string vendor;
-        std::string material_type;
-    };
-
-    std::vector<DbWithMeta> selected;
-
-    if (params.contains("db_names") && params["db_names"].is_array()) {
-        selected.reserve(params["db_names"].size());
-        for (const auto& name_val : params["db_names"]) {
-            if (!name_val.is_string()) {
-                return ServiceResult::Error(400, "invalid_params",
-                                            "db_names must be an array of strings");
-            }
-            const std::string name = name_val.get<std::string>();
-            const ColorDB* db      = nullptr;
-            std::string vendor, material;
-            if (const auto* entry = data_.ColorDbCache().FindEntryByName(name)) {
-                db       = &entry->db;
-                vendor   = entry->vendor;
-                material = entry->material_type;
-            }
-            if (!db && session) {
-                auto it = session->color_dbs.find(name);
-                if (it != session->color_dbs.end()) {
-                    auto copy = std::make_shared<const ColorDB>(it->second);
-                    session_owned.push_back(copy);
-                    db = copy.get();
-                }
-            }
-            if (!db) {
-                return ServiceResult::Error(400, "invalid_params", "ColorDB not found: " + name);
-            }
-            selected.push_back({db, vendor, material});
-        }
-        if (selected.empty()) {
-            return ServiceResult::Error(400, "invalid_params", "No valid ColorDB names provided");
-        }
-    } else {
-        selected.reserve(data_.ColorDbCache().databases.size());
-        for (const auto& entry : data_.ColorDbCache().databases) {
-            selected.push_back({&entry.db, entry.vendor, entry.material_type});
-        }
-    }
-
-    out_dbs.reserve(selected.size());
-    for (const auto& s : selected) { out_dbs.push_back(s.db); }
-
-    if (!selected.empty()) {
-        const auto& first_v = selected.front().vendor;
-        const auto& first_m = selected.front().material_type;
-        bool all_same       = !first_v.empty() && !first_m.empty();
-        for (size_t i = 1; i < selected.size() && all_same; ++i) {
-            if (selected[i].vendor != first_v || selected[i].material_type != first_m) {
-                all_same = false;
-            }
-        }
-        if (all_same) {
-            common_vendor   = first_v;
-            common_material = first_m;
-        }
-    }
-
-    return ServiceResult::Success(200, json::object());
-}
-
-ServiceResult ServerFacade::BuildRasterRequest(const json& params,
-                                               const std::vector<uint8_t>& image,
-                                               const std::string& image_name,
-                                               const std::optional<SessionSnapshot>& session,
-                                               ConvertRasterRequest& out) const {
-    out.image_buffer = image;
-    out.image_name   = image_name;
-
-    auto presets_path = std::filesystem::path(cfg_.data_dir) / "presets";
-    if (std::filesystem::is_directory(presets_path)) { out.preset_dir = presets_path.string(); }
-
-    std::string common_vendor, common_material;
-    auto selected = ResolveSelectedColorDbs(params, session, out.preloaded_dbs,
-                                            out.session_owned_dbs, common_vendor, common_material);
-    if (!selected.ok) return selected;
-
-    if (!common_vendor.empty() && !common_material.empty()) {
-        auto profile_keys = BuildProfileChannelKeys(out.preloaded_dbs);
-        out.preloaded_model_pack =
-            data_.ModelPackRegistry().Select(common_vendor, common_material, profile_keys);
-    }
-
-    try {
-        if (params.contains("scale")) out.scale = params["scale"].get<float>();
-        if (params.contains("max_width")) out.max_width = params["max_width"].get<int>();
-        if (params.contains("max_height")) out.max_height = params["max_height"].get<int>();
-        if (params.contains("target_width_mm")) {
-            out.target_width_mm = params["target_width_mm"].get<float>();
-        }
-        if (params.contains("target_height_mm")) {
-            out.target_height_mm = params["target_height_mm"].get<float>();
-        }
-        if (params.contains("color_layers")) {
-            out.color_layers = params["color_layers"].get<int>();
-        }
-        if (params.contains("print_mode")) {
-            const std::string pm = params["print_mode"].get<std::string>();
-            if (pm == "0.08x5" || pm == "0p08x5") {
-                out.color_layers    = 5;
-                out.layer_height_mm = 0.08f;
-            } else if (pm == "0.04x10" || pm == "0p04x10") {
-                out.color_layers    = 10;
-                out.layer_height_mm = 0.04f;
-            }
-        }
-        if (params.contains("color_space")) {
-            out.color_space = ParseColorSpace(params["color_space"].get<std::string>());
-        }
-        if (params.contains("k_candidates")) out.k_candidates = params["k_candidates"].get<int>();
-        if (params.contains("cluster_method")) {
-            out.cluster_method = ParseClusterMethod(params["cluster_method"].get<std::string>());
-        }
-        if (params.contains("cluster_count"))
-            out.cluster_count = params["cluster_count"].get<int>();
-        if (params.contains("slic_target_superpixels")) {
-            out.slic_target_superpixels = params["slic_target_superpixels"].get<int>();
-        }
-        if (params.contains("slic_compactness")) {
-            out.slic_compactness = params["slic_compactness"].get<float>();
-        }
-        if (params.contains("slic_iterations")) {
-            out.slic_iterations = params["slic_iterations"].get<int>();
-        }
-        if (params.contains("slic_min_region_ratio")) {
-            out.slic_min_region_ratio = params["slic_min_region_ratio"].get<float>();
-        }
-        if (params.contains("dither")) {
-            std::string d = params["dither"].get<std::string>();
-            if (d == "blue_noise") {
-                out.dither = DitherMethod::BlueNoise;
-            } else if (d == "floyd_steinberg") {
-                out.dither = DitherMethod::FloydSteinberg;
-            } else if (d == "none") {
-                out.dither = DitherMethod::None;
-            } else {
-                throw std::runtime_error("Invalid dither method: " + d);
-            }
-        }
-        if (params.contains("dither_strength")) {
-            out.dither_strength = params["dither_strength"].get<float>();
-        }
-        if (params.contains("allowed_channels") && params["allowed_channels"].is_array()) {
-            for (const auto& ch : params["allowed_channels"]) {
-                std::string color    = ch.value("color", "");
-                std::string material = ch.value("material", "");
-                if (!color.empty()) out.allowed_channel_keys.push_back(color + "|" + material);
-            }
-        }
-        if (params.contains("model_enable")) out.model_enable = params["model_enable"].get<bool>();
-        if (params.contains("model_only")) out.model_only = params["model_only"].get<bool>();
-        if (params.contains("model_threshold")) {
-            out.model_threshold = params["model_threshold"].get<float>();
-        }
-        if (params.contains("model_margin")) out.model_margin = params["model_margin"].get<float>();
-        if (params.contains("flip_y")) out.flip_y = params["flip_y"].get<bool>();
-        if (params.contains("pixel_mm")) out.pixel_mm = params["pixel_mm"].get<float>();
-        if (params.contains("layer_height_mm")) {
-            out.layer_height_mm = params["layer_height_mm"].get<float>();
-        }
-        if (params.contains("base_layers")) out.base_layers = params["base_layers"].get<int>();
-        if (params.contains("double_sided")) out.double_sided = params["double_sided"].get<bool>();
-        if (params.contains("transparent_layer_mm")) {
-            out.transparent_layer_mm = params["transparent_layer_mm"].get<float>();
-        }
-        if (params.contains("generate_preview")) {
-            out.generate_preview = params["generate_preview"].get<bool>();
-        }
-        if (params.contains("generate_source_mask")) {
-            out.generate_source_mask = params["generate_source_mask"].get<bool>();
-        }
-        if (params.contains("nozzle_size")) {
-            out.nozzle_size = ParseNozzleSize(params["nozzle_size"].get<std::string>());
-        }
-        if (params.contains("face_orientation")) {
-            out.face_orientation =
-                ParseFaceOrientation(params["face_orientation"].get<std::string>());
-        }
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(400, "invalid_params", e.what());
-    }
-
-    if (out.color_layers < 1 || out.color_layers > 20) {
-        return ServiceResult::Error(400, "invalid_params", "color_layers must be between 1 and 20");
-    }
-    if (out.scale <= 0.0f) return ServiceResult::Error(400, "invalid_params", "scale must be > 0");
-    if (out.max_width < 0 || out.max_height < 0) {
-        return ServiceResult::Error(400, "invalid_params", "max dimensions must be >= 0");
-    }
-    if (out.k_candidates < 1) {
-        return ServiceResult::Error(400, "invalid_params", "k_candidates must be >= 1");
-    }
-    if (out.cluster_count < 0) {
-        return ServiceResult::Error(400, "invalid_params", "cluster_count must be >= 0");
-    }
-    if (out.slic_target_superpixels < 0) {
-        return ServiceResult::Error(400, "invalid_params", "slic_target_superpixels must be >= 0");
-    }
-    if (out.slic_compactness <= 0.0f) {
-        return ServiceResult::Error(400, "invalid_params", "slic_compactness must be > 0");
-    }
-    if (out.slic_iterations < 1) {
-        return ServiceResult::Error(400, "invalid_params", "slic_iterations must be >= 1");
-    }
-    if (out.slic_min_region_ratio < 0.0f || out.slic_min_region_ratio > 1.0f) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "slic_min_region_ratio must be in [0,1]");
-    }
-    if (out.dither_strength < 0.0f || out.dither_strength > 1.0f) {
-        return ServiceResult::Error(400, "invalid_params", "dither_strength must be in [0,1]");
-    }
-    if (out.base_layers < -1) {
-        return ServiceResult::Error(400, "invalid_params", "base_layers must be >= -1");
-    }
-    if (out.transparent_layer_mm < 0.0f) {
-        return ServiceResult::Error(400, "invalid_params", "transparent_layer_mm must be >= 0");
-    }
-    if (out.cluster_method == ClusterMethod::Slic && out.dither != DitherMethod::None) {
-        out.dither = DitherMethod::None;
-    }
-
-    return ServiceResult::Success(200, json::object());
-}
-
-ServiceResult ServerFacade::BuildVectorRequest(const json& params, const std::vector<uint8_t>& svg,
-                                               const std::string& svg_name,
-                                               const std::optional<SessionSnapshot>& session,
-                                               ConvertVectorRequest& out) const {
-    out.svg_buffer = svg;
-    out.svg_name   = svg_name;
-
-    auto vpresets = std::filesystem::path(cfg_.data_dir) / "presets";
-    if (std::filesystem::is_directory(vpresets)) { out.preset_dir = vpresets.string(); }
-
-    std::string vec_common_vendor, vec_common_material;
-    auto selected =
-        ResolveSelectedColorDbs(params, session, out.preloaded_dbs, out.session_owned_dbs,
-                                vec_common_vendor, vec_common_material);
-    if (!selected.ok) return selected;
-
-    if (!vec_common_vendor.empty() && !vec_common_material.empty()) {
-        auto profile_keys = BuildProfileChannelKeys(out.preloaded_dbs);
-        out.preloaded_model_pack =
-            data_.ModelPackRegistry().Select(vec_common_vendor, vec_common_material, profile_keys);
-    }
-
-    try {
-        if (params.contains("target_width_mm")) {
-            out.target_width_mm = params["target_width_mm"].get<float>();
-        }
-        if (params.contains("target_height_mm")) {
-            out.target_height_mm = params["target_height_mm"].get<float>();
-        }
-        if (params.contains("color_layers")) {
-            out.color_layers = params["color_layers"].get<int>();
-        }
-        if (params.contains("print_mode")) {
-            const std::string pm = params["print_mode"].get<std::string>();
-            if (pm == "0.08x5" || pm == "0p08x5") {
-                out.color_layers    = 5;
-                out.layer_height_mm = 0.08f;
-            } else if (pm == "0.04x10" || pm == "0p04x10") {
-                out.color_layers    = 10;
-                out.layer_height_mm = 0.04f;
-            }
-        }
-        if (params.contains("color_space")) {
-            out.color_space = ParseColorSpace(params["color_space"].get<std::string>());
-        }
-        if (params.contains("k_candidates")) out.k_candidates = params["k_candidates"].get<int>();
-        if (params.contains("model_enable")) out.model_enable = params["model_enable"].get<bool>();
-        if (params.contains("model_only")) out.model_only = params["model_only"].get<bool>();
-        if (params.contains("model_threshold")) {
-            out.model_threshold = params["model_threshold"].get<float>();
-        }
-        if (params.contains("model_margin")) out.model_margin = params["model_margin"].get<float>();
-        if (params.contains("flip_y")) out.flip_y = params["flip_y"].get<bool>();
-        if (params.contains("layer_height_mm")) {
-            out.layer_height_mm = params["layer_height_mm"].get<float>();
-        }
-        if (params.contains("base_layers")) out.base_layers = params["base_layers"].get<int>();
-        if (params.contains("double_sided")) out.double_sided = params["double_sided"].get<bool>();
-        if (params.contains("transparent_layer_mm")) {
-            out.transparent_layer_mm = params["transparent_layer_mm"].get<float>();
-        }
-        if (params.contains("tessellation_tolerance_mm")) {
-            out.tessellation_tolerance_mm = params["tessellation_tolerance_mm"].get<float>();
-        }
-        if (params.contains("gradient_pixel_mm")) {
-            out.gradient_pixel_mm = params["gradient_pixel_mm"].get<float>();
-        }
-        if (params.contains("allowed_channels") && params["allowed_channels"].is_array()) {
-            for (const auto& ch : params["allowed_channels"]) {
-                std::string color    = ch.value("color", "");
-                std::string material = ch.value("material", "");
-                if (!color.empty()) out.allowed_channel_keys.push_back(color + "|" + material);
-            }
-        }
-        if (params.contains("generate_preview")) {
-            out.generate_preview = params["generate_preview"].get<bool>();
-        }
-        if (params.contains("generate_source_mask")) {
-            out.generate_source_mask = params["generate_source_mask"].get<bool>();
-        }
-        if (params.contains("nozzle_size")) {
-            out.nozzle_size = ParseNozzleSize(params["nozzle_size"].get<std::string>());
-        }
-        if (params.contains("face_orientation")) {
-            out.face_orientation =
-                ParseFaceOrientation(params["face_orientation"].get<std::string>());
-        }
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(400, "invalid_params", e.what());
-    }
-
-    if (out.color_layers < 1 || out.color_layers > 20) {
-        return ServiceResult::Error(400, "invalid_params", "color_layers must be between 1 and 20");
-    }
-    if (out.k_candidates < 1) {
-        return ServiceResult::Error(400, "invalid_params", "k_candidates must be >= 1");
-    }
-    if (out.base_layers < -1) {
-        return ServiceResult::Error(400, "invalid_params", "base_layers must be >= -1");
-    }
-    if (out.transparent_layer_mm < 0.0f) {
-        return ServiceResult::Error(400, "invalid_params", "transparent_layer_mm must be >= 0");
-    }
-
-    return ServiceResult::Success(200, json::object());
-}
-
-ServiceResult ServerFacade::BuildVectorizeConfig(const json& params, VectorizerConfig& out) const {
-    out = VectorizerConfig{};
-    spdlog::debug("BuildVectorizeConfig: params keys={}", params.size());
-    try {
-        if (params.contains("num_colors")) out.num_colors = params["num_colors"].get<int>();
-        if (params.contains("min_region_area")) {
-            out.min_region_area = params["min_region_area"].get<int>();
-        }
-        if (params.contains("curve_fit_error")) {
-            out.curve_fit_error = params["curve_fit_error"].get<float>();
-        }
-        if (params.contains("corner_angle_threshold")) {
-            out.corner_angle_threshold = params["corner_angle_threshold"].get<float>();
-        }
-        if (params.contains("smoothing_spatial")) {
-            out.smoothing_spatial = params["smoothing_spatial"].get<float>();
-        }
-        if (params.contains("smoothing_color")) {
-            out.smoothing_color = params["smoothing_color"].get<float>();
-        }
-        if (params.contains("upscale_short_edge")) {
-            out.upscale_short_edge = params["upscale_short_edge"].get<int>();
-        }
-        if (params.contains("max_working_pixels")) {
-            out.max_working_pixels = params["max_working_pixels"].get<int>();
-        }
-        if (params.contains("slic_region_size")) {
-            out.slic_region_size = params["slic_region_size"].get<int>();
-        }
-        if (params.contains("edge_sensitivity")) {
-            out.edge_sensitivity = params["edge_sensitivity"].get<float>();
-        }
-        if (params.contains("refine_passes")) {
-            out.refine_passes = params["refine_passes"].get<int>();
-        }
-        if (params.contains("max_merge_color_dist")) {
-            out.max_merge_color_dist = params["max_merge_color_dist"].get<float>();
-        }
-        if (params.contains("thin_line_max_radius")) {
-            out.thin_line_max_radius = params["thin_line_max_radius"].get<float>();
-        }
-        if (params.contains("min_contour_area")) {
-            out.min_contour_area = params["min_contour_area"].get<float>();
-        }
-        if (params.contains("min_hole_area"))
-            out.min_hole_area = params["min_hole_area"].get<float>();
-        if (params.contains("contour_simplify")) {
-            out.contour_simplify = params["contour_simplify"].get<float>();
-        }
-        if (params.contains("enable_coverage_fix")) {
-            out.enable_coverage_fix = params["enable_coverage_fix"].get<bool>();
-        }
-        if (params.contains("min_coverage_ratio")) {
-            out.min_coverage_ratio = params["min_coverage_ratio"].get<float>();
-        }
-        if (params.contains("svg_enable_stroke")) {
-            out.svg_enable_stroke = params["svg_enable_stroke"].get<bool>();
-        }
-        if (params.contains("svg_stroke_width")) {
-            out.svg_stroke_width = params["svg_stroke_width"].get<float>();
-        }
-        if (params.contains("smoothness")) { out.smoothness = params["smoothness"].get<float>(); }
-        if (params.contains("detail_level")) {
-            out.detail_level = params["detail_level"].get<float>();
-        }
-        if (params.contains("merge_segment_tolerance")) {
-            out.merge_segment_tolerance = params["merge_segment_tolerance"].get<float>();
-        }
-        if (params.contains("enable_antialias_detect")) {
-            out.enable_antialias_detect = params["enable_antialias_detect"].get<bool>();
-        }
-        if (params.contains("aa_tolerance")) {
-            out.aa_tolerance = params["aa_tolerance"].get<float>();
-        }
-    } catch (const std::exception& e) {
-        return ServiceResult::Error(400, "invalid_params", e.what());
-    }
-
-    if (out.num_colors != 0 && (out.num_colors < 2 || out.num_colors > 256)) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "num_colors must be 0 (auto) or [2,256]");
-    }
-    if (out.curve_fit_error < 0.1f || out.curve_fit_error > 5.0f) {
-        return ServiceResult::Error(400, "invalid_params", "curve_fit_error must be in [0.1,5]");
-    }
-    if (out.corner_angle_threshold < 90.0f || out.corner_angle_threshold > 175.0f) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "corner_angle_threshold must be in [90,175]");
-    }
-    if (out.smoothing_spatial < 0.0f || out.smoothing_spatial > 50.0f) {
-        return ServiceResult::Error(400, "invalid_params", "smoothing_spatial must be in [0,50]");
-    }
-    if (out.smoothing_color < 0.0f || out.smoothing_color > 80.0f) {
-        return ServiceResult::Error(400, "invalid_params", "smoothing_color must be in [0,80]");
-    }
-    if (out.upscale_short_edge < 0 || out.upscale_short_edge > 2000) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "upscale_short_edge must be in [0,2000]");
-    }
-    if (out.max_working_pixels < 0 || out.max_working_pixels > 100000000) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "max_working_pixels must be in [0,100000000]");
-    }
-    if (out.slic_region_size < 0 || out.slic_region_size > 100) {
-        return ServiceResult::Error(400, "invalid_params", "slic_region_size must be in [0,100]");
-    }
-    if (out.edge_sensitivity < 0.0f || out.edge_sensitivity > 1.0f) {
-        return ServiceResult::Error(400, "invalid_params", "edge_sensitivity must be in [0,1]");
-    }
-    if (out.refine_passes < 0 || out.refine_passes > 20) {
-        return ServiceResult::Error(400, "invalid_params", "refine_passes must be in [0,20]");
-    }
-    if (out.max_merge_color_dist < 0.0f || out.max_merge_color_dist > 2000.0f) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "max_merge_color_dist must be in [0,2000]");
-    }
-    if (out.thin_line_max_radius < 0.5f || out.thin_line_max_radius > 10.0f) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "thin_line_max_radius must be in [0.5,10]");
-    }
-    if (out.min_region_area < 0 || out.min_contour_area < 0.0f || out.min_hole_area < 0.0f) {
-        return ServiceResult::Error(400, "invalid_params", "area options must be >= 0");
-    }
-    if (out.contour_simplify < 0.0f || out.contour_simplify > 10.0f) {
-        return ServiceResult::Error(400, "invalid_params", "contour_simplify must be in [0,10]");
-    }
-    if (out.min_coverage_ratio < 0.0f || out.min_coverage_ratio > 1.0f) {
-        return ServiceResult::Error(400, "invalid_params", "min_coverage_ratio must be in [0,1]");
-    }
-    if (out.svg_stroke_width < 0.0f || out.svg_stroke_width > 20.0f) {
-        return ServiceResult::Error(400, "invalid_params", "svg_stroke_width must be in [0,20]");
-    }
-    if (out.smoothness < 0.0f || out.smoothness > 1.0f) {
-        return ServiceResult::Error(400, "invalid_params", "smoothness must be in [0,1]");
-    }
-    if (out.detail_level > 1.0f) {
-        return ServiceResult::Error(400, "invalid_params", "detail_level must be <= 1");
-    }
-    if (out.merge_segment_tolerance < 0.0f || out.merge_segment_tolerance > 0.5f) {
-        return ServiceResult::Error(400, "invalid_params",
-                                    "merge_segment_tolerance must be in [0,0.5]");
-    }
-    if (out.aa_tolerance < 1.0f || out.aa_tolerance > 50.0f) {
-        return ServiceResult::Error(400, "invalid_params", "aa_tolerance must be in [1,50]");
-    }
-    spdlog::debug(
-        "BuildVectorizeConfig resolved: num_colors={}, min_region_area={}, curve_fit_error={:.3f}, "
-        "corner_angle_threshold={:.1f}, smoothing_spatial={:.1f}, smoothing_color={:.1f}, "
-        "upscale_short_edge={}, max_working_pixels={}, slic_region_size={}, "
-        "edge_sensitivity={:.2f}, refine_passes={}, max_merge_color_dist={:.1f}, "
-        "thin_line_max_radius={:.2f}, "
-        "min_contour_area={:.2f}, min_hole_area={:.2f}, contour_simplify={:.2f}, "
-        "enable_coverage_fix={}, min_coverage_ratio={:.4f}, "
-        "svg_enable_stroke={}, svg_stroke_width={:.2f}",
-        out.num_colors, out.min_region_area, out.curve_fit_error, out.corner_angle_threshold,
-        out.smoothing_spatial, out.smoothing_color, out.upscale_short_edge, out.max_working_pixels,
-        out.slic_region_size, out.edge_sensitivity, out.refine_passes, out.max_merge_color_dist,
-        out.thin_line_max_radius, out.min_contour_area, out.min_hole_area, out.contour_simplify,
-        out.enable_coverage_fix, out.min_coverage_ratio, out.svg_enable_stroke,
-        out.svg_stroke_width);
-    return ServiceResult::Success(200, json::object());
+    return calib_svc_.BuildColorDb(owner, image, meta_json, db_name, corners_json);
 }
 
 } // namespace chromaprint3d::backend

--- a/web/backend/src/application/server_facade.h
+++ b/web/backend/src/application/server_facade.h
@@ -26,6 +26,11 @@ class ServerFacade {
 public:
     explicit ServerFacade(ServerConfig cfg);
 
+    ServerFacade(const ServerFacade&)            = delete;
+    ServerFacade& operator=(const ServerFacade&) = delete;
+    ServerFacade(ServerFacade&&)                 = delete;
+    ServerFacade& operator=(ServerFacade&&)      = delete;
+
     const ServerConfig& Config() const { return cfg_; }
 
     bool IsCrossOriginMode() const { return !cfg_.cors_origin.empty(); }

--- a/web/backend/src/application/server_facade.h
+++ b/web/backend/src/application/server_facade.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include "application/calibration_service.h"
+#include "application/color_db_service.h"
+#include "application/convert_service.h"
+#include "application/matting_vectorize_service.h"
+#include "application/recipe_editor_service.h"
+#include "application/service_result.h"
+#include "application/task_service.h"
 #include "config/server_config.h"
 #include "infrastructure/board_runtime_cache.h"
 #include "infrastructure/data_repository.h"
@@ -14,17 +21,6 @@
 #include <vector>
 
 namespace chromaprint3d::backend {
-
-struct ServiceResult {
-    bool ok         = false;
-    int status_code = 500;
-    std::string code;
-    std::string message;
-    nlohmann::json data = nlohmann::json::object();
-
-    static ServiceResult Success(int status, nlohmann::json d);
-    static ServiceResult Error(int status, std::string c, std::string m);
-};
 
 class ServerFacade {
 public:
@@ -101,38 +97,18 @@ public:
                                const std::string& corners_json = "");
 
 private:
-    static nlohmann::json ColorDbInfoToJson(const ChromaPrint3D::ColorDB& db,
-                                            const std::string& material_type = "",
-                                            const std::string& vendor        = "");
-    static nlohmann::json ColorDbBuildResultToJson(const ChromaPrint3D::ColorDB& db);
-    static nlohmann::json TaskToJson(const TaskSnapshot& task);
-    static const char* ConvertStageToString(ChromaPrint3D::ConvertStage stage);
-
-    ServiceResult ParseJsonObject(const std::optional<std::string>& raw, nlohmann::json& out) const;
-    ServiceResult ValidateDecodedImage(const std::vector<uint8_t>& image) const;
-    ServiceResult ResolveSelectedColorDbs(
-        const nlohmann::json& params, const std::optional<SessionSnapshot>& session,
-        std::vector<const ChromaPrint3D::ColorDB*>& out_dbs,
-        std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>>& session_owned,
-        std::string& common_vendor, std::string& common_material) const;
-
-    ServiceResult BuildRasterRequest(const nlohmann::json& params,
-                                     const std::vector<uint8_t>& image,
-                                     const std::string& image_name,
-                                     const std::optional<SessionSnapshot>& session,
-                                     ChromaPrint3D::ConvertRasterRequest& out) const;
-    ServiceResult BuildVectorRequest(const nlohmann::json& params, const std::vector<uint8_t>& svg,
-                                     const std::string& svg_name,
-                                     const std::optional<SessionSnapshot>& session,
-                                     ChromaPrint3D::ConvertVectorRequest& out) const;
-    ServiceResult BuildVectorizeConfig(const nlohmann::json& params,
-                                       neroued::vectorizer::VectorizerConfig& out) const;
-
     ServerConfig cfg_;
     DataRepository data_;
     SessionStore sessions_;
     TaskRuntime tasks_;
     BoardRuntimeCache boards_;
+
+    ColorDbService color_db_svc_;
+    TaskService task_svc_;
+    ConvertService convert_svc_;
+    MattingVectorizeService matting_svc_;
+    RecipeEditorService recipe_svc_;
+    CalibrationService calib_svc_;
 };
 
 } // namespace chromaprint3d::backend

--- a/web/backend/src/application/service_result.h
+++ b/web/backend/src/application/service_result.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+
+namespace chromaprint3d::backend {
+
+struct ServiceResult {
+    bool ok         = false;
+    int status_code = 500;
+    std::string code;
+    std::string message;
+    nlohmann::json data = nlohmann::json::object();
+
+    static ServiceResult Success(int status, nlohmann::json d) {
+        ServiceResult r;
+        r.ok          = true;
+        r.status_code = status;
+        r.data        = std::move(d);
+        return r;
+    }
+
+    static ServiceResult Error(int status, std::string c, std::string m) {
+        ServiceResult r;
+        r.ok          = false;
+        r.status_code = status;
+        r.code        = std::move(c);
+        r.message     = std::move(m);
+        return r;
+    }
+};
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/task_service.cpp
+++ b/web/backend/src/application/task_service.cpp
@@ -1,0 +1,45 @@
+#include "application/task_service.h"
+
+#include "application/json_serialization.h"
+
+namespace chromaprint3d::backend {
+
+using json = nlohmann::json;
+
+TaskService::TaskService(TaskRuntime& tasks) : tasks_(tasks) {}
+
+ServiceResult TaskService::ListTasks(const std::string& owner) const {
+    if (owner.empty()) return ServiceResult::Success(200, {{"tasks", json::array()}});
+    json tasks = json::array();
+    for (const auto& t : tasks_.ListTasks(owner)) tasks.push_back(TaskToJson(t));
+    return ServiceResult::Success(200, {{"tasks", std::move(tasks)}});
+}
+
+ServiceResult TaskService::GetTask(const std::string& owner, const std::string& id) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    auto task = tasks_.FindTask(owner, id);
+    if (!task) return ServiceResult::Error(404, "not_found", "Task not found");
+    return ServiceResult::Success(200, TaskToJson(*task));
+}
+
+ServiceResult TaskService::DeleteTask(const std::string& owner, const std::string& id) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    int status          = 500;
+    std::string message = "Unknown error";
+    bool ok             = tasks_.DeleteTask(owner, id, status, message);
+    if (!ok) return ServiceResult::Error(status, "delete_failed", message);
+    return ServiceResult::Success(200, {{"deleted", true}});
+}
+
+ServiceResult TaskService::DownloadTaskArtifact(const std::string& owner, const std::string& id,
+                                                const std::string& artifact, TaskArtifact& out) {
+    if (owner.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
+    int status          = 500;
+    std::string message = "Unknown error";
+    auto data           = tasks_.LoadArtifact(owner, id, artifact, status, message);
+    if (!data) return ServiceResult::Error(status, "artifact_error", message);
+    out = std::move(*data);
+    return ServiceResult::Success(200, json::object());
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/task_service.h
+++ b/web/backend/src/application/task_service.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "application/service_result.h"
+#include "infrastructure/task_runtime.h"
+
+#include <string>
+
+namespace chromaprint3d::backend {
+
+class TaskService {
+public:
+    explicit TaskService(TaskRuntime& tasks);
+
+    ServiceResult ListTasks(const std::string& owner) const;
+    ServiceResult GetTask(const std::string& owner, const std::string& id);
+    ServiceResult DeleteTask(const std::string& owner, const std::string& id);
+    ServiceResult DownloadTaskArtifact(const std::string& owner, const std::string& id,
+                                       const std::string& artifact, TaskArtifact& out);
+
+private:
+    TaskRuntime& tasks_;
+};
+
+} // namespace chromaprint3d::backend


### PR DESCRIPTION
## Summary

- 将 `ServerFacade`（1924 行 / 40+ 方法的上帝对象）拆分为 6 个独立领域 Service + 3 组共享内核模块，Facade 退化为 324 行的薄委托层
- API 契约完全不变，纯内部重构；编译、链接、测试均通过

## 变更内容

### 共享内核（无状态工具模块）

| 模块 | 职责 |
|---|---|
| `service_result.h` | 统一服务层 DTO（原内嵌于 `server_facade.h`） |
| `request_parsing.{h,cpp}` | 请求解析与校验（ParseJsonObject, ValidateDecodedImage 等） |
| `json_serialization.{h,cpp}` | JSON 序列化辅助（TaskToJson, ColorDbInfoToJson 等） |
| `colordb_resolution.{h,cpp}` | ColorDB 解析与通道键归一化（ResolveSelectedColorDbs 等） |

### 领域 Service（依赖注入，无跨服务直接调用）

| Service | 行数 | 职责 |
|---|---|---|
| `ColorDbService` | 95 | ColorDB 列表与会话库 CRUD |
| `TaskService` | 45 | 任务列表/查询/删除/artifact 下载 |
| `CalibrationService` | 356 | 校准板生成/定位/ColorDB 构建 |
| `ConvertService` | 462 | 光栅/矢量转换任务提交与请求构建 |
| `MattingVectorizeService` | 329 | 抠图与矢量化任务 |
| `RecipeEditorService` | 201 | 配方编辑器全流程 |

### ServerFacade 重构

- 保留跨域查询方法（Health, ConvertDefaults, VectorizeDefaults, MattingMethods, GetModelPackInfo）
- 所有领域方法转为一行委托调用
- 构造函数作为组合根初始化所有子服务

### 其他

- `CMakeLists.txt` 注册全部 9 个新 .cpp 源文件
- `docs/agents/web/backend/README.md` 同步更新模块索引

## Test plan

- [x] `cmake --build . --target chromaprint3d_server` 编译链接通过
- [x] `chromaprint3d_backend_tests` 全部 PASSED
- [ ] 部署后 `GET /api/v1/health` 冒烟验证
- [ ] 核心流程端到端验证（转换、抠图、矢量化、校准板、配方编辑）