### PR TITLE
release: v1.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ChromaPrint3D VERSION 1.3.0 LANGUAGES CXX)
+project(ChromaPrint3D VERSION 1.3.1 LANGUAGES CXX)
 
 set(CHROMAPRINT3D_VERSION_PRERELEASE "" CACHE STRING "Pre-release suffix, e.g. rc.1")
 if(CHROMAPRINT3D_VERSION_PRERELEASE)

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "ChromaPrint3D - Multi-color 3D printing image processor",
   "author": "neroued <neroued@gmail.com>",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromaprint3d-web",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Web frontend for ChromaPrint3D — multi-color 3D print image processor",
   "type": "module",
   "license": "Apache-2.0",

--- a/web/frontend/public/version-manifest.json
+++ b/web/frontend/public/version-manifest.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.3.0",
-  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.3.0",
-  "changelog": "- 色层数自由调节，支持 1–20 层，不再受限于固定模式\n- 新增自定义配方编辑器，可手动设计配色方案并实时预览颜色效果\n- 自定义配方支持历史记录，可一键复用到其他区域\n- 配方搜索支持按层颜色模式匹配，快速定位目标配方\n- 配方面板改版，替代配方与自定义配方分区展示",
-  "changelog_en": "- Freely adjustable color layers (1–20), no longer limited to fixed modes\n- New custom recipe editor with real-time color prediction\n- Custom recipe history: reuse recipes across regions with one click\n- Recipe search by layer color pattern for quick matching\n- Revamped recipe panel with tabbed layout",
-  "published_at": "2026-04-11"
+  "version": "1.3.1",
+  "download_url": "https://github.com/neroued/ChromaPrint3D/releases/tag/v1.3.1",
+  "changelog": "- 色层数自由调节，支持 1–20 层，不再受限于固定模式\n- 新增自定义配方编辑器，可手动设计配色方案并实时预览颜色效果\n- 自定义配方支持历史记录，可一键复用到其他区域\n- 配方搜索支持按层颜色模式匹配，快速定位目标配方\n- 配方面板改版，替代配方与自定义配方分区展示\n- 配方编辑器支持点击空白区域取消选中\n- 修复 6 层及以上配置时模型预测与配方搜索不可用的问题\n- 修复 8 色校准板无法生成的问题\n- 修复自定义配方调色盘设置不生效的问题",
+  "changelog_en": "- Freely adjustable color layers (1–20), no longer limited to fixed modes\n- New custom recipe editor with real-time color prediction\n- Custom recipe history: reuse recipes across regions with one click\n- Recipe search by layer color pattern for quick matching\n- Revamped recipe panel with tabbed layout\n- Recipe editor now supports deselecting by clicking empty area\n- Fixed model prediction and recipe search unavailable for 6+ layer configurations\n- Fixed 8-color calibration board generation failure\n- Fixed custom recipe palette settings not taking effect",
+  "published_at": "2026-04-12"
 }


### PR DESCRIPTION
## Release v1.3.1

Bumps version to `1.3.1` in:
- `CMakeLists.txt`
- `web/frontend/package.json`
- `web/electron/package.json`
- `web/frontend/public/version-manifest.json`

After this PR is merged, the `release-tag` workflow will automatically
create tag `v1.3.1` and trigger the full release pipeline.