### PR TITLE
feat: 集成 Umami 自托管访问统计

### DIFF
--- a/docs/deploy/umami/docker-compose.yml
+++ b/docs/deploy/umami/docker-compose.yml
@@ -1,0 +1,40 @@
+# Umami 访问统计 — 独立 Docker Compose 栈
+#
+# 部署位置：家庭主机 ~/umami-deploy/docker-compose.yml
+# 与 ChromaPrint3D 完全独立，互不影响。
+#
+# 使用方法：
+#   1. 复制本文件到 ~/umami-deploy/docker-compose.yml
+#   2. 创建 ~/umami-deploy/.env（见下方注释）
+#   3. cd ~/umami-deploy && docker compose up -d
+#   4. 浏览器访问 http://192.168.1.9:3000 进入管理后台
+#   5. 默认账号 admin / umami，首次登录后立即修改密码
+#
+# .env 文件内容：
+#   UMAMI_DB_PASSWORD=<随机密码>
+#   UMAMI_APP_SECRET=<随机密钥>
+
+services:
+  umami-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: umami
+      POSTGRES_USER: umami
+      POSTGRES_PASSWORD: ${UMAMI_DB_PASSWORD}
+    volumes:
+      - umami-db-data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    environment:
+      DATABASE_URL: postgresql://umami:${UMAMI_DB_PASSWORD}@umami-db:5432/umami
+      APP_SECRET: ${UMAMI_APP_SECRET}
+    ports:
+      - "192.168.1.9:3000:3000"
+    depends_on:
+      - umami-db
+    restart: unless-stopped
+
+volumes:
+  umami-db-data:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -478,8 +478,8 @@ server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-    # CSP 中明确允许前端连接家庭 API
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://api.chromaprint3d.com:9443; connect-src 'self' https://api.chromaprint3d.com:9443;" always;
+    # CSP 中明确允许前端连接家庭 API；script-src 包含 API 域名以加载 Umami 追踪脚本
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://api.chromaprint3d.com:9443; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://api.chromaprint3d.com:9443; connect-src 'self' https://api.chromaprint3d.com:9443;" always;
 
     # --- 压缩（HTML/CSS/JS/SVG/JSON） ---
     gzip on;
@@ -762,3 +762,103 @@ mkdir -p ~/chromaprint3d-deploy-preview/nginx/conf.d
 ```
 
 两套部署使用不同配置文件，指向不同的 `CLOUD_WEB_ROOT`、`HOME_DEPLOY_DIR`、`VITE_API_BASE`，复用同一个部署脚本。
+
+---
+
+## 8. Umami 访问统计（可选）
+
+自托管 [Umami](https://umami.is/) 提供轻量、隐私友好的网站访问统计。
+
+### 8.1 部署 Umami（家庭主机，一次性）
+
+参考配置见仓库 `docs/deploy/umami/docker-compose.yml`。
+
+```bash
+mkdir -p ~/umami-deploy && cd ~/umami-deploy
+
+# 创建 .env
+cat > .env <<'EOF'
+UMAMI_DB_PASSWORD=<随机密码>
+UMAMI_APP_SECRET=<随机密钥>
+EOF
+
+# 复制 docker-compose.yml（或从仓库 docs/deploy/umami/ 获取）
+# 启动
+docker compose up -d
+```
+
+管理后台：`http://192.168.1.9:3000`（仅局域网可访问），默认账号 `admin` / `umami`，首次登录后修改密码。
+
+### 8.2 Nginx 配置
+
+#### 家庭 Nginx（api.chromaprint3d.com server block）
+
+添加两条精确匹配规则，将数据采集请求代理到 Umami：
+
+```nginx
+location = /stats/script.js {
+    proxy_pass http://192.168.1.9:3000/script.js;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+location = /stats/api/send {
+    proxy_pass http://192.168.1.9:3000/api/send;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+预览环境（`api-preview.chromaprint3d.com`）的 server block 添加相同规则。
+
+#### 云 Nginx（chromaprint3d.com server block）
+
+仅更新 CSP 头，允许从 API 域名加载追踪脚本：
+
+```
+script-src 'self' https://api.chromaprint3d.com:9443;
+```
+
+预览站同理添加 `https://api-preview.chromaprint3d.com:9444`。
+
+### 8.3 前端环境变量
+
+在构建环境的 `.env` 文件中添加（与 `VITE_API_BASE` 同级，一次性配置）：
+
+```bash
+# 正式版 (scripts/deploy_split.local.env)
+VITE_UMAMI_HOST=https://api.chromaprint3d.com:9443/stats
+VITE_UMAMI_WEBSITE_ID=<正式版 website-id>
+
+# 预览版 (scripts/deploy_split-preview.local.env)
+VITE_UMAMI_HOST=https://api-preview.chromaprint3d.com:9444/stats
+VITE_UMAMI_WEBSITE_ID=<预览版 website-id>
+```
+
+`website-id` 在 Umami 管理后台添加网站后获取。
+
+### 8.4 备份
+
+```bash
+# 手动备份
+docker compose -f ~/umami-deploy/docker-compose.yml exec -T umami-db \
+  pg_dump -U umami umami > ~/backups/umami-$(date +%Y%m%d).sql
+
+# 自动备份（crontab，每天 3 点，保留 30 天）
+0 3 * * * docker compose -f ~/umami-deploy/docker-compose.yml exec -T umami-db \
+  pg_dump -U umami umami | gzip > ~/backups/umami-$(date +\%Y\%m\%d).sql.gz \
+  && find ~/backups/ -name "umami-*.sql.gz" -mtime +30 -delete
+```
+
+### 8.5 升级
+
+Umami 容器启动时自动执行数据库迁移，升级只需：
+
+```bash
+cd ~/umami-deploy
+docker compose pull && docker compose up -d
+```
+
+升级前建议先执行一次手动备份。

--- a/scripts/deploy_split-preview.env.example
+++ b/scripts/deploy_split-preview.env.example
@@ -1,0 +1,45 @@
+# Preview deployment config for split architecture.
+# Copy to scripts/deploy_split-preview.env and edit values.
+#
+# Usage: ./scripts/deploy_split.sh scripts/deploy_split-preview.env
+#
+# This deploys the preview track alongside the stable track.
+# The stable track uses deploy_split.env.
+
+# ---------- Cloud host (preview frontend static files) ----------
+CLOUD_HOST="neroued@chromaprint3d.com"
+CLOUD_SSH_PORT="22"
+CLOUD_WEB_ROOT="/var/www/chromaprint3d-preview"
+CLOUD_UPLOAD_TAR="/tmp/chromaprint3d-preview-web.tar.gz"
+CLOUD_USE_SUDO="1"
+CLOUD_RELOAD_NGINX="1"
+CLOUD_KEEP_ROLLBACKS="2"
+
+# ---------- Home host (preview backend docker compose) ----------
+# The docker-compose.yml for preview should use the preview-api image:
+#   image: neroued/chromaprint3d:preview-api
+# This runs on a separate port from the stable API stack.
+HOME_HOST="neroued@<home-host>"
+HOME_SSH_PORT="22"
+HOME_DEPLOY_DIR="$HOME/chromaprint3d-deploy-preview"
+HOME_USE_SUDO="0"
+HOME_HEALTH_TIMEOUT_SECONDS="120"
+HOME_ROLLBACK_DIR="$HOME/.chromaprint3d-rollbacks-preview"
+
+# ---------- Frontend build ----------
+# Point to the preview API endpoint (different port from stable).
+VITE_API_BASE="https://api-preview.chromaprint3d.com:9444"
+
+# Update check points to preview domain manifest.
+VITE_UPDATE_MANIFEST_URL="https://preview.chromaprint3d.com/version-manifest.json"
+
+# Link shown in footer to switch between preview and stable versions.
+VITE_STABLE_URL="https://chromaprint3d.com"
+
+# ---------- Umami analytics (optional) ----------
+# Leave empty to disable. See docs/deployment.md §8.
+VITE_UMAMI_HOST="https://api-preview.chromaprint3d.com:9444/stats"
+VITE_UMAMI_WEBSITE_ID=""
+
+# Set to 1 to run "npm ci" before build.
+WEB_INSTALL_DEPS="0"

--- a/scripts/deploy_split.env.example
+++ b/scripts/deploy_split.env.example
@@ -1,0 +1,45 @@
+# Copy this file to scripts/deploy_split.env, then edit values.
+
+# ---------- Cloud host (frontend static files) ----------
+CLOUD_HOST="neroued@chromaprint3d.com"
+CLOUD_SSH_PORT="22"
+CLOUD_WEB_ROOT="/var/www/chromaprint3d"
+CLOUD_UPLOAD_TAR="/tmp/chromaprint3d-web.tar.gz"
+CLOUD_USE_SUDO="1"
+CLOUD_RELOAD_NGINX="1"
+# Keep latest N rollback snapshots on cloud host.
+CLOUD_KEEP_ROLLBACKS="2"
+
+# ---------- Home host (backend docker compose) ----------
+# The docker-compose.yml on the home host should use the API-only image:
+#   image: neroued/chromaprint3d:api
+# This image contains only the backend (no frontend static files).
+# The deploy script runs "docker compose pull && up" to update to the latest tag.
+HOME_HOST="neroued@<home-host>"
+HOME_SSH_PORT="22"
+HOME_DEPLOY_DIR="$HOME/chromaprint3d-deploy"
+HOME_USE_SUDO="0"
+# Wait up to N seconds for containers to become running/healthy after update.
+HOME_HEALTH_TIMEOUT_SECONDS="120"
+# Store rollback snapshots (compose config + image references) on home host.
+HOME_ROLLBACK_DIR="$HOME/.chromaprint3d-rollbacks"
+
+# ---------- Frontend build ----------
+# Leave empty to use existing web/.env.production value.
+VITE_API_BASE="https://api.chromaprint3d.com:9443"
+
+# Manifest URL for version update notification.
+# Points to the cloud-hosted manifest file; leave empty to disable update checks.
+VITE_UPDATE_MANIFEST_URL="https://chromaprint3d.com/version-manifest.json"
+
+# Link shown in footer to switch to the preview version.
+# Leave empty to hide the link (e.g. when no preview is currently deployed).
+VITE_PREVIEW_URL=""
+
+# ---------- Umami analytics (optional) ----------
+# Leave empty to disable. See docs/deployment.md §8.
+VITE_UMAMI_HOST="https://api.chromaprint3d.com:9443/stats"
+VITE_UMAMI_WEBSITE_ID=""
+
+# Set to 1 to run "npm ci" before build.
+WEB_INSTALL_DEPS="0"

--- a/scripts/deploy_split.sh
+++ b/scripts/deploy_split.sh
@@ -90,6 +90,14 @@ if [[ -n "${VITE_PREVIEW_URL:-}" ]]; then
     info "Using VITE_PREVIEW_URL=$VITE_PREVIEW_URL"
     BUILD_ENV+=(VITE_PREVIEW_URL="$VITE_PREVIEW_URL")
 fi
+if [[ -n "${VITE_UMAMI_HOST:-}" ]]; then
+    info "Using VITE_UMAMI_HOST=$VITE_UMAMI_HOST"
+    BUILD_ENV+=(VITE_UMAMI_HOST="$VITE_UMAMI_HOST")
+fi
+if [[ -n "${VITE_UMAMI_WEBSITE_ID:-}" ]]; then
+    info "Using VITE_UMAMI_WEBSITE_ID=$VITE_UMAMI_WEBSITE_ID"
+    BUILD_ENV+=(VITE_UMAMI_WEBSITE_ID="$VITE_UMAMI_WEBSITE_ID")
+fi
 if (( ${#BUILD_ENV[@]} > 0 )); then
     (cd "$ROOT_DIR/web/frontend" && env "${BUILD_ENV[@]}" npm run build)
 else

--- a/web/frontend/src/api/base.test.ts
+++ b/web/frontend/src/api/base.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isAutomatedRequest, normalizeEndpoint, request } from './base'
+import { setSessionToken } from '../runtime/session'
+
+describe('normalizeEndpoint', () => {
+  it('strips the /api/v1/ prefix', () => {
+    expect(normalizeEndpoint('/api/v1/databases')).toBe('databases')
+  })
+
+  it('replaces UUIDs with :id', () => {
+    expect(normalizeEndpoint('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(
+      'tasks/:id',
+    )
+  })
+
+  it('replaces artifact keys with :key', () => {
+    expect(
+      normalizeEndpoint('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890/artifacts/layer-top'),
+    ).toBe('tasks/:id/artifacts/:key')
+  })
+
+  it('handles recipe-editor paths', () => {
+    expect(
+      normalizeEndpoint('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890/recipe-editor/summary'),
+    ).toBe('tasks/:id/recipe-editor/summary')
+  })
+
+  it('leaves paths without dynamic segments unchanged', () => {
+    expect(normalizeEndpoint('/api/v1/convert/raster')).toBe('convert/raster')
+    expect(normalizeEndpoint('/api/v1/convert/vector/analyze-width')).toBe(
+      'convert/vector/analyze-width',
+    )
+  })
+
+  it('handles multiple UUIDs in one path', () => {
+    expect(
+      normalizeEndpoint(
+        '/api/v1/tasks/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/artifacts/ffffffff-1111-2222-3333-444444444444',
+      ),
+    ).toBe('tasks/:id/artifacts/:key')
+  })
+})
+
+describe('isAutomatedRequest', () => {
+  it('excludes task status polling (GET /api/v1/tasks/:id)', () => {
+    expect(isAutomatedRequest('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'GET')).toBe(
+      true,
+    )
+  })
+
+  it('excludes health check', () => {
+    expect(isAutomatedRequest('/api/v1/health', 'GET')).toBe(true)
+  })
+
+  it('allows task list (GET /api/v1/tasks)', () => {
+    expect(isAutomatedRequest('/api/v1/tasks', 'GET')).toBe(false)
+  })
+
+  it('allows task deletion (DELETE /api/v1/tasks/:id)', () => {
+    expect(isAutomatedRequest('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'DELETE')).toBe(
+      false,
+    )
+  })
+
+  it('allows POST conversion', () => {
+    expect(isAutomatedRequest('/api/v1/convert/raster', 'POST')).toBe(false)
+  })
+
+  it('allows recipe-editor sub-paths', () => {
+    expect(
+      isAutomatedRequest(
+        '/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890/recipe-editor/summary',
+        'GET',
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('request() tracking', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    setSessionToken(null)
+  })
+
+  function mockFetch(envelope: object, status = 200) {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(envelope), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  it('calls umami.track on successful non-automated request', async () => {
+    mockFetch({ ok: true, data: { databases: [] } })
+    const trackMock = vi.fn()
+    vi.stubGlobal('umami', { track: trackMock })
+    window.umami = { track: trackMock }
+
+    await request('/api/v1/databases')
+
+    expect(trackMock).toHaveBeenCalledTimes(1)
+    const [event, data] = trackMock.mock.calls[0] as [string, Record<string, unknown>]
+    expect(event).toBe('api-call')
+    expect(data.endpoint).toBe('databases')
+    expect(data.method).toBe('GET')
+    expect(data.success).toBe(true)
+    expect(typeof data.duration).toBe('number')
+  })
+
+  it('does not call umami.track for automated requests (polling)', async () => {
+    mockFetch({ ok: true, data: { id: 't1', status: 'completed' } })
+    const trackMock = vi.fn()
+    window.umami = { track: trackMock }
+
+    await request('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+
+    expect(trackMock).not.toHaveBeenCalled()
+  })
+
+  it('does not call umami.track for health check', async () => {
+    mockFetch({ ok: true, data: { status: 'ok' } })
+    const trackMock = vi.fn()
+    window.umami = { track: trackMock }
+
+    await request('/api/v1/health')
+
+    expect(trackMock).not.toHaveBeenCalled()
+  })
+
+  it('reports success=false when request fails', async () => {
+    mockFetch({ ok: false, error: 'bad request' }, 400)
+    const trackMock = vi.fn()
+    window.umami = { track: trackMock }
+
+    await expect(request('/api/v1/convert/raster', { method: 'POST' })).rejects.toThrow()
+
+    expect(trackMock).toHaveBeenCalledTimes(1)
+    const [, data] = trackMock.mock.calls[0] as [string, Record<string, unknown>]
+    expect(data.success).toBe(false)
+    expect(data.method).toBe('POST')
+  })
+
+  it('does not throw when window.umami is undefined', async () => {
+    mockFetch({ ok: true, data: [] })
+    window.umami = undefined
+
+    await expect(request('/api/v1/databases')).resolves.toEqual([])
+  })
+})

--- a/web/frontend/src/api/base.ts
+++ b/web/frontend/src/api/base.ts
@@ -19,21 +19,54 @@ function parseErrorMessage(payload: ApiErrorPayload | undefined, fallback: strin
   return payload.message ?? payload.code ?? fallback
 }
 
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
+
+export function normalizeEndpoint(url: string): string {
+  return url
+    .replace(/^\/api\/v1\//, '')
+    .replace(UUID_RE, ':id')
+    .replace(/\/artifacts\/[^/?]+/, '/artifacts/:key')
+}
+
+export function isAutomatedRequest(url: string, method: string): boolean {
+  if (method === 'GET' && /^\/api\/v1\/tasks\/[^/]+$/.test(url)) return true
+  if (url === '/api/v1/health') return true
+  return false
+}
+
 export async function request<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetchWithSession(url, init)
+  const method = init?.method?.toUpperCase() ?? 'GET'
+  const shouldTrack = !isAutomatedRequest(url, method)
+  const start = shouldTrack ? performance.now() : 0
 
-  let envelope: ApiEnvelope<T> | null = null
+  let success = true
   try {
-    envelope = (await res.json()) as ApiEnvelope<T>
-  } catch {
-    // ignore parse errors, fallback to HTTP status
-  }
+    const res = await fetchWithSession(url, init)
 
-  if (!res.ok) {
-    throw new Error(parseErrorMessage(envelope?.error, `HTTP ${res.status}`))
+    let envelope: ApiEnvelope<T> | null = null
+    try {
+      envelope = (await res.json()) as ApiEnvelope<T>
+    } catch {
+      // ignore parse errors, fallback to HTTP status
+    }
+
+    if (!res.ok) {
+      success = false
+      throw new Error(parseErrorMessage(envelope?.error, `HTTP ${res.status}`))
+    }
+    if (!envelope?.ok) {
+      success = false
+      throw new Error(parseErrorMessage(envelope?.error, 'Request failed'))
+    }
+    return envelope.data as T
+  } catch (err) {
+    success = false
+    throw err
+  } finally {
+    if (shouldTrack) {
+      const duration = Math.round(performance.now() - start)
+      const endpoint = normalizeEndpoint(url)
+      window.umami?.track('api-call', { endpoint, method, success, duration })
+    }
   }
-  if (!envelope?.ok) {
-    throw new Error(parseErrorMessage(envelope?.error, 'Request failed'))
-  }
-  return envelope.data as T
 }

--- a/web/frontend/src/composables/useTracking.ts
+++ b/web/frontend/src/composables/useTracking.ts
@@ -1,0 +1,6 @@
+export function useTracking() {
+  function trackEvent(name: string, data?: Record<string, unknown>) {
+    window.umami?.track(name, data)
+  }
+  return { trackEvent }
+}

--- a/web/frontend/src/electron.d.ts
+++ b/web/frontend/src/electron.d.ts
@@ -122,5 +122,14 @@ declare global {
 
   interface Window {
     electron?: ElectronRendererApi
+    umami?: {
+      track(event: string, data?: Record<string, unknown>): void
+      track(callback: () => { name: string; data?: Record<string, unknown> }): void
+    }
+  }
+
+  interface ImportMetaEnv {
+    readonly VITE_UMAMI_HOST?: string
+    readonly VITE_UMAMI_WEBSITE_ID?: string
   }
 }

--- a/web/frontend/src/main.ts
+++ b/web/frontend/src/main.ts
@@ -6,6 +6,16 @@ import './styles/base.css'
 import './styles/app-shell.css'
 import './styles/calibration.css'
 
+const umamiHost = import.meta.env.VITE_UMAMI_HOST
+const umamiWebsiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID
+if (umamiHost && umamiWebsiteId) {
+  const script = document.createElement('script')
+  script.defer = true
+  script.src = `${umamiHost}/script.js`
+  script.dataset.websiteId = umamiWebsiteId
+  document.head.appendChild(script)
+}
+
 const app = createApp(App)
 app.use(createPinia())
 app.use(i18n)

--- a/web/frontend/src/runtime/download.ts
+++ b/web/frontend/src/runtime/download.ts
@@ -27,9 +27,10 @@ export async function downloadFromUrl(url: string, filename: string): Promise<vo
     const electronDownload = getElectronApi()?.download
     if (electronDownload?.saveObjectUrlAs) {
       await electronDownload.saveObjectUrlAs(blobUrl, filename)
-      return
+    } else {
+      clickDownloadLink(blobUrl, filename)
     }
-    clickDownloadLink(blobUrl, filename)
+    window.umami?.track('file-download', { filename })
   } finally {
     revokeBlobUrl(blobUrl)
   }


### PR DESCRIPTION
## Summary

- 集成自托管 Umami 访问统计，追踪页面浏览和 API 调用
- 前端通过 `VITE_UMAMI_HOST` / `VITE_UMAMI_WEBSITE_ID` 环境变量控制，开发环境不注入脚本
- API 调用自动追踪内置于 `request()` 函数，含路径归一化（UUID → `:id`）和自动化流量排除（500ms 任务轮询、健康检查不计入）
- 新增 `useTracking` composable 供组件手动埋点，文件下载已埋点
- `deploy_split.sh` 支持传递 Umami 构建变量
- 新增 Umami Docker Compose 参考配置和完整部署文档（deployment.md §8）

## 基础设施变更（已在服务器执行）

- 家庭主机：Umami Docker 容器已部署在 `~/umami-deploy/`，管理后台局域网直连 `:3000`
- 家庭主机：正式版/预览版 Nginx 已添加 `/stats/script.js` 和 `/stats/api/send` 反代
- Umami 后台已创建正式版和预览版两个 website
- **待手动执行**：云主机 Nginx CSP `script-src` 需添加 API 域名（需 sudo）

## Test plan

- [x] `npm run test` — 54 个测试全部通过（含 17 个新增追踪相关测试）
- [ ] 云主机 CSP 更新后，部署预览版验证追踪脚本加载和数据上报
- [ ] 在 Umami 管理面板确认页面浏览和 API 事件数据
- [ ] 确认开发环境（无 VITE_UMAMI_* 变量）不加载追踪脚本