### PR TITLE
fix(ParamPanel): 修复启用模型开关重复渲染的问题

### DIFF
--- a/web/frontend/src/components/ParamPanel.vue
+++ b/web/frontend/src/components/ParamPanel.vue
@@ -517,62 +517,30 @@ watch(canEnableTransparentLayer, (can) => {
           </NText>
         </div>
 
-        <NFormItem
-          v-else-if="isVector && supportsModelGate"
-          class="param-inline-item"
-          label-placement="left"
-          :label-width="simpleLabelWidth"
-        >
-          <template #label>
-            <NTooltip>
-              <template #trigger>
-                <span class="tip-label">{{ t('param.enableModel') }}</span>
-              </template>
-              {{ modelPackAvailable ? tooltips.model_enable : t('param.modelPackNoMatch') }}
-            </NTooltip>
-          </template>
-          <NSwitch
-            :value="modelValue.model_enable"
-            :disabled="!modelPackAvailable"
-            @update:value="(v: boolean) => update({ model_enable: v })"
-          />
-        </NFormItem>
-        <NText
-          v-if="modelPackModeHint && modelPackAvailable && isVector && supportsModelGate"
-          depth="3"
-          style="font-size: 12px"
-        >
-          {{ modelPackModeHint }}
-        </NText>
-
-        <NFormItem
-          v-else-if="supportsModelGate"
-          label-placement="left"
-          :label-width="simpleLabelWidth"
-        >
-          <template #label>
-            <NTooltip>
-              <template #trigger>
-                <span class="tip-label">{{ t('param.enableModel') }}</span>
-              </template>
-              {{ modelPackAvailable ? tooltips.model_enable : t('param.modelPackNoMatch') }}
-            </NTooltip>
-          </template>
-          <NSwitch
-            :value="modelValue.model_enable"
-            :disabled="!modelPackAvailable"
-            @update:value="(v: boolean) => update({ model_enable: v })"
-          />
-        </NFormItem>
-        <NText
-          v-if="
-            modelPackModeHint && modelPackAvailable && supportsModelGate && !isRaster && !isVector
-          "
-          depth="3"
-          style="font-size: 12px"
-        >
-          {{ modelPackModeHint }}
-        </NText>
+        <template v-else-if="supportsModelGate">
+          <NFormItem
+            :class="{ 'param-inline-item': isVector }"
+            label-placement="left"
+            :label-width="simpleLabelWidth"
+          >
+            <template #label>
+              <NTooltip>
+                <template #trigger>
+                  <span class="tip-label">{{ t('param.enableModel') }}</span>
+                </template>
+                {{ modelPackAvailable ? tooltips.model_enable : t('param.modelPackNoMatch') }}
+              </NTooltip>
+            </template>
+            <NSwitch
+              :value="modelValue.model_enable"
+              :disabled="!modelPackAvailable"
+              @update:value="(v: boolean) => update({ model_enable: v })"
+            />
+          </NFormItem>
+          <NText v-if="modelPackModeHint && modelPackAvailable" depth="3" style="font-size: 12px">
+            {{ modelPackModeHint }}
+          </NText>
+        </template>
 
         <NFormItem
           v-if="isRaster && modelValue.dither && modelValue.dither !== 'none'"


### PR DESCRIPTION
## Summary

- 修复 `ParamPanel.vue` 中"启用模型"开关在 vector 模式下重复渲染的 bug
- 原因：`v-else-if` 条件链被中间的 `<NText v-if="...">` 打断，第三个开关错误地与 `NText` 配对而非第二个开关，导致两个开关同时显示
- 将 vector 分支和兜底分支合并为一个 `<template v-else-if="supportsModelGate">` 块，通过动态 class 区分样式，消除 ~30 行重复代码

## Test plan

- [ ] 在 raster 模式下确认仅显示一个"启用模型"开关（位于 dither 同行）
- [ ] 在 vector 模式下确认仅显示一个"启用模型"开关，且带 `param-inline-item` 样式
- [ ] 在非 raster/非 vector 模式下确认仅显示一个"启用模型"开关
- [ ] 确认 `modelPackModeHint` 提示文本在各模式下正常显示/隐藏