### PR TITLE
fix(recipe-editor): 修复自定义配方调色盘无法生效的问题

### DIFF
--- a/web/frontend/src/components/recipeEditor/CustomRecipeDialog.vue
+++ b/web/frontend/src/components/recipeEditor/CustomRecipeDialog.vue
@@ -286,7 +286,7 @@ function renderChannelLabel(option: { label: string; value: number }) {
               :modes="['hex']"
               :show-alpha="false"
               style="width: 120px"
-              @complete="handleHexChange"
+              @update:value="handleHexChange"
             />
             <span class="color-preview-swatch" :style="{ backgroundColor: hexColor }" />
           </div>


### PR DESCRIPTION
## Summary

- `NColorPicker` 的 `@complete` 事件仅在面板关闭时触发，但调色盘内联在对话框中没有独立的关闭操作，导致用户选色后回调永远不会执行
- 改为 `@update:value`，实时响应颜色选择

## Test plan

- [x] 打开自定义配方对话框，拖动调色盘选色，确认 hex 和 Lab 值实时更新