### PR TITLE
fix(recipe-editor): 点击空白区域取消选中

### DIFF
--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -225,10 +225,16 @@ function handleViewportClick(event: MouseEvent) {
   }
 
   const pixel = screenToImagePixel(event.clientX, event.clientY)
-  if (!pixel) return
+  if (!pixel) {
+    clearSelection()
+    return
+  }
 
   const regionId = getRegionAtPixel(pixel.x, pixel.y)
-  if (regionId === null || regionId === 0xffffffff) return
+  if (regionId === null || regionId === 0xffffffff) {
+    clearSelection()
+    return
+  }
 
   if (globalMode.value) {
     const recipeIdx = regionLookup.value.get(regionId)


### PR DESCRIPTION
## Summary

- 配方编辑器预览区域中，点击不属于任何区域的空白位置时，自动清空当前选中状态
- 之前点击空白区域无任何响应，现在行为与"清除选择"按钮一致

## Test plan

- [ ] 在配方编辑器中选中一个区域，点击图像空白处，确认选中状态被清除
- [ ] 在全局模式下选中配方后，点击空白处，确认选中被清除
- [ ] 拖拽画布后释放在空白处，确认不会误触发取消选中（拖拽阈值保护）
- [ ] 点击有效区域的选择/取消选择行为不受影响