### PR TITLE
fix: 8色校色板生成失败——理论配方数上限误判

### DIFF
--- a/core/src/calib/calib.cpp
+++ b/core/src/calib/calib.cpp
@@ -34,13 +34,8 @@ namespace {
 
 constexpr uint16_t kInvalidRecipeIdx = 0xFFFF;
 
-static void ValidateConfig(const CalibrationBoardConfig& cfg) {
+static void ValidateConfigBase(const CalibrationBoardConfig& cfg) {
     if (!cfg.recipe.IsSupported()) { throw ConfigError("Calibration recipe is not supported"); }
-    if (cfg.recipe.NumRecipes() > CalibrationRecipeSpec::kMaxRecipes) {
-        throw ConfigError("Recipe count (" + std::to_string(cfg.recipe.NumRecipes()) +
-                          ") exceeds maximum (" +
-                          std::to_string(CalibrationRecipeSpec::kMaxRecipes) + ")");
-    }
     if (!cfg.palette.empty() && static_cast<int>(cfg.palette.size()) != cfg.recipe.num_channels) {
         throw ConfigError("Calibration palette size does not match num_channels");
     }
@@ -323,7 +318,12 @@ static ColorDB BuildColorDBFromColorRegion(const cv::Mat& input, const Calibrati
 } // namespace
 
 CalibrationBoardMeta BuildCalibrationBoardMeta(const CalibrationBoardConfig& cfg) {
-    ValidateConfig(cfg);
+    ValidateConfigBase(cfg);
+    if (cfg.recipe.NumRecipes() > CalibrationRecipeSpec::kMaxRecipes) {
+        throw ConfigError("Recipe count (" + std::to_string(cfg.recipe.NumRecipes()) +
+                          ") exceeds maximum (" +
+                          std::to_string(CalibrationRecipeSpec::kMaxRecipes) + ")");
+    }
 
     CalibrationBoardMeta meta;
     meta.config = cfg;
@@ -354,7 +354,7 @@ CalibrationBoardMeta BuildCalibrationBoardMeta(const CalibrationBoardConfig& cfg
 CalibrationBoardMeta
 BuildCalibrationBoardMetaCustom(const CalibrationBoardConfig& cfg, int grid_rows, int grid_cols,
                                 const std::vector<std::vector<uint8_t>>& custom_recipes) {
-    ValidateConfig(cfg);
+    ValidateConfigBase(cfg);
     if (grid_rows <= 0 || grid_cols <= 0) { throw InputError("grid size must be positive"); }
 
     CalibrationBoardMeta meta;
@@ -583,7 +583,7 @@ struct BoardBuildResult {
 };
 
 static BoardBuildResult BuildBoardModel(const CalibrationBoardMeta& meta) {
-    ValidateConfig(meta.config);
+    ValidateConfigBase(meta.config);
     ValidateMetaRecipes(meta);
 
     const int grid_rows = meta.grid_rows;


### PR DESCRIPTION
## Summary

- v1.3.0 引入的 `ValidateConfig` 将 `NumRecipes()`（`num_channels^color_layers`）与 `kMaxRecipes(1024)` 比较作为 OOM 防护，但该校验被无差别应用到自定义配方路径，导致 8 色 5 层校色板（理论 `8^5=32768`，实际每板仅用 1600 条预选配方）报错：`Recipe count (32768) exceeds maximum (1024)`
- 将 `ValidateConfig` 拆为 `ValidateConfigBase`（不含配方数上限校验），仅在标准板路径 `BuildCalibrationBoardMeta` 中保留 `NumRecipes` 校验；`BuildCalibrationBoardMetaCustom` 和 `BuildBoardModel` 改用 `ValidateConfigBase`

## 改动范围

仅修改 `core/src/calib/calib.cpp`，3 处调用点：

| 调用点 | 改动 |
|---|---|
| `ValidateConfig` → `ValidateConfigBase` | 移除 `NumRecipes > kMaxRecipes` 检查 |
| `BuildCalibrationBoardMeta` | 调用 `ValidateConfigBase` 后内联 `NumRecipes` 上限检查 |
| `BuildCalibrationBoardMetaCustom` | 改用 `ValidateConfigBase`，不检查理论组合数 |
| `BuildBoardModel` | 改用 `ValidateConfigBase`，避免重复误判 |

## Test plan

- [ ] 全量编译通过（已验证）
- [ ] 8 色校色板生成不再报 `Recipe count exceeds maximum` 错误
- [ ] 标准 4 色校色板 OOM 防护仍然生效（4 色 6 层 = 4096 > 1024 应被拒绝）