### PR TITLE
fix: 内存分析与优化——jemalloc 集成、shared_ptr 迁移、内存监控

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libopencv-dev libpotrace-dev uuid-dev zlib1g-dev ccache ninja-build
+            libopencv-dev libpotrace-dev uuid-dev zlib1g-dev ccache ninja-build \
+            libjemalloc-dev
           mkdir -p "$CCACHE_DIR"
           mkdir -p build
 

--- a/.github/workflows/release-backend-linux.yml
+++ b/.github/workflows/release-backend-linux.yml
@@ -20,7 +20,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libopencv-dev libpotrace-dev uuid-dev zlib1g-dev ccache ninja-build patchelf
+            libopencv-dev libpotrace-dev uuid-dev zlib1g-dev ccache ninja-build patchelf \
+            libjemalloc-dev
           mkdir -p "$CCACHE_DIR"
           mkdir -p build
 

--- a/.github/workflows/release-backend-macos.yml
+++ b/.github/workflows/release-backend-macos.yml
@@ -59,7 +59,7 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
         run: |
           missing=()
-          for formula in opencv openblas potrace ccache libomp jpeg-turbo ninja zlib; do
+          for formula in opencv openblas potrace ccache libomp jpeg-turbo ninja zlib jemalloc; do
             brew list --formula "$formula" >/dev/null 2>&1 || missing+=("$formula")
           done
           if [ ${#missing[@]} -gt 0 ]; then

--- a/.github/workflows/release-backend-windows.yml
+++ b/.github/workflows/release-backend-windows.yml
@@ -220,7 +220,8 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=sccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
             -DPOTRACE_INCLUDE_DIR="${{ steps.potrace_win.outputs.potrace_include }}" `
-            -DPOTRACE_LIBRARY="${{ steps.potrace_win.outputs.potrace_lib }}"
+            -DPOTRACE_LIBRARY="${{ steps.potrace_win.outputs.potrace_lib }}" `
+            -DCHROMAPRINT3D_USE_JEMALLOC=OFF
 
       - name: Build
         run: cmake --build build --config Release --parallel 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,36 @@ option(CHROMAPRINT3D_BUILD_TESTS "Build unit tests" OFF)
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static libraries" FORCE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# ── jemalloc (optional, reduces heap fragmentation for long-running server) ──
+if(WIN32)
+    option(CHROMAPRINT3D_USE_JEMALLOC "Link jemalloc (experimental on Windows)" OFF)
+else()
+    option(CHROMAPRINT3D_USE_JEMALLOC "Link jemalloc for reduced heap fragmentation" ON)
+endif()
+
+if(CHROMAPRINT3D_USE_JEMALLOC)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(JEMALLOC IMPORTED_TARGET jemalloc)
+    endif()
+    if(NOT JEMALLOC_FOUND)
+        find_library(JEMALLOC_LIB NAMES jemalloc jemalloc_pic)
+        find_path(JEMALLOC_INCLUDE NAMES jemalloc/jemalloc.h)
+        if(JEMALLOC_LIB AND JEMALLOC_INCLUDE)
+            set(JEMALLOC_FOUND TRUE)
+            add_library(jemalloc::jemalloc UNKNOWN IMPORTED)
+            set_target_properties(jemalloc::jemalloc PROPERTIES
+                IMPORTED_LOCATION "${JEMALLOC_LIB}"
+                INTERFACE_INCLUDE_DIRECTORIES "${JEMALLOC_INCLUDE}")
+        endif()
+    endif()
+    if(JEMALLOC_FOUND)
+        message(STATUS "jemalloc found — linking for reduced fragmentation")
+    else()
+        message(STATUS "jemalloc not found — falling back to system allocator")
+    endif()
+endif()
+
 find_package(OpenCV 4.5 REQUIRED COMPONENTS core imgproc imgcodecs)
 message(STATUS "Found OpenCV ${OpenCV_VERSION}: ${OpenCV_INSTALL_PATH}")
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
         libopencv-imgproc4.5d \
         libopencv-imgcodecs4.5d \
         libpotrace0 \
+        libjemalloc2 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid 10001 chromaprint3d \
     && useradd --system --uid 10001 --gid 10001 --home-dir /nonexistent --shell /usr/sbin/nologin chromaprint3d

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libpotrace-dev \
         uuid-dev \
         zlib1g-dev \
+        libjemalloc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -73,7 +73,8 @@ target_sources(chromaprint3d PRIVATE
     src/matting/matting.cpp
     src/matting/matting_postprocess.cpp
     src/detail/icc_utils.cpp
-    src/model/forward_color_model.cpp)
+    src/model/forward_color_model.cpp
+    src/common/memory_utils.cpp)
 
 # ── Optional: infer module for DL matting ─────────────────────────────────────
 
@@ -110,6 +111,17 @@ endif()
 find_package(OpenMP)
 if(OpenMP_CXX_FOUND)
     target_link_libraries(chromaprint3d PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
+# ── jemalloc (propagates to all executables via PUBLIC link) ──────────────────
+
+if(CHROMAPRINT3D_USE_JEMALLOC AND JEMALLOC_FOUND)
+    if(TARGET PkgConfig::JEMALLOC)
+        target_link_libraries(chromaprint3d PUBLIC PkgConfig::JEMALLOC)
+    elseif(TARGET jemalloc::jemalloc)
+        target_link_libraries(chromaprint3d PUBLIC jemalloc::jemalloc)
+    endif()
+    target_compile_definitions(chromaprint3d PUBLIC CHROMAPRINT3D_HAS_JEMALLOC=1)
 endif()
 
 # ── Compiler flags (per-build-type, no hardcoded -O3) ────────────────────────

--- a/core/include/chromaprint3d/memory_utils.h
+++ b/core/include/chromaprint3d/memory_utils.h
@@ -1,0 +1,46 @@
+/// \file memory_utils.h
+/// \brief Cross-platform heap introspection and memory-return utilities.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace ChromaPrint3D {
+
+/// Return freed heap pages to the OS.
+/// Built-in throttle: skips if the last successful purge was less than
+/// \p min_interval_ms ago (default 5 000 ms). Thread-safe.
+/// \return true only if memory was actually returned to the OS.
+bool ReleaseFreedMemory(int min_interval_ms = 5000);
+
+/// Current process RSS in bytes (0 on failure).
+std::size_t GetProcessRssBytes();
+
+/// Container / system memory limit in bytes (0 on failure).
+/// Linux: cgroup v2 `/sys/fs/cgroup/memory.max`, then cgroup v1
+/// `/sys/fs/cgroup/memory/memory.limit_in_bytes`, then total physical RAM.
+/// Other platforms: total physical RAM.
+std::size_t GetMemoryLimitBytes();
+
+struct HeapStats {
+    std::size_t allocated = 0; // application-level allocated
+    std::size_t resident  = 0; // physical memory held by allocator
+    std::size_t mapped    = 0; // virtual memory mapped by allocator
+    bool valid            = false;
+};
+
+HeapStats GetHeapStats();
+
+/// Compile-time allocator identifier.
+constexpr const char* AllocatorName() {
+#if CHROMAPRINT3D_HAS_JEMALLOC
+    return "jemalloc";
+#elif defined(__GLIBC__)
+    return "glibc";
+#else
+    return "system";
+#endif
+}
+
+} // namespace ChromaPrint3D

--- a/core/include/chromaprint3d/model_package.h
+++ b/core/include/chromaprint3d/model_package.h
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -82,15 +83,16 @@ public:
     /// Select the best-matching package for a request.
     /// Requires ALL selected ColorDBs to share the same vendor + material_type.
     /// Returns nullptr if no package matches.
-    const ModelPackage* Select(const std::string& vendor, const std::string& material_type,
-                               const std::vector<std::string>& profile_channel_keys) const;
+    std::shared_ptr<const ModelPackage>
+    Select(const std::string& vendor, const std::string& material_type,
+           const std::vector<std::string>& profile_channel_keys) const;
 
-    const std::vector<ModelPackage>& All() const { return packages_; }
+    const std::vector<std::shared_ptr<const ModelPackage>>& All() const { return packages_; }
 
     bool Empty() const { return packages_.empty(); }
 
 private:
-    std::vector<ModelPackage> packages_;
+    std::vector<std::shared_ptr<const ModelPackage>> packages_;
 };
 
 /// Configuration for the model gate that decides when to prefer model

--- a/core/include/chromaprint3d/pipeline.h
+++ b/core/include/chromaprint3d/pipeline.h
@@ -33,17 +33,14 @@ struct ConvertRasterRequest {
     // ColorDB input (preloaded_dbs takes priority if non-empty)
     std::vector<std::string>
         db_paths; ///< ColorDB file paths or directories (ignored if preloaded_dbs is non-empty).
-    std::vector<const ColorDB*>
+    std::vector<std::shared_ptr<const ColorDB>>
         preloaded_dbs; ///< Preloaded ColorDB instances (takes priority over db_paths).
-    /// Owned copies of session-uploaded ColorDBs; keeps preloaded_dbs pointers valid
-    /// after the originating session snapshot is destroyed.
-    std::vector<std::shared_ptr<const ColorDB>> session_owned_dbs;
 
     // Model package (optional, preloaded takes priority)
     std::string
         model_pack_path; ///< Path to model package file (ignored if preloaded_model_pack is set).
-    const ModelPackage* preloaded_model_pack =
-        nullptr; ///< Preloaded model package (takes priority over model_pack_path).
+    std::shared_ptr<const ModelPackage>
+        preloaded_model_pack; ///< Preloaded model package (takes priority over model_pack_path).
 
     // Image processing
     float scale    = 1.0f; ///< Image scaling factor.
@@ -167,7 +164,7 @@ struct MatchRasterResult {
     FaceOrientation face_orientation = FaceOrientation::FaceUp;
     std::string preset_dir;
 
-    std::vector<ColorDB> dbs;
+    std::vector<std::shared_ptr<const ColorDB>> dbs;
     MatchConfig match_config;
     ModelGateConfig model_gate;
 
@@ -206,11 +203,10 @@ struct ConvertVectorRequest {
     std::string svg_name;            ///< Name when loading from buffer.
 
     std::vector<std::string> db_paths;
-    std::vector<const ColorDB*> preloaded_dbs;
-    std::vector<std::shared_ptr<const ColorDB>> session_owned_dbs;
+    std::vector<std::shared_ptr<const ColorDB>> preloaded_dbs;
 
     std::string model_pack_path;
-    const ModelPackage* preloaded_model_pack = nullptr;
+    std::shared_ptr<const ModelPackage> preloaded_model_pack;
 
     float target_width_mm  = 0.0f; ///< 0 = use SVG original size.
     float target_height_mm = 0.0f; ///< 0 = use SVG original size.
@@ -261,7 +257,7 @@ struct MatchVectorResult {
     FaceOrientation face_orientation = FaceOrientation::FaceUp;
     std::string preset_dir;
 
-    std::vector<ColorDB> dbs;
+    std::vector<std::shared_ptr<const ColorDB>> dbs;
     MatchConfig match_config;
     ModelGateConfig model_gate;
 

--- a/core/include/chromaprint3d/print_profile.h
+++ b/core/include/chromaprint3d/print_profile.h
@@ -52,6 +52,10 @@ struct PrintProfile {
                                           float layer_height_mm        = 0.0f,
                                           const FilamentConfig* config = nullptr);
 
+    static PrintProfile BuildFromColorDBPtrs(std::span<const ColorDB* const> dbs, int color_layers,
+                                             float layer_height_mm        = 0.0f,
+                                             const FilamentConfig* config = nullptr);
+
     /// Keep only channels whose normalized key is in \p allowed_keys.
     /// The base channel is always retained.
     void FilterChannels(const std::vector<std::string>& allowed_keys);

--- a/core/include/chromaprint3d/recipe_alternatives.h
+++ b/core/include/chromaprint3d/recipe_alternatives.h
@@ -90,6 +90,12 @@ public:
     Build(std::span<const ColorDB> dbs, const PrintProfile& profile, const MatchConfig& match_cfg,
           const ModelPackage* model_package = nullptr, const ModelGateConfig& model_gate = {});
 
+    [[nodiscard]] static RecipeSearchCache Build(std::span<const ColorDB* const> db_ptrs,
+                                                 const PrintProfile& profile,
+                                                 const MatchConfig& match_cfg,
+                                                 const ModelPackage* model_package = nullptr,
+                                                 const ModelGateConfig& model_gate = {});
+
     bool IsValid() const;
 
     /// Access the merged palette used by this cache.

--- a/core/include/chromaprint3d/recipe_map.h
+++ b/core/include/chromaprint3d/recipe_map.h
@@ -96,6 +96,14 @@ struct RecipeMap {
                                      const ModelGateConfig& model_gate = ModelGateConfig{},
                                      MatchStats* out_stats             = nullptr);
 
+    static RecipeMap MatchFromRasterPtrs(const RasterProcResult& img,
+                                         std::span<const ColorDB* const> dbs,
+                                         const PrintProfile& profile,
+                                         const MatchConfig& cfg            = MatchConfig{},
+                                         const ModelPackage* model_package = nullptr,
+                                         const ModelGateConfig& model_gate = ModelGateConfig{},
+                                         MatchStats* out_stats             = nullptr);
+
     /// Replace recipes for all pixels in \p target_region_ids with \p new_recipe.
     /// Also updates \c mapped_color and \c source_mask for affected pixels.
     void ReplaceRecipeInRegions(const struct RasterRegionMap& region_map,

--- a/core/include/chromaprint3d/vector_recipe_map.h
+++ b/core/include/chromaprint3d/vector_recipe_map.h
@@ -39,6 +39,14 @@ struct VectorRecipeMap {
                                  const ModelGateConfig& model_gate = {},
                                  MatchStats* out_stats             = nullptr);
 
+    /// Pointer-based overload for shared_ptr pipelines (avoids deep-copying ColorDB objects).
+    static VectorRecipeMap MatchPtrs(const VectorProcResult& result,
+                                     std::span<const ColorDB* const> db_ptrs,
+                                     const PrintProfile& profile, const MatchConfig& cfg = {},
+                                     const ModelPackage* model_package = nullptr,
+                                     const ModelGateConfig& model_gate = {},
+                                     MatchStats* out_stats             = nullptr);
+
     /// Replace the recipe for specified entries.
     void ReplaceRecipeForEntries(const std::vector<int>& entry_indices,
                                  const std::vector<uint8_t>& new_recipe,

--- a/core/src/common/memory_utils.cpp
+++ b/core/src/common/memory_utils.cpp
@@ -98,13 +98,14 @@ bool ReleaseFreedMemory(int min_interval_ms) {
         return false;
     }
 
-    const auto release_guard = [&]() { purge_in_progress.store(false, std::memory_order_release); };
+    struct PurgeGuard {
+        std::atomic<bool>& flag;
+
+        ~PurgeGuard() { flag.store(false, std::memory_order_release); }
+    } guard{purge_in_progress};
 
     prev = last_successful_purge_ms.load(std::memory_order_acquire);
-    if (now_ms - prev < min_interval_ms) {
-        release_guard();
-        return false;
-    }
+    if (now_ms - prev < min_interval_ms) { return false; }
 
     bool purged = false;
 
@@ -115,7 +116,6 @@ bool ReleaseFreedMemory(int min_interval_ms) {
 #endif
 
     if (purged) { last_successful_purge_ms.store(now_ms, std::memory_order_release); }
-    release_guard();
     return purged;
 }
 

--- a/core/src/common/memory_utils.cpp
+++ b/core/src/common/memory_utils.cpp
@@ -1,0 +1,220 @@
+/// \file memory_utils.cpp
+/// \brief Cross-platform heap introspection and memory-return utilities.
+
+#include "chromaprint3d/memory_utils.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+
+#if CHROMAPRINT3D_HAS_JEMALLOC
+#    include <jemalloc/jemalloc.h>
+#endif
+
+#if defined(__linux__)
+#    include <malloc.h>
+#    include <unistd.h>
+#elif defined(__APPLE__)
+#    include <mach/mach.h>
+#    include <sys/sysctl.h>
+#elif defined(_WIN32)
+#    define WIN32_LEAN_AND_MEAN
+#    include <windows.h>
+// must come after windows.h
+#    include <psapi.h>
+#endif
+
+namespace ChromaPrint3D {
+
+namespace {
+
+bool IsUnlimitedMemoryValue(unsigned long long value) {
+    return value == 0 || value >= (1ULL << 60);
+}
+
+#if defined(__linux__)
+std::size_t ReadMemoryLimitFile(const char* path) {
+    std::FILE* f = std::fopen(path, "r");
+    if (!f) return 0;
+
+    char buf[64]{};
+    if (!std::fgets(buf, sizeof(buf), f)) {
+        std::fclose(f);
+        return 0;
+    }
+    std::fclose(f);
+
+    if (std::strncmp(buf, "max", 3) == 0) { return 0; }
+
+    char* end                = nullptr;
+    const auto parsed_value  = std::strtoull(buf, &end, 10);
+    const bool parsed_number = end != buf;
+    if (!parsed_number || IsUnlimitedMemoryValue(parsed_value)) { return 0; }
+    if (parsed_value > static_cast<unsigned long long>(std::numeric_limits<std::size_t>::max())) {
+        return 0;
+    }
+    return static_cast<std::size_t>(parsed_value);
+}
+#endif
+
+#if CHROMAPRINT3D_HAS_JEMALLOC
+bool PurgeJemallocArenas() {
+    unsigned narenas = 0;
+    std::size_t sz   = sizeof(narenas);
+    if (mallctl("arenas.narenas", &narenas, &sz, nullptr, 0) != 0 || narenas == 0) { return false; }
+
+    bool purged_any = false;
+    for (unsigned arena_idx = 0; arena_idx < narenas; ++arena_idx) {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "arena.%u.purge", arena_idx);
+        if (mallctl(buf, nullptr, nullptr, nullptr, 0) == 0) { purged_any = true; }
+    }
+    return purged_any;
+}
+#elif defined(__GLIBC__)
+bool PurgeGlibcHeap() { return malloc_trim(0) != 0; }
+#endif
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// ReleaseFreedMemory — lock-free throttled purge
+// ---------------------------------------------------------------------------
+
+bool ReleaseFreedMemory(int min_interval_ms) {
+    using namespace std::chrono;
+    static std::atomic<int64_t> last_successful_purge_ms{0};
+    static std::atomic<bool> purge_in_progress{false};
+
+    auto now_ms = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+    auto prev   = last_successful_purge_ms.load(std::memory_order_relaxed);
+    if (now_ms - prev < min_interval_ms) return false;
+
+    bool expected = false;
+    if (!purge_in_progress.compare_exchange_strong(expected, true, std::memory_order_acq_rel,
+                                                   std::memory_order_relaxed)) {
+        return false;
+    }
+
+    const auto release_guard = [&]() { purge_in_progress.store(false, std::memory_order_release); };
+
+    prev = last_successful_purge_ms.load(std::memory_order_acquire);
+    if (now_ms - prev < min_interval_ms) {
+        release_guard();
+        return false;
+    }
+
+    bool purged = false;
+
+#if CHROMAPRINT3D_HAS_JEMALLOC
+    purged = PurgeJemallocArenas();
+#elif defined(__GLIBC__)
+    purged = PurgeGlibcHeap();
+#endif
+
+    if (purged) { last_successful_purge_ms.store(now_ms, std::memory_order_release); }
+    release_guard();
+    return purged;
+}
+
+// ---------------------------------------------------------------------------
+// GetProcessRssBytes
+// ---------------------------------------------------------------------------
+
+std::size_t GetProcessRssBytes() {
+#if defined(__linux__)
+    // /proc/self/statm fields: size resident shared text lib data dt (in pages)
+    std::FILE* f = std::fopen("/proc/self/statm", "r");
+    if (!f) return 0;
+    unsigned long pages = 0;
+    // skip first field (total vm size)
+    if (std::fscanf(f, "%*lu %lu", &pages) != 1) pages = 0;
+    std::fclose(f);
+    return static_cast<std::size_t>(pages) * static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
+#elif defined(__APPLE__)
+    mach_task_basic_info_data_t info{};
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info),
+                  &count) == KERN_SUCCESS) {
+        return static_cast<std::size_t>(info.resident_size);
+    }
+    return 0;
+#elif defined(_WIN32)
+    PROCESS_MEMORY_COUNTERS pmc{};
+    pmc.cb = sizeof(pmc);
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
+        return static_cast<std::size_t>(pmc.WorkingSetSize);
+    }
+    return 0;
+#else
+    return 0;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// GetMemoryLimitBytes
+// ---------------------------------------------------------------------------
+
+std::size_t GetMemoryLimitBytes() {
+#if defined(__linux__)
+    if (const auto v2_limit = ReadMemoryLimitFile("/sys/fs/cgroup/memory.max"); v2_limit > 0) {
+        return v2_limit;
+    }
+    if (const auto v1_limit = ReadMemoryLimitFile("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+        v1_limit > 0) {
+        return v1_limit;
+    }
+    long pages     = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (pages > 0 && page_size > 0)
+        return static_cast<std::size_t>(pages) * static_cast<std::size_t>(page_size);
+    return 0;
+#elif defined(__APPLE__)
+    int mib[2]      = {CTL_HW, HW_MEMSIZE};
+    uint64_t mem    = 0;
+    std::size_t len = sizeof(mem);
+    if (sysctl(mib, 2, &mem, &len, nullptr, 0) == 0) return static_cast<std::size_t>(mem);
+    return 0;
+#elif defined(_WIN32)
+    MEMORYSTATUSEX ms{};
+    ms.dwLength = sizeof(ms);
+    if (GlobalMemoryStatusEx(&ms)) return static_cast<std::size_t>(ms.ullTotalPhys);
+    return 0;
+#else
+    return 0;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// GetHeapStats
+// ---------------------------------------------------------------------------
+
+HeapStats GetHeapStats() {
+    HeapStats st{};
+#if CHROMAPRINT3D_HAS_JEMALLOC
+    std::size_t epoch    = 1;
+    std::size_t sz_epoch = sizeof(epoch);
+    mallctl("epoch", &epoch, &sz_epoch, &epoch, sz_epoch);
+
+    std::size_t sz = sizeof(std::size_t);
+    mallctl("stats.allocated", &st.allocated, &sz, nullptr, 0);
+    mallctl("stats.resident", &st.resident, &sz, nullptr, 0);
+    mallctl("stats.mapped", &st.mapped, &sz, nullptr, 0);
+    st.valid = true;
+#elif defined(__GLIBC__)
+#    if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33)
+    auto mi = mallinfo2();
+#    else
+    auto mi = mallinfo();
+#    endif
+    st.allocated = static_cast<std::size_t>(mi.uordblks);
+    st.resident  = static_cast<std::size_t>(mi.arena + mi.hblkhd);
+    st.mapped    = st.resident;
+    st.valid     = true;
+#endif
+    return st;
+}
+
+} // namespace ChromaPrint3D

--- a/core/src/match/detail/recipe_convert.h
+++ b/core/src/match/detail/recipe_convert.h
@@ -24,6 +24,8 @@ bool ConvertRecipeToProfile(const Entry& entry, const PreparedDB& prepared_db,
                             const PrintProfile& profile, std::vector<uint8_t>& out_recipe);
 
 std::vector<PreparedDB> PrepareDBs(std::span<const ColorDB> dbs, const PrintProfile& profile);
+std::vector<PreparedDB> PrepareDBs(std::span<const ColorDB* const> dbs,
+                                   const PrintProfile& profile);
 
 } // namespace detail
 } // namespace ChromaPrint3D

--- a/core/src/match/match.cpp
+++ b/core/src/match/match.cpp
@@ -145,48 +145,12 @@ void ValidateImageForMatch(const RasterProcResult& img, bool use_lab) {
     }
 }
 
-} // namespace
-
-RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<const ColorDB> dbs,
-                                     const PrintProfile& profile, const MatchConfig& cfg,
-                                     const ModelPackage* model_package,
-                                     const ModelGateConfig& model_gate, MatchStats* out_stats) {
-    profile.Validate();
-    if (dbs.empty() && !model_gate.model_only) {
-        throw InputError("MatchFromRaster requires at least one ColorDB");
-    }
-
-    spdlog::info("MatchFromRaster: image={}x{}, dbs={}, color_space={}, k={}, clusters={}",
-                 img.width, img.height, dbs.size(),
-                 cfg.color_space == ColorSpace::Lab ? "Lab" : "RGB", cfg.k_candidates,
-                 cfg.cluster_count);
-
-    const bool use_lab = (cfg.color_space == ColorSpace::Lab);
-    ValidateImageForMatch(img, use_lab);
-    const bool model_only = model_gate.model_only;
-
-    std::vector<detail::PreparedDB> prepared_dbs;
-    if (!model_only) {
-        prepared_dbs = detail::PrepareDBs(dbs, profile);
-        spdlog::debug("PrepareDBs: {} DB(s) prepared", prepared_dbs.size());
-    }
-
-    const std::optional<detail::PreparedModel> prepared_model =
-        detail::PrepareModel(model_package, model_gate, profile);
-    if (prepared_model.has_value()) {
-        spdlog::debug("PrepareModel: model ready, model_only={}", model_only);
-    } else {
-        spdlog::debug("PrepareModel: no model available");
-    }
-    if (model_only && !prepared_model.has_value()) {
-        throw ConfigError("Model-only matching requires a compatible model package");
-    }
-    if (!model_only && prepared_dbs.empty() && !prepared_model.has_value()) {
-        throw ConfigError("No compatible ColorDB entries for color_layers=" +
-                          std::to_string(profile.color_layers) +
-                          "; try using the default layer count (5 or 10)");
-    }
-
+RecipeMap MatchFromRasterCore(const RasterProcResult& img,
+                              const std::vector<detail::PreparedDB>& prepared_dbs,
+                              const std::optional<detail::PreparedModel>& prepared_model,
+                              const PrintProfile& profile, const MatchConfig& cfg,
+                              const ModelGateConfig& model_gate, bool model_only, bool use_lab,
+                              MatchStats* out_stats) {
     int stat_total_queries   = 0;
     int stat_db_only         = 0;
     int stat_model_used      = 0;
@@ -433,7 +397,6 @@ RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<cons
                 const int c           = static_cast<int>(idx % static_cast<std::size_t>(img.width));
                 const int label       = slic.labels.at<int>(r, c);
                 if (label < 0 || label >= slic_clusters) { throw InputError("Invalid SLIC label"); }
-
                 const detail::CandidateResult& best =
                     cluster_candidates[static_cast<std::size_t>(label)];
                 result.mapped_color[idx] = best.mapped_lab;
@@ -492,9 +455,9 @@ RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<cons
     const bool use_cluster =
         (resolved_k > 1 && static_cast<std::size_t>(resolved_k) < valid_indices.size());
 
-    spdlog::debug("MatchFromRaster: valid_pixels={}, cluster_method=kmeans, clustering={} (k={}{})",
-                  valid_indices.size(), use_cluster ? "yes" : "no", resolved_k,
-                  auto_k ? ", auto" : "");
+    spdlog::debug("MatchFromRaster: valid_pixels={}, cluster_method=kmeans, clustering={} "
+                  "(resolved_k={}, auto={})",
+                  valid_indices.size(), use_cluster ? "yes" : "no", resolved_k, auto_k);
 
     if (!use_cluster) {
         run_per_pixel_matching();
@@ -502,8 +465,7 @@ RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<cons
         return result;
     }
 
-    cv::Mat labels;
-    cv::Mat centers;
+    cv::Mat labels, centers;
     const cv::TermCriteria criteria(cv::TermCriteria::EPS | cv::TermCriteria::MAX_ITER,
                                     kKMeansMaxIter, kKMeansEps);
 
@@ -511,24 +473,21 @@ RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<cons
         cv::Mat sub_indices(num_valid, 1, CV_32SC1);
         for (int i = 0; i < num_valid; ++i) sub_indices.at<int>(i) = i;
         cv::randShuffle(sub_indices);
-
         cv::Mat sub_samples(kMaxClusterSubsamples, 3, CV_32FC1);
         for (int i = 0; i < kMaxClusterSubsamples; ++i) {
             samples.row(sub_indices.at<int>(i)).copyTo(sub_samples.row(i));
         }
-
         cv::Mat sub_labels;
         cv::kmeans(sub_samples, resolved_k, sub_labels, criteria, 3, cv::KMEANS_PP_CENTERS,
                    centers);
-
         labels = cv::Mat(num_valid, 1, CV_32SC1);
 #ifdef _OPENMP
 #    pragma omp parallel for schedule(static)
 #endif
         for (int i = 0; i < num_valid; ++i) {
-            const float* sample = samples.ptr<float>(i);
             float best_dist     = std::numeric_limits<float>::max();
             int best_label      = 0;
+            const float* sample = samples.ptr<float>(i);
             for (int k = 0; k < resolved_k; ++k) {
                 const float* center = centers.ptr<float>(k);
                 float dist          = 0.0f;
@@ -612,6 +571,91 @@ RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<cons
 
     write_stats();
     return result;
+}
+
+} // namespace
+
+RecipeMap RecipeMap::MatchFromRaster(const RasterProcResult& img, std::span<const ColorDB> dbs,
+                                     const PrintProfile& profile, const MatchConfig& cfg,
+                                     const ModelPackage* model_package,
+                                     const ModelGateConfig& model_gate, MatchStats* out_stats) {
+    profile.Validate();
+    if (dbs.empty() && !model_gate.model_only) {
+        throw InputError("MatchFromRaster requires at least one ColorDB");
+    }
+
+    spdlog::info("MatchFromRaster: image={}x{}, dbs={}, color_space={}, k={}, clusters={}",
+                 img.width, img.height, dbs.size(),
+                 cfg.color_space == ColorSpace::Lab ? "Lab" : "RGB", cfg.k_candidates,
+                 cfg.cluster_count);
+
+    const bool use_lab = (cfg.color_space == ColorSpace::Lab);
+    ValidateImageForMatch(img, use_lab);
+    const bool model_only = model_gate.model_only;
+
+    std::vector<detail::PreparedDB> prepared_dbs;
+    if (!model_only) {
+        prepared_dbs = detail::PrepareDBs(dbs, profile);
+        spdlog::debug("PrepareDBs: {} DB(s) prepared", prepared_dbs.size());
+    }
+
+    const std::optional<detail::PreparedModel> prepared_model =
+        detail::PrepareModel(model_package, model_gate, profile);
+    if (prepared_model.has_value()) {
+        spdlog::debug("PrepareModel: model ready, model_only={}", model_only);
+    } else {
+        spdlog::debug("PrepareModel: no model available");
+    }
+    if (model_only && !prepared_model.has_value()) {
+        throw ConfigError("Model-only matching requires a compatible model package");
+    }
+    if (!model_only && prepared_dbs.empty() && !prepared_model.has_value()) {
+        throw ConfigError("No compatible ColorDB entries for color_layers=" +
+                          std::to_string(profile.color_layers) +
+                          "; try using the default layer count (5 or 10)");
+    }
+
+    return MatchFromRasterCore(img, prepared_dbs, prepared_model, profile, cfg, model_gate,
+                               model_only, use_lab, out_stats);
+}
+
+RecipeMap RecipeMap::MatchFromRasterPtrs(const RasterProcResult& img,
+                                         std::span<const ColorDB* const> db_ptrs,
+                                         const PrintProfile& profile, const MatchConfig& cfg,
+                                         const ModelPackage* model_package,
+                                         const ModelGateConfig& model_gate, MatchStats* out_stats) {
+    profile.Validate();
+    if (db_ptrs.empty() && !model_gate.model_only) {
+        throw InputError("MatchFromRasterPtrs requires at least one ColorDB");
+    }
+
+    spdlog::info("MatchFromRasterPtrs: image={}x{}, dbs={}, color_space={}, k={}, clusters={}",
+                 img.width, img.height, db_ptrs.size(),
+                 cfg.color_space == ColorSpace::Lab ? "Lab" : "RGB", cfg.k_candidates,
+                 cfg.cluster_count);
+
+    const bool use_lab = (cfg.color_space == ColorSpace::Lab);
+    ValidateImageForMatch(img, use_lab);
+    const bool model_only = model_gate.model_only;
+
+    std::vector<detail::PreparedDB> prepared_dbs;
+    if (!model_only) {
+        prepared_dbs = detail::PrepareDBs(db_ptrs, profile);
+        spdlog::debug("PrepareDBs: {} DB(s) prepared (ptr overload)", prepared_dbs.size());
+    }
+
+    const std::optional<detail::PreparedModel> prepared_model =
+        detail::PrepareModel(model_package, model_gate, profile);
+    if (model_only && !prepared_model.has_value()) {
+        throw ConfigError("Model-only matching requires a compatible model package");
+    }
+    if (!model_only && prepared_dbs.empty() && !prepared_model.has_value()) {
+        throw ConfigError("No compatible ColorDB entries for color_layers=" +
+                          std::to_string(profile.color_layers));
+    }
+
+    return MatchFromRasterCore(img, prepared_dbs, prepared_model, profile, cfg, model_gate,
+                               model_only, use_lab, out_stats);
 }
 
 } // namespace ChromaPrint3D

--- a/core/src/match/model_package.cpp
+++ b/core/src/match/model_package.cpp
@@ -65,9 +65,10 @@ ModelPackage ModelPackage::Load(const std::string& path) {
     std::ifstream in(path, std::ios::binary);
     if (!in.is_open()) { throw IOError("Failed to open model package: " + path); }
 
-    const std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)),
-                                     std::istreambuf_iterator<char>());
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)),
+                               std::istreambuf_iterator<char>());
     json j = json::from_msgpack(bytes);
+    { auto discard = std::move(bytes); }
 
     const int schema_ver = j.value("schema_version", 0);
     if (schema_ver != kSchemaVersion) {
@@ -195,9 +196,10 @@ void ModelPackageRegistry::LoadFromDirectory(const std::string& dir) {
 
     for (const auto& file : files) {
         try {
-            packages_.push_back(ModelPackage::Load(file.string()));
-            spdlog::info("Loaded model package: {} [{}::{}]", packages_.back().name,
-                         packages_.back().scope.vendor, packages_.back().scope.material_type);
+            auto pkg = std::make_shared<const ModelPackage>(ModelPackage::Load(file.string()));
+            spdlog::info("Loaded model package: {} [{}::{}]", pkg->name, pkg->scope.vendor,
+                         pkg->scope.material_type);
+            packages_.push_back(std::move(pkg));
         } catch (const std::exception& e) {
             spdlog::warn("Skipping invalid model package {}: {}", file.string(), e.what());
         }
@@ -207,12 +209,13 @@ void ModelPackageRegistry::LoadFromDirectory(const std::string& dir) {
 }
 
 void ModelPackageRegistry::LoadSingle(const std::string& path) {
-    packages_.push_back(ModelPackage::Load(path));
-    spdlog::info("Loaded model package: {} [{}::{}]", packages_.back().name,
-                 packages_.back().scope.vendor, packages_.back().scope.material_type);
+    auto pkg = std::make_shared<const ModelPackage>(ModelPackage::Load(path));
+    spdlog::info("Loaded model package: {} [{}::{}]", pkg->name, pkg->scope.vendor,
+                 pkg->scope.material_type);
+    packages_.push_back(std::move(pkg));
 }
 
-const ModelPackage*
+std::shared_ptr<const ModelPackage>
 ModelPackageRegistry::Select(const std::string& vendor, const std::string& material_type,
                              const std::vector<std::string>& profile_channel_keys) const {
     if (vendor.empty() || material_type.empty()) { return nullptr; }
@@ -220,14 +223,14 @@ ModelPackageRegistry::Select(const std::string& vendor, const std::string& mater
     const std::unordered_set<std::string> profile_keys(profile_channel_keys.begin(),
                                                        profile_channel_keys.end());
 
-    const ModelPackage* best  = nullptr;
+    std::shared_ptr<const ModelPackage> best;
     size_t best_channel_count = 0;
 
     for (const auto& pack : packages_) {
-        if (!pack.MatchesScope(vendor, material_type)) { continue; }
+        if (!pack->MatchesScope(vendor, material_type)) { continue; }
 
         bool all_keys_found = true;
-        for (const auto& key : pack.channel_keys) {
+        for (const auto& key : pack->channel_keys) {
             if (profile_keys.find(key) == profile_keys.end()) {
                 all_keys_found = false;
                 break;
@@ -235,9 +238,9 @@ ModelPackageRegistry::Select(const std::string& vendor, const std::string& mater
         }
         if (!all_keys_found) { continue; }
 
-        if (pack.channel_keys.size() > best_channel_count) {
-            best               = &pack;
-            best_channel_count = pack.channel_keys.size();
+        if (pack->channel_keys.size() > best_channel_count) {
+            best               = pack;
+            best_channel_count = pack->channel_keys.size();
         }
     }
 

--- a/core/src/match/print_profile.cpp
+++ b/core/src/match/print_profile.cpp
@@ -85,23 +85,24 @@ ColorDB PrintProfile::ToColorDB(const std::string& name) const {
     return out;
 }
 
-PrintProfile PrintProfile::BuildFromColorDBs(std::span<const ColorDB> dbs, int color_layers,
-                                             float layer_height_mm, const FilamentConfig* config) {
-    if (dbs.empty()) { throw InputError("BuildFromColorDBs requires at least one ColorDB"); }
+PrintProfile PrintProfile::BuildFromColorDBPtrs(std::span<const ColorDB* const> db_ptrs,
+                                                int color_layers, float layer_height_mm,
+                                                const FilamentConfig* config) {
+    if (db_ptrs.empty()) { throw InputError("BuildFromColorDBs requires at least one ColorDB"); }
 
+    const ColorDB& front = *db_ptrs.front();
     PrintProfile profile;
-    profile.color_layers = color_layers;
-    profile.layer_height_mm =
-        (layer_height_mm > 0.0f) ? layer_height_mm : dbs.front().layer_height_mm;
-
-    profile.base_layers   = dbs.front().base_layers;
-    profile.line_width_mm = (dbs.front().line_width_mm > 0.0f) ? dbs.front().line_width_mm : 0.42f;
-    profile.layer_order   = dbs.front().layer_order;
+    profile.color_layers    = color_layers;
+    profile.layer_height_mm = (layer_height_mm > 0.0f) ? layer_height_mm : front.layer_height_mm;
+    profile.base_layers     = front.base_layers;
+    profile.line_width_mm   = (front.line_width_mm > 0.0f) ? front.line_width_mm : 0.42f;
+    profile.layer_order     = front.layer_order;
 
     std::optional<std::string> base_channel_key;
     std::map<std::string, Channel> sorted_palette;
 
-    for (const ColorDB& db : dbs) {
+    for (const ColorDB* p : db_ptrs) {
+        const ColorDB& db = *p;
         if (db.palette.empty()) { throw ConfigError("ColorDB palette is empty"); }
         if (db.base_channel_idx < 0 ||
             static_cast<std::size_t>(db.base_channel_idx) >= db.palette.size()) {
@@ -146,6 +147,14 @@ PrintProfile PrintProfile::BuildFromColorDBs(std::span<const ColorDB> dbs, int c
 
     profile.Validate();
     return profile;
+}
+
+PrintProfile PrintProfile::BuildFromColorDBs(std::span<const ColorDB> dbs, int color_layers,
+                                             float layer_height_mm, const FilamentConfig* config) {
+    std::vector<const ColorDB*> ptrs;
+    ptrs.reserve(dbs.size());
+    for (const ColorDB& db : dbs) { ptrs.push_back(&db); }
+    return BuildFromColorDBPtrs(ptrs, color_layers, layer_height_mm, config);
 }
 
 void PrintProfile::FilterChannels(const std::vector<std::string>& allowed_keys) {

--- a/core/src/match/recipe_alternatives.cpp
+++ b/core/src/match/recipe_alternatives.cpp
@@ -276,6 +276,26 @@ RecipeSearchCache RecipeSearchCache::Build(std::span<const ColorDB> dbs,
     return cache;
 }
 
+RecipeSearchCache RecipeSearchCache::Build(std::span<const ColorDB* const> db_ptrs,
+                                           const PrintProfile& profile,
+                                           const MatchConfig& match_cfg,
+                                           const ModelPackage* model_package,
+                                           const ModelGateConfig& model_gate) {
+    auto impl            = std::make_shared<Impl>();
+    impl->prepared_dbs   = detail::PrepareDBs(db_ptrs, profile);
+    impl->prepared_model = detail::PrepareModel(model_package, model_gate, profile);
+    impl->profile        = profile;
+    impl->use_lab        = (match_cfg.color_space == ColorSpace::Lab);
+
+    spdlog::info("RecipeSearchCache::Build(ptrs): color_layers={}, dbs={}, model={}",
+                 profile.color_layers, impl->prepared_dbs.size(),
+                 impl->prepared_model.has_value() ? "ready" : "unavailable");
+
+    RecipeSearchCache cache;
+    cache.impl_ = std::move(impl);
+    return cache;
+}
+
 bool RecipeSearchCache::IsValid() const {
     return impl_ && (!impl_->prepared_dbs.empty() || impl_->prepared_model.has_value());
 }

--- a/core/src/match/recipe_convert.cpp
+++ b/core/src/match/recipe_convert.cpp
@@ -182,5 +182,85 @@ std::vector<PreparedDB> PrepareDBs(std::span<const ColorDB> dbs, const PrintProf
     return prepared;
 }
 
+std::vector<PreparedDB> PrepareDBs(std::span<const ColorDB* const> db_ptrs,
+                                   const PrintProfile& profile) {
+    std::unordered_map<std::string, int> key_to_target_channel;
+    key_to_target_channel.reserve(profile.palette.size());
+    for (std::size_t i = 0; i < profile.palette.size(); ++i) {
+        const std::string key = BuildChannelKey(profile.palette[i]);
+        auto [it, inserted]   = key_to_target_channel.emplace(key, static_cast<int>(i));
+        if (!inserted) {
+            throw ConfigError("PrintProfile palette contains duplicated normalized channel");
+        }
+    }
+
+    std::vector<PreparedDB> prepared;
+    prepared.reserve(db_ptrs.size());
+    for (const ColorDB* p : db_ptrs) {
+        const ColorDB& db = *p;
+        if (db.entries.empty() || db.NumChannels() == 0) { continue; }
+        if (db.palette.size() != db.NumChannels()) {
+            throw ConfigError("ColorDB palette size does not match NumChannels");
+        }
+        PreparedDB item;
+        item.db = &db;
+        item.source_to_target_channel.assign(db.NumChannels(), -1);
+        bool has_unmapped = false;
+        for (std::size_t i = 0; i < db.palette.size(); ++i) {
+            const std::string key = BuildChannelKey(db.palette[i]);
+            auto it               = key_to_target_channel.find(key);
+            if (it != key_to_target_channel.end()) {
+                item.source_to_target_channel[i] = it->second;
+            } else {
+                has_unmapped = true;
+            }
+        }
+
+        if (has_unmapped) {
+            auto fdb              = std::make_unique<ColorDB>();
+            fdb->name             = db.name + "_filtered";
+            fdb->max_color_layers = db.max_color_layers;
+            fdb->base_layers      = db.base_layers;
+            fdb->base_channel_idx = db.base_channel_idx;
+            fdb->layer_height_mm  = db.layer_height_mm;
+            fdb->line_width_mm    = db.line_width_mm;
+            fdb->layer_order      = db.layer_order;
+            fdb->palette          = db.palette;
+
+            fdb->entries.reserve(db.entries.size());
+            std::vector<uint8_t> dummy_recipe;
+            for (const Entry& entry : db.entries) {
+                if (ConvertRecipeToProfile(entry, item, profile, dummy_recipe)) {
+                    fdb->entries.push_back(entry);
+                }
+            }
+
+            if (!fdb->entries.empty()) {
+                spdlog::info("PrepareDBs: filtered '{}' from {} to {} entries", db.name,
+                             db.entries.size(), fdb->entries.size());
+                item.filtered_db = std::move(fdb);
+            } else {
+                spdlog::debug(
+                    "PrepareDBs: skipping '{}' — 0 compatible entries after channel filtering",
+                    db.name);
+                continue;
+            }
+        }
+
+        const ColorDB* search_db = item.filtered_db ? item.filtered_db.get() : item.db;
+        if (search_db && !search_db->entries.empty()) {
+            (void)search_db->NearestEntry(search_db->entries.front().lab);
+        }
+
+        prepared.push_back(std::move(item));
+    }
+    if (prepared.empty()) {
+        spdlog::warn("PrepareDBs: all {} DB(s) filtered out — no compatible entries for the "
+                     "current profile (model fallback may still be available)",
+                     db_ptrs.size());
+    }
+    return prepared;
+}
+
 } // namespace detail
 } // namespace ChromaPrint3D

--- a/core/src/match/vector_match.cpp
+++ b/core/src/match/vector_match.cpp
@@ -5,6 +5,7 @@
 #include "chromaprint3d/recipe_map.h"
 #include "chromaprint3d/error.h"
 #include "detail/candidate_select.h"
+#include "detail/recipe_convert.h"
 
 #include <spdlog/spdlog.h>
 
@@ -42,17 +43,11 @@ struct CachedMatch {
     bool from_model = false;
 };
 
-} // namespace
-
-VectorRecipeMap VectorRecipeMap::Match(const VectorProcResult& result, std::span<const ColorDB> dbs,
-                                       const PrintProfile& profile, const MatchConfig& cfg,
-                                       const ModelPackage* model_package,
-                                       const ModelGateConfig& model_gate, MatchStats* out_stats) {
-    if (dbs.empty() && !model_gate.model_only) {
-        throw InputError("VectorRecipeMap::Match: no ColorDBs provided");
-    }
-    profile.Validate();
-
+VectorRecipeMap MatchVectorCore(const VectorProcResult& result,
+                                const std::vector<detail::PreparedDB>& prepared_dbs,
+                                const std::optional<detail::PreparedModel>& prepared_model,
+                                const PrintProfile& profile, const MatchConfig& cfg,
+                                bool model_only, MatchStats* out_stats) {
     VectorRecipeMap map;
     map.color_layers = profile.color_layers;
     map.num_channels = profile.NumChannels();
@@ -60,21 +55,7 @@ VectorRecipeMap VectorRecipeMap::Match(const VectorProcResult& result, std::span
 
     if (result.shapes.empty()) { return map; }
 
-    const bool use_lab    = (cfg.color_space == ColorSpace::Lab);
-    const bool model_only = model_gate.model_only;
-    std::vector<detail::PreparedDB> prepared_dbs;
-    if (!model_only) { prepared_dbs = detail::PrepareDBs(dbs, profile); }
-
-    const std::optional<detail::PreparedModel> prepared_model =
-        detail::PrepareModel(model_package, model_gate, profile);
-    if (model_only && !prepared_model.has_value()) {
-        throw ConfigError("Model-only matching requires a compatible model package");
-    }
-    if (!model_only && prepared_dbs.empty() && !prepared_model.has_value()) {
-        throw ConfigError("No compatible ColorDB entries for color_layers=" +
-                          std::to_string(profile.color_layers) +
-                          "; try using the default layer count (5 or 10)");
-    }
+    const bool use_lab = (cfg.color_space == ColorSpace::Lab);
 
     std::vector<int> shape_to_unique_idx(result.shapes.size(), -1);
     std::vector<Rgb> unique_colors;
@@ -196,7 +177,7 @@ VectorRecipeMap VectorRecipeMap::Match(const VectorProcResult& result, std::span
         }
         const CachedMatch& cache = unique_matches[idx];
 
-        ShapeEntry entry;
+        VectorRecipeMap::ShapeEntry entry;
         entry.shape_idx     = static_cast<int>(i);
         entry.recipe        = cache.recipe;
         entry.matched_color = cache.matched_lab;
@@ -227,6 +208,65 @@ VectorRecipeMap VectorRecipeMap::Match(const VectorProcResult& result, std::span
         stat_model_queries > 0 ? stat_sum_model_de / static_cast<double>(stat_model_queries) : 0.0);
 
     return map;
+}
+
+} // namespace
+
+VectorRecipeMap VectorRecipeMap::Match(const VectorProcResult& result, std::span<const ColorDB> dbs,
+                                       const PrintProfile& profile, const MatchConfig& cfg,
+                                       const ModelPackage* model_package,
+                                       const ModelGateConfig& model_gate, MatchStats* out_stats) {
+    if (dbs.empty() && !model_gate.model_only) {
+        throw InputError("VectorRecipeMap::Match: no ColorDBs provided");
+    }
+    profile.Validate();
+    const bool model_only = model_gate.model_only;
+
+    std::vector<detail::PreparedDB> prepared_dbs;
+    if (!model_only) { prepared_dbs = detail::PrepareDBs(dbs, profile); }
+
+    const std::optional<detail::PreparedModel> prepared_model =
+        detail::PrepareModel(model_package, model_gate, profile);
+    if (model_only && !prepared_model.has_value()) {
+        throw ConfigError("Model-only matching requires a compatible model package");
+    }
+    if (!model_only && prepared_dbs.empty() && !prepared_model.has_value()) {
+        throw ConfigError("No compatible ColorDB entries for color_layers=" +
+                          std::to_string(profile.color_layers) +
+                          "; try using the default layer count (5 or 10)");
+    }
+
+    return MatchVectorCore(result, prepared_dbs, prepared_model, profile, cfg, model_only,
+                           out_stats);
+}
+
+VectorRecipeMap VectorRecipeMap::MatchPtrs(const VectorProcResult& result,
+                                           std::span<const ColorDB* const> db_ptrs,
+                                           const PrintProfile& profile, const MatchConfig& cfg,
+                                           const ModelPackage* model_package,
+                                           const ModelGateConfig& model_gate,
+                                           MatchStats* out_stats) {
+    if (db_ptrs.empty() && !model_gate.model_only) {
+        throw InputError("VectorRecipeMap::MatchPtrs: no ColorDBs provided");
+    }
+    profile.Validate();
+    const bool model_only = model_gate.model_only;
+
+    std::vector<detail::PreparedDB> prepared_dbs;
+    if (!model_only) { prepared_dbs = detail::PrepareDBs(db_ptrs, profile); }
+
+    const std::optional<detail::PreparedModel> prepared_model =
+        detail::PrepareModel(model_package, model_gate, profile);
+    if (model_only && !prepared_model.has_value()) {
+        throw ConfigError("Model-only matching requires a compatible model package");
+    }
+    if (!model_only && prepared_dbs.empty() && !prepared_model.has_value()) {
+        throw ConfigError("No compatible ColorDB entries for color_layers=" +
+                          std::to_string(profile.color_layers));
+    }
+
+    return MatchVectorCore(result, prepared_dbs, prepared_model, profile, cfg, model_only,
+                           out_stats);
 }
 
 void VectorRecipeMap::ReplaceRecipeForEntries(const std::vector<int>& entry_indices,

--- a/core/src/pipeline/pipeline.cpp
+++ b/core/src/pipeline/pipeline.cpp
@@ -94,13 +94,7 @@ std::size_t MatchRasterResult::EstimateBytes() const {
         bytes += ch.color.capacity() + ch.material.capacity() + ch.hex_color.capacity();
     }
 
-    for (const auto& db : dbs) {
-        for (const auto& entry : db.entries) { bytes += sizeof(Entry) + entry.recipe.capacity(); }
-        for (const auto& ch : db.palette) {
-            bytes += ch.color.capacity() + ch.material.capacity() + ch.hex_color.capacity();
-        }
-    }
-
+    bytes += dbs.size() * sizeof(std::shared_ptr<const ColorDB>);
     bytes += preset_dir.capacity();
     return bytes;
 }
@@ -126,28 +120,24 @@ MatchRasterResult MatchRaster(const ConvertRasterRequest& request, ProgressCallb
     // === 1. Load resources ===
     NotifyProgress(progress, ConvertStage::LoadingResources, 0.0f);
 
-    std::vector<ColorDB> owned_dbs;
-    std::vector<const ColorDB*> db_ptrs;
-
+    std::vector<std::shared_ptr<const ColorDB>> db_shared;
     if (!request.preloaded_dbs.empty()) {
-        db_ptrs = request.preloaded_dbs;
+        db_shared = request.preloaded_dbs;
     } else {
         const std::vector<std::string> resolved = ResolveDBPaths(request.db_paths);
-        owned_dbs                               = LoadColorDBsFromPaths(resolved);
-        db_ptrs.reserve(owned_dbs.size());
-        for (const ColorDB& db : owned_dbs) { db_ptrs.push_back(&db); }
+        auto loaded                             = LoadColorDBsFromPaths(resolved);
+        db_shared.reserve(loaded.size());
+        for (auto& db : loaded) {
+            db_shared.push_back(std::make_shared<const ColorDB>(std::move(db)));
+        }
     }
 
-    if (db_ptrs.empty()) { throw InputError("No ColorDB available"); }
-    spdlog::info("Loaded {} ColorDB(s)", db_ptrs.size());
+    if (db_shared.empty()) { throw InputError("No ColorDB available"); }
+    spdlog::info("Loaded {} ColorDB(s)", db_shared.size());
 
-    std::vector<ColorDB> db_span_storage;
-    if (!request.preloaded_dbs.empty()) {
-        db_span_storage.reserve(db_ptrs.size());
-        for (const ColorDB* p : db_ptrs) { db_span_storage.push_back(*p); }
-    }
-    const std::vector<ColorDB>& dbs_ref =
-        request.preloaded_dbs.empty() ? owned_dbs : db_span_storage;
+    std::vector<const ColorDB*> db_ptrs;
+    db_ptrs.reserve(db_shared.size());
+    for (const auto& sp : db_shared) { db_ptrs.push_back(sp.get()); }
 
     std::optional<FilamentConfig> fil_config;
     if (!request.preset_dir.empty()) {
@@ -155,8 +145,8 @@ MatchRasterResult MatchRaster(const ConvertRasterRequest& request, ProgressCallb
     }
 
     PrintProfile profile =
-        PrintProfile::BuildFromColorDBs(dbs_ref, request.color_layers, request.layer_height_mm,
-                                        fil_config ? &*fil_config : nullptr);
+        PrintProfile::BuildFromColorDBPtrs(db_ptrs, request.color_layers, request.layer_height_mm,
+                                           fil_config ? &*fil_config : nullptr);
     profile.nozzle_size      = request.nozzle_size;
     profile.face_orientation = request.face_orientation;
 
@@ -166,7 +156,7 @@ MatchRasterResult MatchRaster(const ConvertRasterRequest& request, ProgressCallb
     }
 
     std::optional<ModelPackage> owned_model_pack;
-    const ModelPackage* model_pack_ptr = request.preloaded_model_pack;
+    const ModelPackage* model_pack_ptr = request.preloaded_model_pack.get();
     if (!model_pack_ptr && !request.model_pack_path.empty()) {
         owned_model_pack.emplace(ModelPackage::Load(request.model_pack_path));
         model_pack_ptr = &owned_model_pack.value();
@@ -264,8 +254,8 @@ MatchRasterResult MatchRaster(const ConvertRasterRequest& request, ProgressCallb
     }
 
     MatchStats match_stats;
-    RecipeMap recipe_map = RecipeMap::MatchFromRaster(img, dbs_ref, profile, match_cfg,
-                                                      model_pack_ptr, model_gate, &match_stats);
+    RecipeMap recipe_map = RecipeMap::MatchFromRasterPtrs(img, db_ptrs, profile, match_cfg,
+                                                          model_pack_ptr, model_gate, &match_stats);
 
     NotifyProgress(progress, ConvertStage::Matching, 1.0f);
     spdlog::info("Stage: matching completed, clusters={}, db_only={}, model_fallback={}, "
@@ -301,11 +291,7 @@ MatchRasterResult MatchRaster(const ConvertRasterRequest& request, ProgressCallb
     result.generate_preview     = request.generate_preview;
     result.generate_source_mask = request.generate_source_mask;
 
-    if (!request.preloaded_dbs.empty()) {
-        result.dbs = std::move(db_span_storage);
-    } else {
-        result.dbs = std::move(owned_dbs);
-    }
+    result.dbs = std::move(db_shared);
 
     spdlog::info("MatchRaster completed: {}x{}, pixel_mm={:.3f}", result.input_width,
                  result.input_height, result.resolved_pixel_mm);
@@ -415,6 +401,12 @@ ConvertResult GenerateRasterModel(MatchRasterResult& mr, ProgressCallback progre
     ColorDB profile_db = mr.profile.ToColorDB("MergedPrintProfile");
     ModelIR model      = ModelIR::Build(mr.recipe_map, profile_db, build_cfg);
 
+    // recipe_map is no longer needed — release heavy buffers early.
+    { auto tmp = std::move(mr.recipe_map.recipes); }
+    { auto tmp = std::move(mr.recipe_map.mask); }
+    { auto tmp = std::move(mr.recipe_map.mapped_color); }
+    { auto tmp = std::move(mr.recipe_map.source_mask); }
+
     NotifyProgress(progress, ConvertStage::BuildingModel, 1.0f);
     spdlog::info("Stage: building_model completed, grids={}, layers={}", model.voxel_grids.size(),
                  model.base_layers + model.color_layers);
@@ -506,6 +498,8 @@ ConvertResult GenerateRasterModel(MatchRasterResult& mr, ProgressCallback progre
             result.model_3mf = Export3mfToBuffer(model, mesh_cfg, mr.face_orientation);
         }
     }
+
+    for (auto& grid : model.voxel_grids) { decltype(grid.ooc){}.swap(grid.ooc); }
 
     result.resolved_pixel_mm  = mr.resolved_pixel_mm;
     result.physical_width_mm  = static_cast<float>(mr.input_width) * mr.resolved_pixel_mm;

--- a/core/src/pipeline/vector_pipeline.cpp
+++ b/core/src/pipeline/vector_pipeline.cpp
@@ -14,6 +14,7 @@
 
 #include <filesystem>
 #include <cmath>
+#include <memory>
 #include <optional>
 
 namespace ChromaPrint3D {
@@ -66,13 +67,7 @@ std::size_t MatchVectorResult::EstimateBytes() const {
         bytes += ch.color.capacity() + ch.material.capacity() + ch.hex_color.capacity();
     }
 
-    for (const auto& db : dbs) {
-        for (const auto& entry : db.entries) { bytes += sizeof(Entry) + entry.recipe.capacity(); }
-        for (const auto& ch : db.palette) {
-            bytes += ch.color.capacity() + ch.material.capacity() + ch.hex_color.capacity();
-        }
-    }
-
+    bytes += dbs.size() * sizeof(std::shared_ptr<const ColorDB>);
     bytes += preset_dir.capacity();
     return bytes;
 }
@@ -93,28 +88,24 @@ MatchVectorResult MatchVector(const ConvertVectorRequest& request, ProgressCallb
     // === 1. Load resources ===
     NotifyProgress(progress, ConvertStage::LoadingResources, 0.0f);
 
-    std::vector<ColorDB> owned_dbs;
-    std::vector<const ColorDB*> db_ptrs;
-
+    std::vector<std::shared_ptr<const ColorDB>> db_shared;
     if (!request.preloaded_dbs.empty()) {
-        db_ptrs = request.preloaded_dbs;
+        db_shared = request.preloaded_dbs;
     } else {
         const std::vector<std::string> resolved = ResolveDBPaths(request.db_paths);
-        owned_dbs                               = LoadColorDBsFromPaths(resolved);
-        db_ptrs.reserve(owned_dbs.size());
-        for (const ColorDB& db : owned_dbs) { db_ptrs.push_back(&db); }
+        auto loaded                             = LoadColorDBsFromPaths(resolved);
+        db_shared.reserve(loaded.size());
+        for (auto& db : loaded) {
+            db_shared.push_back(std::make_shared<const ColorDB>(std::move(db)));
+        }
     }
 
-    if (db_ptrs.empty()) { throw InputError("No ColorDB available"); }
-    spdlog::info("Loaded {} ColorDB(s)", db_ptrs.size());
+    if (db_shared.empty()) { throw InputError("No ColorDB available"); }
+    spdlog::info("Loaded {} ColorDB(s)", db_shared.size());
 
-    std::vector<ColorDB> db_span_storage;
-    if (!request.preloaded_dbs.empty()) {
-        db_span_storage.reserve(db_ptrs.size());
-        for (const ColorDB* p : db_ptrs) { db_span_storage.push_back(*p); }
-    }
-    std::vector<ColorDB> all_dbs =
-        request.preloaded_dbs.empty() ? std::move(owned_dbs) : std::move(db_span_storage);
+    std::vector<const ColorDB*> db_ptrs;
+    db_ptrs.reserve(db_shared.size());
+    for (const auto& sp : db_shared) { db_ptrs.push_back(sp.get()); }
 
     std::optional<FilamentConfig> fil_config;
     if (!request.preset_dir.empty()) {
@@ -122,8 +113,8 @@ MatchVectorResult MatchVector(const ConvertVectorRequest& request, ProgressCallb
     }
 
     PrintProfile profile =
-        PrintProfile::BuildFromColorDBs(all_dbs, request.color_layers, request.layer_height_mm,
-                                        fil_config ? &*fil_config : nullptr);
+        PrintProfile::BuildFromColorDBPtrs(db_ptrs, request.color_layers, request.layer_height_mm,
+                                           fil_config ? &*fil_config : nullptr);
     profile.nozzle_size      = request.nozzle_size;
     profile.face_orientation = request.face_orientation;
 
@@ -132,7 +123,7 @@ MatchVectorResult MatchVector(const ConvertVectorRequest& request, ProgressCallb
         spdlog::info("Filtered profile palette to {} channel(s)", profile.NumChannels());
     }
 
-    const ModelPackage* model_pack_ptr = request.preloaded_model_pack;
+    const ModelPackage* model_pack_ptr = request.preloaded_model_pack.get();
     std::optional<ModelPackage> owned_model_pack;
     if (!model_pack_ptr && !request.model_pack_path.empty()) {
         owned_model_pack.emplace(ModelPackage::Load(request.model_pack_path));
@@ -202,8 +193,8 @@ MatchVectorResult MatchVector(const ConvertVectorRequest& request, ProgressCallb
     }
 
     MatchStats match_stats;
-    VectorRecipeMap recipe_map = VectorRecipeMap::Match(vimg, all_dbs, profile, match_cfg,
-                                                        model_pack_ptr, model_gate, &match_stats);
+    VectorRecipeMap recipe_map = VectorRecipeMap::MatchPtrs(
+        vimg, db_ptrs, profile, match_cfg, model_pack_ptr, model_gate, &match_stats);
 
     NotifyProgress(progress, ConvertStage::Matching, 1.0f);
     spdlog::info("MatchVector completed: {} entries, avg_de={:.2f}", recipe_map.entries.size(),
@@ -223,7 +214,7 @@ MatchVectorResult MatchVector(const ConvertVectorRequest& request, ProgressCallb
     mr.nozzle_size          = request.nozzle_size;
     mr.face_orientation     = request.face_orientation;
     mr.preset_dir           = request.preset_dir;
-    mr.dbs                  = std::move(all_dbs);
+    mr.dbs                  = std::move(db_shared);
     mr.match_config         = match_cfg;
     mr.model_gate           = model_gate;
     mr.generate_preview     = request.generate_preview;
@@ -368,6 +359,8 @@ ConvertResult GenerateVectorModel(MatchVectorResult& mr, ProgressCallback progre
                                                    resolved_base_layers, mr.face_orientation);
         }
     }
+
+    { auto tmp = std::move(meshes); }
 
     NotifyProgress(progress, ConvertStage::Exporting, 1.0f);
     spdlog::info("GenerateVectorModel completed: 3mf={} bytes, preview={} bytes, "

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -20,7 +20,8 @@ set(TEST_SOURCES
     test_vector_mesh.cpp
     test_3mf_writer.cpp
     test_matting.cpp
-    test_slicer_preset.cpp)
+    test_slicer_preset.cpp
+    test_memory_utils.cpp)
 
 add_executable(chromaprint3d_tests ${TEST_SOURCES})
 target_link_libraries(chromaprint3d_tests PRIVATE ChromaPrint3D::core GTest::gtest_main)

--- a/core/tests/test_memory_utils.cpp
+++ b/core/tests/test_memory_utils.cpp
@@ -1,0 +1,71 @@
+#include "chromaprint3d/memory_utils.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <thread>
+#include <vector>
+
+namespace {
+
+TEST(MemoryUtils, AllocatorNameIsNonEmpty) {
+    const char* name = ChromaPrint3D::AllocatorName();
+    ASSERT_NE(name, nullptr);
+    EXPECT_GT(std::strlen(name), 0u);
+}
+
+TEST(MemoryUtils, GetProcessRssBytesReturnsNonZero) {
+    std::size_t rss = ChromaPrint3D::GetProcessRssBytes();
+    EXPECT_GT(rss, 0u);
+}
+
+TEST(MemoryUtils, GetMemoryLimitBytesReturnsNonZero) {
+    std::size_t limit = ChromaPrint3D::GetMemoryLimitBytes();
+    EXPECT_GT(limit, 0u);
+}
+
+TEST(MemoryUtils, GetHeapStatsReturnsValidResult) {
+    auto stats = ChromaPrint3D::GetHeapStats();
+    if (stats.valid) {
+        EXPECT_GT(stats.allocated, 0u);
+    } else {
+        EXPECT_EQ(stats.allocated, 0u);
+        EXPECT_EQ(stats.resident, 0u);
+        EXPECT_EQ(stats.mapped, 0u);
+    }
+}
+
+TEST(MemoryUtils, ReleaseFreedMemoryThrottlesCorrectly) {
+    bool first  = ChromaPrint3D::ReleaseFreedMemory(0);
+    bool second = ChromaPrint3D::ReleaseFreedMemory(60000);
+    if (first) {
+        EXPECT_FALSE(second);
+    } else {
+        EXPECT_FALSE(second);
+    }
+}
+
+TEST(MemoryUtils, ReleaseFreedMemoryConcurrentCAS) {
+    int success_count = 0;
+    std::mutex mtx;
+    std::vector<std::thread> threads;
+
+    ChromaPrint3D::ReleaseFreedMemory(0);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    for (int i = 0; i < 8; ++i) {
+        threads.emplace_back([&] {
+            bool ok = ChromaPrint3D::ReleaseFreedMemory(0);
+            if (ok) {
+                std::lock_guard<std::mutex> lock(mtx);
+                ++success_count;
+            }
+        });
+    }
+    for (auto& t : threads) t.join();
+
+    EXPECT_LE(success_count, 1);
+}
+
+} // namespace

--- a/core/tests/test_memory_utils.cpp
+++ b/core/tests/test_memory_utils.cpp
@@ -2,7 +2,10 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstring>
+#include <latch>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -40,24 +43,34 @@ TEST(MemoryUtils, ReleaseFreedMemoryThrottlesCorrectly) {
     EXPECT_FALSE(ChromaPrint3D::ReleaseFreedMemory(60000));
 }
 
-TEST(MemoryUtils, ReleaseFreedMemoryConcurrentCAS) {
-    int success_count = 0;
+TEST(MemoryUtils, ReleaseFreedMemoryConcurrentCallsRespectThrottle) {
+    constexpr int kThreadCount    = 8;
+    constexpr int kMinIntervalMs  = 100;
+    constexpr int kStartupSlackMs = 10;
+    int success_count             = 0;
     std::mutex mtx;
+    std::latch ready(kThreadCount);
+    std::latch start(1);
     std::vector<std::thread> threads;
 
-    ChromaPrint3D::ReleaseFreedMemory(0);
+    // Let any prior successful purge age out so this test is independent
+    // from the previous test's static throttle state.
+    std::this_thread::sleep_for(std::chrono::milliseconds(kMinIntervalMs + kStartupSlackMs));
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-    for (int i = 0; i < 8; ++i) {
+    for (int i = 0; i < kThreadCount; ++i) {
         threads.emplace_back([&] {
-            bool ok = ChromaPrint3D::ReleaseFreedMemory(0);
+            ready.count_down();
+            start.wait();
+
+            bool ok = ChromaPrint3D::ReleaseFreedMemory(kMinIntervalMs);
             if (ok) {
                 std::lock_guard<std::mutex> lock(mtx);
                 ++success_count;
             }
         });
     }
+    ready.wait();
+    start.count_down();
     for (auto& t : threads) t.join();
 
     EXPECT_LE(success_count, 1);

--- a/core/tests/test_memory_utils.cpp
+++ b/core/tests/test_memory_utils.cpp
@@ -36,13 +36,8 @@ TEST(MemoryUtils, GetHeapStatsReturnsValidResult) {
 }
 
 TEST(MemoryUtils, ReleaseFreedMemoryThrottlesCorrectly) {
-    bool first  = ChromaPrint3D::ReleaseFreedMemory(0);
-    bool second = ChromaPrint3D::ReleaseFreedMemory(60000);
-    if (first) {
-        EXPECT_FALSE(second);
-    } else {
-        EXPECT_FALSE(second);
-    }
+    ChromaPrint3D::ReleaseFreedMemory(0);
+    EXPECT_FALSE(ChromaPrint3D::ReleaseFreedMemory(60000));
 }
 
 TEST(MemoryUtils, ReleaseFreedMemoryConcurrentCAS) {

--- a/docs/agents/web/backend/README.md
+++ b/docs/agents/web/backend/README.md
@@ -61,6 +61,10 @@
 
 `GET /api/v1/model-pack/info` 返回所有已加载模型包的元数据（名称、schema 版本、scope、可用 mode 列表）。前端用此接口判断当前 ColorDB 组合是否有匹配的模型包。实现在 `ServerFacade::GetModelPackInfo()` → `ApiV1Controller::ModelPackInfo`。
 
+## Health 指标
+
+`GET /api/v1/health` 中的 `memory.colordb_pool_bytes` 表示“全局 ColorDB 缓存 + 会话 ColorDB”的总估算体量，由 `ColorDBCache` 与 `SessionStore` 增量维护，读取路径保持 O(1)。它是容量近似值，不是 RSS 的精确拆分。
+
 ## 配方编辑器
 
 `POST /api/v1/convert/raster/match-only` 提交 match-only 任务，完成颜色匹配但不生成 3MF。任务完成后通过以下端点进行配方编辑：
@@ -74,6 +78,12 @@
 `region-map` artifact 通过 `GET /api/v1/tasks/{id}/artifacts/region-map` 下载。
 
 约束：仅支持 `dither=None` 的 Raster 流水线，唯一配方数 ≤128。
+
+任务查询语义补充：
+
+- `GET /api/v1/tasks/{id}` 对 `match_only` 转换任务会返回 `generation` 子对象。
+- 顶层 `task.status` 只表示主生命周期；若 3MF 生成失败，会呈现为 `status=completed` 且 `generation.status=failed`。
+- 只有 `generation.status=succeeded` 时，`result.has_3mf` 才会为 `true`。
 
 核心实现：`task_runtime.h/.cpp`（`SubmitConvertRasterMatchOnly`、`GetRecipeEditorSummary`、`QueryRecipeAlternatives`、`ReplaceRecipe`、`SubmitGenerateModel`、`GetTaskPrintProfile`、`GetTaskColorDbNames`）、`recipe_editor_service.cpp`（`RecipeEditorSummary`、`RecipeEditorAlternatives`、`RecipeEditorReplace`、`RecipeEditorGenerate`、`RecipeEditorPredict`）。
 

--- a/docs/agents/web/frontend/README.md
+++ b/docs/agents/web/frontend/README.md
@@ -22,10 +22,11 @@
 |---|---|
 | 新增页面交互逻辑 | `src/components/*.vue` + `src/composables/` |
 | 新增/调整后端参数映射 | `src/domain/params/convertParamBuilders.ts` + `src/api/convert.ts` |
-| 调整任务轮询与状态处理 | `src/composables/useAsyncTask.ts` + `src/services/convertService.ts` |
+| 调整任务轮询与状态处理 | `src/composables/useAsyncTask.ts` + `src/services/convertService.ts`；recipe editor 生成轮询优先看 `src/services/recipeEditorService.ts` |
 | 调整分层预览行为 | `src/domain/result/layerPreview.ts` + `src/components/ResultPanel.vue` |
-| 调整配方编辑器 | `src/components/recipeEditor/*.vue` + `src/api/recipeEditor.ts` + `src/composables/useRegionMap.ts` |
-| 调整自定义配方与颜色预测 | `src/components/recipeEditor/CustomRecipeDialog.vue` + `src/api/recipeEditor.ts`（`predictRecipeColor`） |
+| 调整配方编辑器 | `src/components/recipeEditor/*.vue` + `src/services/recipeEditorService.ts` + `src/composables/useRegionMap.ts` |
+| 调整自定义配方与颜色预测 | `src/components/recipeEditor/CustomRecipeDialog.vue` + `src/services/recipeEditorService.ts` |
+| 调整多标签健康上报/leader 选举 | `src/composables/feature/useLeaderLease.ts` + `src/composables/feature/useAppLifecycle.ts` |
 | 调整 Browser/Electron 行为差异 | `src/runtime/*.ts` + `src/electron.d.ts` |
 
 ## 分层边界（强约束）

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,6 +119,13 @@ services:
       # 公式：OMP_NUM_THREADS ≈ 可用核心数 / max_tasks
       # 示例：4 核 / 4 worker = 1；16 核 / 6 worker ≈ 3
       - OMP_NUM_THREADS=1
+      # === jemalloc 与 glibc 调优变量二选一，不可同时设置 ===
+      # 官方镜像默认链接 jemalloc，使用以下配置：
+      - MALLOC_CONF=background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:30000
+      # 若自编译且未链接 jemalloc（-DCHROMAPRINT3D_USE_JEMALLOC=OFF），改用 glibc 调优：
+      # - MALLOC_ARENA_MAX=2
+      # - MALLOC_TRIM_THRESHOLD_=131072
+      # - MALLOC_MMAP_THRESHOLD_=262144
     # 跨域模式：限制 CORS 只允许云主机前端域名
     # model_packs/ 已包含在 --data 指向的数据目录中，无需单独指定 --model-pack
     command:
@@ -658,6 +665,8 @@ crontab -e
 | `--max-owner-tasks` | 单用户不应独占全部 worker | 4 | 8 |
 | `--max-queue` | 控制排队深度 | 128 | 128 |
 | `--task-ttl` | 结果保留时间（秒） | 900 | 1800 |
+| `--board-geometry-cache-ttl` | 校准板几何缓存 TTL（秒） | 600 | 600 |
+| `--board-geometry-cache-max` | 校准板几何缓存最大条数（LRU 淘汰） | 16 | 16 |
 | Docker cpus | 留 1 核给 OS + Nginx | 4.0 | 15.0 |
 | Docker mem_limit | 留 4GB 给 OS | 4g | 28g |
 
@@ -666,6 +675,41 @@ crontab -e
 单个 pipeline 任务峰值内存约 3–4GB（大图 + 体素网格 + Mesh 构建 + 流式压缩）。
 总峰值 ≈ max_tasks × 4GB + 基础开销 (~1GB)。
 确保 Docker mem_limit > 该总峰值，并为 OS page cache 留出余量。
+
+### 内存分配器调优
+
+官方镜像默认链接 **jemalloc**，可大幅降低 glibc malloc 碎片化导致的稳态 RSS 膨胀。
+任务完成后服务会自动触发内存归还（内置 5 秒节流）。
+
+**jemalloc 环境变量**（官方镜像默认适用）：
+
+```yaml
+- MALLOC_CONF=background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:30000
+```
+
+- `background_thread:true`：后台线程异步回收脏页
+- `dirty_decay_ms:5000`：脏页在 5 秒后归还 OS
+- `muzzy_decay_ms:30000`：muzzy 页在 30 秒后解除映射
+
+**glibc 环境变量**（自编译且 `-DCHROMAPRINT3D_USE_JEMALLOC=OFF` 时使用）：
+
+```yaml
+- MALLOC_ARENA_MAX=2
+- MALLOC_TRIM_THRESHOLD_=131072
+- MALLOC_MMAP_THRESHOLD_=262144
+```
+
+> **互斥警告**：`MALLOC_CONF` 是 jemalloc 专有变量，`MALLOC_ARENA_MAX` / `MALLOC_TRIM_THRESHOLD_` / `MALLOC_MMAP_THRESHOLD_` 是 glibc 专有变量。两组变量不能同时设置——jemalloc 会忽略 glibc 变量但不报错，容易造成"以为生效了但实际没有"的困惑。
+
+**诊断命令**：
+
+```bash
+# 查看当前 RSS
+docker exec chromaprint3d cat /proc/1/smaps_rollup | head -3
+
+# 查看分配器信息（通过 health 端点）
+curl -s http://localhost:8080/api/v1/health | jq '.data.memory'
+```
 
 ### OMP_NUM_THREADS 的重要性
 
@@ -839,7 +883,24 @@ VITE_UMAMI_WEBSITE_ID=<预览版 website-id>
 
 `website-id` 在 Umami 管理后台添加网站后获取。
 
-### 8.4 备份
+### 8.4 多标签 `memory-status` 去重
+
+前端会额外上报一个自定义事件 `memory-status`，用于观测服务端内存占用趋势。部署时建议理解它的去重策略：
+
+- 浏览器端通过 `BroadcastChannel` + heartbeat/lease 选举单个 leader tab。
+- 只有 leader tab 会每 5 分钟发送一次 `memory-status`，避免同一用户开多个标签页时重复上报。
+- leader tab 关闭或失联后，其它标签页会在 lease 超时后自动接管，无需人工刷新。
+- 当 `/api/v1/health` 请求失败时，前端会清空缓存的 health 状态并停止该事件上报，避免继续发送过期内存值。
+
+事件字段：
+
+- `rss_mb`
+- `heap_mb`
+- `artifact_pct`
+- `usage_pct`
+- `allocator`
+
+### 8.5 备份
 
 ```bash
 # 手动备份
@@ -852,7 +913,7 @@ docker compose -f ~/umami-deploy/docker-compose.yml exec -T umami-db \
   && find ~/backups/ -name "umami-*.sql.gz" -mtime +30 -delete
 ```
 
-### 8.5 升级
+### 8.6 升级
 
 Umami 容器启动时自动执行数据库迁移，升级只需：
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,7 +170,49 @@ npm run dev
 1. `session` cookie
 2. `X-ChromaPrint3D-Session` header
 
-### 5.3 关键接口分组
+### 5.3 Health 端点响应格式
+
+`GET /api/v1/health` 响应包含 `memory` 对象，提供服务端内存状态：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "status": "ok",
+    "version": "1.3.1",
+    "active_tasks": 2,
+    "total_tasks": 15,
+    "memory": {
+      "rss_bytes": 1073741824,
+      "heap_allocated_bytes": 536870912,
+      "heap_resident_bytes": 805306368,
+      "artifact_budget_bytes": 134217728,
+      "artifact_budget_limit_bytes": 536870912,
+      "colordb_pool_bytes": 52428800,
+      "memory_limit_bytes": 4294967296,
+      "allocator": "jemalloc"
+    }
+  }
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `rss_bytes` | 进程 RSS |
+| `heap_allocated_bytes` | 应用层已分配的堆内存 |
+| `heap_resident_bytes` | 分配器保留的物理内存 |
+| `artifact_budget_bytes` | 任务独占数据（recipe_map/region_map 等）占用 |
+| `artifact_budget_limit_bytes` | `--max-result-mb` 对应的预算上限 |
+| `colordb_pool_bytes` | ColorDB 缓存 + 会话 DB 的总估算体量 |
+| `memory_limit_bytes` | 容器内存限制（cgroup）或物理内存总量 |
+| `allocator` | 编译时链接的分配器（`jemalloc` / `glibc` / `system`） |
+
+补充说明：
+
+- `colordb_pool_bytes` 是启发式容量指标，不是 RSS 的拆分项。它由全局 `ColorDBCache` 与会话 `SessionStore` 的估算字节数增量维护，`GET /api/v1/health` 读取该值不再做全量遍历，保持 O(1) 热路径。
+- `status` 当前固定返回 `ok`；前端应以请求是否成功判断“在线/离线”，不要把 `status === "ok"` 当成唯一在线判据，以便后续扩展 `degraded` 等服务状态。
+
+### 5.4 关键接口分组
 
 | 分组 | 代表接口 |
 |---|---|
@@ -343,6 +385,41 @@ npm run dev
 - 单会话并发上限：`--max-owner-tasks`
 - 结果缓存 TTL：`--task-ttl`
 - 结果总内存预算：`--max-result-mb`
+
+对 `match_only` 转换任务还有一层独立的生成子状态：
+
+- 配色匹配阶段完成后，顶层 `task.status` 进入 `completed`，此时配方编辑器所需的 summary / region-map / preview 已可用。
+- `POST /api/v1/tasks/{id}/recipe-editor/generate` 只推进 `generation.status`：`idle -> running -> succeeded/failed`。
+- 当 `generation.status=failed` 时，顶层 `task.status` 仍保持 `completed`，以保留 recipe editor 的可编辑与可重试语义；此时 `result.has_3mf=false`。
+- 只有 `generation.status=succeeded` 后，`result.has_3mf` 才会变为 `true`，3MF 下载端点才可用。
+
+`GET /api/v1/tasks/{id}` 在 `match_only` 转换任务上会返回：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "id": "task-id",
+    "status": "completed",
+    "match_only": true,
+    "generation": {
+      "status": "failed",
+      "error": "Cannot open 3MF spill file: ..."
+    },
+    "result": {
+      "has_3mf": false,
+      "has_preview": true,
+      "has_source_mask": true
+    }
+  }
+}
+```
+
+保活语义：
+
+- 后端内部将任务终态时间与访问时间拆分为 `completed_at` 和 `last_accessed_at`。
+- `completed_at` 只在任务主生命周期真正结束时写入，用于 `--task-ttl`。
+- `GET /api/v1/tasks/{id}`、artifact 下载、recipe editor 查询只会刷新 `last_accessed_at`，不会延长 `--task-ttl`。
 
 ## 6. 常见开发问题
 

--- a/web/backend/server/color_db_cache.h
+++ b/web/backend/server/color_db_cache.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include "infrastructure/color_db_bytes.h"
+
 #include "chromaprint3d/color_db.h"
 
 #include <spdlog/spdlog.h>
 
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -12,7 +15,7 @@
 using namespace ChromaPrint3D;
 
 struct ColorDBEntry {
-    ColorDB db;
+    std::shared_ptr<const ColorDB> db;
     std::string material_type; // "PLA", "PETG", ... (from directory structure)
     std::string vendor;        // "BambuLab", "Aliz", ... (from directory structure)
 };
@@ -20,6 +23,7 @@ struct ColorDBEntry {
 struct ColorDBCache {
     std::vector<ColorDBEntry> databases;
     std::unordered_map<std::string, size_t> name_to_index;
+    std::size_t estimated_total_bytes = 0;
 
     void LoadFromDirectory(const std::string& dir) {
         namespace fs = std::filesystem;
@@ -29,6 +33,9 @@ struct ColorDBCache {
         }
 
         const fs::path root(dir);
+        databases.clear();
+        name_to_index.clear();
+        estimated_total_bytes = 0;
 
         for (const auto& entry : fs::recursive_directory_iterator(root)) {
             if (!entry.is_regular_file()) { continue; }
@@ -37,16 +44,18 @@ struct ColorDBCache {
             auto [material, vendor] = InferMaterialVendor(root, entry.path());
 
             try {
-                ColorDB db       = ColorDB::LoadFromJson(entry.path().string());
-                std::string name = db.name;
+                auto db =
+                    std::make_shared<const ColorDB>(ColorDB::LoadFromJson(entry.path().string()));
+                std::string name = db->name;
                 size_t idx       = databases.size();
 
-                databases.push_back({std::move(db), std::move(material), std::move(vendor)});
+                databases.push_back({db, std::move(material), std::move(vendor)});
                 name_to_index[name] = idx;
+                estimated_total_bytes += chromaprint3d::backend::detail::EstimateColorDbBytes(*db);
 
                 const auto& e = databases.back();
                 spdlog::info("  Loaded ColorDB: {} ({} entries, {} ch) [{}::{}]", name,
-                             e.db.entries.size(), e.db.NumChannels(), e.material_type, e.vendor);
+                             e.db->entries.size(), e.db->NumChannels(), e.material_type, e.vendor);
             } catch (const std::exception& e) {
                 spdlog::warn("  Failed to load {}: {}", entry.path().string(), e.what());
             }
@@ -60,22 +69,21 @@ struct ColorDBCache {
         return &databases[it->second];
     }
 
-    const ColorDB* FindByName(const std::string& name) const {
+    std::shared_ptr<const ColorDB> FindByName(const std::string& name) const {
         const auto* entry = FindEntryByName(name);
-        return entry ? &entry->db : nullptr;
+        return entry ? entry->db : nullptr;
     }
 
-    std::vector<const ColorDB*> GetAll() const {
-        std::vector<const ColorDB*> result;
+    std::vector<std::shared_ptr<const ColorDB>> GetAll() const {
+        std::vector<std::shared_ptr<const ColorDB>> result;
         result.reserve(databases.size());
-        for (const auto& e : databases) { result.push_back(&e.db); }
+        for (const auto& e : databases) { result.push_back(e.db); }
         return result;
     }
 
+    std::size_t EstimateTotalBytes() const { return estimated_total_bytes; }
+
 private:
-    /// Derive material_type and vendor from directory structure.
-    /// Expected layout: root / Material / Vendor / file.json
-    /// Falls back to "Unknown" when the hierarchy is flat.
     static std::pair<std::string, std::string>
     InferMaterialVendor(const std::filesystem::path& root, const std::filesystem::path& file) {
         auto rel = std::filesystem::relative(file.parent_path(), root);

--- a/web/backend/src/application/color_db_service.cpp
+++ b/web/backend/src/application/color_db_service.cpp
@@ -16,14 +16,14 @@ ColorDbService::ColorDbService(DataRepository& data, SessionStore& sessions)
 ServiceResult ColorDbService::ListDatabases(const std::optional<std::string>& session_token) {
     json arr = json::array();
     for (const auto& entry : data_.ColorDbCache().databases) {
-        auto j      = ColorDbInfoToJson(entry.db, entry.material_type, entry.vendor);
+        auto j      = ColorDbInfoToJson(*entry.db, entry.material_type, entry.vendor);
         j["source"] = "global";
         arr.push_back(std::move(j));
     }
     if (session_token && !session_token->empty()) {
         auto dbs = sessions_.ListSessionDbs(*session_token);
         for (const auto& db : dbs) {
-            auto j      = ColorDbInfoToJson(db);
+            auto j      = ColorDbInfoToJson(*db);
             j["source"] = "session";
             arr.push_back(std::move(j));
         }
@@ -35,7 +35,7 @@ ServiceResult ColorDbService::ListSessionDatabases(const std::string& token) {
     if (token.empty()) return ServiceResult::Error(401, "unauthorized", "No session");
     json arr = json::array();
     for (const auto& db : sessions_.ListSessionDbs(token)) {
-        auto j      = ColorDbInfoToJson(db);
+        auto j      = ColorDbInfoToJson(*db);
         j["source"] = "session";
         arr.push_back(std::move(j));
     }

--- a/web/backend/src/application/colordb_resolution.cpp
+++ b/web/backend/src/application/colordb_resolution.cpp
@@ -33,18 +33,26 @@ std::vector<std::string> BuildProfileChannelKeys(const std::vector<const ColorDB
     return {keys.begin(), keys.end()};
 }
 
+std::vector<std::string>
+BuildProfileChannelKeys(const std::vector<std::shared_ptr<const ColorDB>>& dbs) {
+    std::unordered_set<std::string> keys;
+    for (const auto& db : dbs) {
+        for (const auto& ch : db->palette) { keys.insert(NormalizeChannelKey(ch)); }
+    }
+    return {keys.begin(), keys.end()};
+}
+
 ServiceResult ResolveSelectedColorDbs(const json& params,
                                       const std::optional<SessionSnapshot>& session,
                                       const DataRepository& data,
-                                      std::vector<const ColorDB*>& out_dbs,
-                                      std::vector<std::shared_ptr<const ColorDB>>& session_owned,
+                                      std::vector<std::shared_ptr<const ColorDB>>& out_dbs,
                                       std::string& common_vendor, std::string& common_material) {
     out_dbs.clear();
     common_vendor.clear();
     common_material.clear();
 
     struct DbWithMeta {
-        const ColorDB* db;
+        std::shared_ptr<const ColorDB> db;
         std::string vendor;
         std::string material_type;
     };
@@ -59,25 +67,21 @@ ServiceResult ResolveSelectedColorDbs(const json& params,
                                             "db_names must be an array of strings");
             }
             const std::string name = name_val.get<std::string>();
-            const ColorDB* db      = nullptr;
+            std::shared_ptr<const ColorDB> db;
             std::string vendor, material;
             if (const auto* entry = data.ColorDbCache().FindEntryByName(name)) {
-                db       = &entry->db;
+                db       = entry->db;
                 vendor   = entry->vendor;
                 material = entry->material_type;
             }
             if (!db && session) {
                 auto it = session->color_dbs.find(name);
-                if (it != session->color_dbs.end()) {
-                    auto copy = std::make_shared<const ColorDB>(it->second);
-                    session_owned.push_back(copy);
-                    db = copy.get();
-                }
+                if (it != session->color_dbs.end()) { db = it->second; }
             }
             if (!db) {
                 return ServiceResult::Error(400, "invalid_params", "ColorDB not found: " + name);
             }
-            selected.push_back({db, vendor, material});
+            selected.push_back({std::move(db), vendor, material});
         }
         if (selected.empty()) {
             return ServiceResult::Error(400, "invalid_params", "No valid ColorDB names provided");
@@ -85,12 +89,12 @@ ServiceResult ResolveSelectedColorDbs(const json& params,
     } else {
         selected.reserve(data.ColorDbCache().databases.size());
         for (const auto& entry : data.ColorDbCache().databases) {
-            selected.push_back({&entry.db, entry.vendor, entry.material_type});
+            selected.push_back({entry.db, entry.vendor, entry.material_type});
         }
     }
 
     out_dbs.reserve(selected.size());
-    for (const auto& s : selected) { out_dbs.push_back(s.db); }
+    for (auto& s : selected) { out_dbs.push_back(std::move(s.db)); }
 
     if (!selected.empty()) {
         const auto& first_v = selected.front().vendor;

--- a/web/backend/src/application/colordb_resolution.h
+++ b/web/backend/src/application/colordb_resolution.h
@@ -18,12 +18,13 @@ namespace chromaprint3d::backend {
 std::string NormalizeChannelKey(const ChromaPrint3D::Channel& ch);
 std::vector<std::string>
 BuildProfileChannelKeys(const std::vector<const ChromaPrint3D::ColorDB*>& dbs);
+std::vector<std::string>
+BuildProfileChannelKeys(const std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>>& dbs);
 
 ServiceResult
 ResolveSelectedColorDbs(const nlohmann::json& params, const std::optional<SessionSnapshot>& session,
                         const DataRepository& data,
-                        std::vector<const ChromaPrint3D::ColorDB*>& out_dbs,
-                        std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>>& session_owned,
+                        std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>>& out_dbs,
                         std::string& common_vendor, std::string& common_material);
 
 void ResolveTaskVendorMaterial(const std::vector<std::string>& db_names, const DataRepository& data,

--- a/web/backend/src/application/convert_service.cpp
+++ b/web/backend/src/application/convert_service.cpp
@@ -201,7 +201,7 @@ ServiceResult ConvertService::BuildRasterRequest(const json& params,
 
     std::string common_vendor, common_material;
     auto selected = ResolveSelectedColorDbs(params, session, data_, out.preloaded_dbs,
-                                            out.session_owned_dbs, common_vendor, common_material);
+                                            common_vendor, common_material);
     if (!selected.ok) return selected;
 
     if (!common_vendor.empty() && !common_material.empty()) {
@@ -363,9 +363,8 @@ ServiceResult ConvertService::BuildVectorRequest(const json& params,
     if (std::filesystem::is_directory(vpresets)) { out.preset_dir = vpresets.string(); }
 
     std::string vec_common_vendor, vec_common_material;
-    auto selected =
-        ResolveSelectedColorDbs(params, session, data_, out.preloaded_dbs, out.session_owned_dbs,
-                                vec_common_vendor, vec_common_material);
+    auto selected = ResolveSelectedColorDbs(params, session, data_, out.preloaded_dbs,
+                                            vec_common_vendor, vec_common_material);
     if (!selected.ok) return selected;
 
     if (!vec_common_vendor.empty() && !vec_common_material.empty()) {

--- a/web/backend/src/application/json_serialization.cpp
+++ b/web/backend/src/application/json_serialization.cpp
@@ -133,7 +133,10 @@ json TaskToJson(const TaskSnapshot& task) {
         j["stage"]      = ConvertStageToString(cp->stage);
         j["progress"]   = cp->progress;
         j["match_only"] = cp->match_only;
-        if (!cp->generate_error.empty()) { j["generate_error"] = cp->generate_error; }
+        j["generation"] = {
+            {"status", GenerationStatusToString(cp->generation.status)},
+            {"error", cp->generation.error.empty() ? json(nullptr) : json(cp->generation.error)},
+        };
         if (!cp->result.warnings.empty()) { j["warnings"] = cp->result.warnings; }
         if (task.status == RuntimeTaskStatus::Completed) {
             j["result"] = {

--- a/web/backend/src/application/recipe_editor_service.cpp
+++ b/web/backend/src/application/recipe_editor_service.cpp
@@ -46,8 +46,8 @@ ServiceResult RecipeEditorService::RecipeEditorAlternatives(const std::string& o
 
     std::string recipe_pattern = body.value("recipe_pattern", std::string{});
 
-    const ChromaPrint3D::ModelPackage* model_pack = nullptr;
-    auto db_names_opt                             = tasks_.GetTaskColorDbNames(owner, task_id);
+    std::shared_ptr<const ChromaPrint3D::ModelPackage> model_pack;
+    auto db_names_opt = tasks_.GetTaskColorDbNames(owner, task_id);
     if (db_names_opt) {
         std::string mp_vendor, mp_material;
         ResolveTaskVendorMaterial(*db_names_opt, data_, mp_vendor, mp_material);
@@ -65,7 +65,7 @@ ServiceResult RecipeEditorService::RecipeEditorAlternatives(const std::string& o
     }
 
     auto result = tasks_.QueryRecipeAlternatives(owner, task_id, target, max_candidates, offset,
-                                                 model_pack, recipe_pattern);
+                                                 model_pack.get(), recipe_pattern);
     if (!result) return ServiceResult::Error(404, "not_found", "Alternatives not available");
     return ServiceResult::Success(200, {{"candidates", std::move(*result)}});
 }

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -2,6 +2,7 @@
 
 #include "application/json_serialization.h"
 
+#include "chromaprint3d/memory_utils.h"
 #include "chromaprint3d/pipeline.h"
 #include "chromaprint3d/version.h"
 
@@ -20,10 +21,11 @@ ServerFacade::ServerFacade(ServerConfig cfg)
       sessions_(cfg_.session_ttl_seconds, cfg_.max_session_colordbs),
       tasks_(cfg_.max_tasks, cfg_.max_task_queue, cfg_.task_ttl_seconds, cfg_.max_tasks_per_owner,
              cfg_.max_task_result_mb * 1024 * 1024, cfg_.data_dir),
-      boards_(cfg_.board_cache_ttl, cfg_.data_dir), color_db_svc_(data_, sessions_),
-      task_svc_(tasks_), convert_svc_(cfg_, data_, sessions_, tasks_),
-      matting_svc_(cfg_, data_, tasks_), recipe_svc_(data_, tasks_),
-      calib_svc_(cfg_, data_, sessions_, boards_) {}
+      boards_(cfg_.board_cache_ttl, cfg_.data_dir, cfg_.board_geometry_cache_ttl,
+              cfg_.board_geometry_cache_max),
+      color_db_svc_(data_, sessions_), task_svc_(tasks_),
+      convert_svc_(cfg_, data_, sessions_, tasks_), matting_svc_(cfg_, data_, tasks_),
+      recipe_svc_(data_, tasks_), calib_svc_(cfg_, data_, sessions_, boards_) {}
 
 std::string ServerFacade::EnsureSession(const std::optional<std::string>& existing_token,
                                         bool* created) {
@@ -39,11 +41,27 @@ std::optional<SessionSnapshot> ServerFacade::SessionSnapshotByToken(const std::s
 // ---------------------------------------------------------------------------
 
 ServiceResult ServerFacade::Health() const {
+    const auto heap   = ChromaPrint3D::GetHeapStats();
+    const auto budget = tasks_.GetArtifactBudgetInfo();
+
+    json memory = {
+        {"rss_bytes", ChromaPrint3D::GetProcessRssBytes()},
+        {"heap_allocated_bytes", heap.valid ? heap.allocated : 0},
+        {"heap_resident_bytes", heap.valid ? heap.resident : 0},
+        {"artifact_budget_bytes", budget.used_bytes},
+        {"artifact_budget_limit_bytes", budget.limit_bytes},
+        {"colordb_pool_bytes",
+         data_.ColorDbCache().EstimateTotalBytes() + sessions_.EstimateAllSessionDbBytes()},
+        {"memory_limit_bytes", ChromaPrint3D::GetMemoryLimitBytes()},
+        {"allocator", ChromaPrint3D::AllocatorName()},
+    };
+
     return ServiceResult::Success(200, {
                                            {"status", "ok"},
                                            {"version", CHROMAPRINT3D_VERSION_STRING},
                                            {"active_tasks", tasks_.ActiveTaskCount()},
                                            {"total_tasks", tasks_.TotalTaskCount()},
+                                           {"memory", std::move(memory)},
                                        });
 }
 
@@ -117,7 +135,7 @@ json ServerFacade::GetModelPackInfo() const {
     json packs = json::array();
     for (const auto& pack : data_.ModelPackRegistry().All()) {
         json modes = json::array();
-        for (const auto& lp : pack.layer_packages) {
+        for (const auto& lp : pack->layer_packages) {
             modes.push_back({
                 {"color_layers", lp.color_layers},
                 {"layer_height_mm", lp.layer_height_mm},
@@ -125,12 +143,14 @@ json ServerFacade::GetModelPackInfo() const {
             });
         }
         packs.push_back({
-            {"name", pack.name},
+            {"name", pack->name},
             {"schema_version", ModelPackage::kSchemaVersion},
-            {"scope", {{"vendor", pack.scope.vendor}, {"material_type", pack.scope.material_type}}},
-            {"channel_keys", pack.channel_keys},
+            {"scope",
+             {{"vendor", pack->scope.vendor}, {"material_type", pack->scope.material_type}}},
+            {"channel_keys", pack->channel_keys},
             {"modes", std::move(modes)},
-            {"defaults", {{"threshold", pack.default_threshold}, {"margin", pack.default_margin}}},
+            {"defaults",
+             {{"threshold", pack->default_threshold}, {"margin", pack->default_margin}}},
         });
     }
     return {{"packs", std::move(packs)}};

--- a/web/backend/src/config/server_config.cpp
+++ b/web/backend/src/config/server_config.cpp
@@ -72,6 +72,8 @@ std::string BuildUsage(const char* exe_name) {
            "1048576-268435456)\n"
         << "  --max-session-colordbs N    Max uploaded ColorDB count per session (default: 10)\n"
         << "  --board-cache-ttl N         Calibration board cache TTL seconds (default: 600)\n"
+        << "  --board-geometry-cache-ttl N Board geometry cache TTL seconds (default: 600)\n"
+        << "  --board-geometry-cache-max N Max cached board geometries (default: 16)\n"
         << "  -h, --help                  Show this help\n";
     return oss.str();
 }
@@ -92,6 +94,8 @@ ConfigParseResult ParseConfig(int argc, char** argv) {
         {"--max-pixels", &cfg.max_pixels_per_image},
         {"--max-session-colordbs", &cfg.max_session_colordbs},
         {"--board-cache-ttl", &cfg.board_cache_ttl},
+        {"--board-geometry-cache-ttl", &cfg.board_geometry_cache_ttl},
+        {"--board-geometry-cache-max", &cfg.board_geometry_cache_max},
     };
 
     for (int i = 1; i < argc; ++i) {
@@ -185,6 +189,12 @@ ConfigParseResult ParseConfig(int argc, char** argv) {
     if (!ValidateI64Range("--max-session-colordbs", cfg.max_session_colordbs, 1, 256, result))
         return result;
     if (!ValidateI64Range("--board-cache-ttl", cfg.board_cache_ttl, 60, 86400, result))
+        return result;
+    if (!ValidateI64Range("--board-geometry-cache-ttl", cfg.board_geometry_cache_ttl, 60, 86400,
+                          result))
+        return result;
+    if (!ValidateI64Range("--board-geometry-cache-max", cfg.board_geometry_cache_max, 1, 256,
+                          result))
         return result;
 
     if (cfg.require_cors_origin && cfg.cors_origin.empty()) {

--- a/web/backend/src/config/server_config.h
+++ b/web/backend/src/config/server_config.h
@@ -24,13 +24,15 @@ struct ServerConfig {
     std::int64_t session_ttl_seconds = 3600;
     std::int64_t max_task_queue      = 256;
 
-    std::int64_t max_tasks_per_owner  = 32;
-    std::int64_t max_task_result_mb   = 512;
-    std::int64_t max_pixels_per_image = 4096LL * 4096LL;
-    std::int64_t max_session_colordbs = 10;
-    std::int64_t board_cache_ttl      = 600;
-    bool require_cors_origin          = false;
-    bool allow_open_cors              = true;
+    std::int64_t max_tasks_per_owner      = 32;
+    std::int64_t max_task_result_mb       = 512;
+    std::int64_t max_pixels_per_image     = 4096LL * 4096LL;
+    std::int64_t max_session_colordbs     = 10;
+    std::int64_t board_cache_ttl          = 600;
+    std::int64_t board_geometry_cache_ttl = 600;
+    std::int64_t board_geometry_cache_max = 16;
+    bool require_cors_origin              = false;
+    bool allow_open_cors                  = true;
 };
 
 struct ConfigParseResult {

--- a/web/backend/src/infrastructure/board_runtime_cache.cpp
+++ b/web/backend/src/infrastructure/board_runtime_cache.cpp
@@ -3,6 +3,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <system_error>
@@ -68,8 +69,11 @@ std::size_t BoardGeometryKeyHash::operator()(const BoardGeometryKey& k) const {
     return h;
 }
 
-BoardRuntimeCache::BoardRuntimeCache(std::int64_t ttl_seconds, const std::string& data_dir)
-    : ttl_seconds_(ttl_seconds),
+BoardRuntimeCache::BoardRuntimeCache(std::int64_t ttl_seconds, const std::string& data_dir,
+                                     std::int64_t geometry_ttl_seconds,
+                                     std::int64_t geometry_max_entries)
+    : ttl_seconds_(ttl_seconds), geometry_ttl_seconds_(geometry_ttl_seconds),
+      geometry_max_entries_(static_cast<std::size_t>(geometry_max_entries)),
       temp_dir_(std::filesystem::path(data_dir) / "tmp" / "results" / "boards") {
     std::error_code ec;
     std::filesystem::create_directories(temp_dir_, ec);
@@ -137,14 +141,18 @@ BoardRuntimeCache::FindGeometry(int num_channels, int color_layers, int board_va
     std::lock_guard<std::mutex> lock(mtx_);
     auto it = geometry_.find(BoardGeometryKey{num_channels, color_layers, board_variant});
     if (it == geometry_.end()) return std::nullopt;
-    return it->second;
+    it->second.last_accessed_at = std::chrono::steady_clock::now();
+    return it->second.data;
 }
 
 void BoardRuntimeCache::StoreGeometry(int num_channels, int color_layers,
                                       ChromaPrint3D::CalibrationBoardMeshes&& data,
                                       int board_variant) {
     std::lock_guard<std::mutex> lock(mtx_);
-    geometry_[BoardGeometryKey{num_channels, color_layers, board_variant}] = std::move(data);
+    auto now = std::chrono::steady_clock::now();
+    CleanupGeometryLocked(now);
+    geometry_[BoardGeometryKey{num_channels, color_layers, board_variant}] =
+        GeometryRecord{std::move(data), now, now};
 }
 
 void BoardRuntimeCache::CleanupExpiredLocked(const std::chrono::steady_clock::time_point& now) {
@@ -156,6 +164,27 @@ void BoardRuntimeCache::CleanupExpiredLocked(const std::chrono::steady_clock::ti
         } else {
             ++it;
         }
+    }
+    CleanupGeometryLocked(now);
+}
+
+void BoardRuntimeCache::CleanupGeometryLocked(const std::chrono::steady_clock::time_point& now) {
+    for (auto it = geometry_.begin(); it != geometry_.end();) {
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::seconds>(now - it->second.last_accessed_at)
+                .count();
+        if (elapsed > geometry_ttl_seconds_) {
+            it = geometry_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    while (geometry_.size() > geometry_max_entries_) {
+        auto oldest =
+            std::min_element(geometry_.begin(), geometry_.end(), [](const auto& a, const auto& b) {
+                return a.second.last_accessed_at < b.second.last_accessed_at;
+            });
+        geometry_.erase(oldest);
     }
 }
 

--- a/web/backend/src/infrastructure/board_runtime_cache.h
+++ b/web/backend/src/infrastructure/board_runtime_cache.h
@@ -45,9 +45,17 @@ struct BoardGeometryKeyHash {
     std::size_t operator()(const BoardGeometryKey& k) const;
 };
 
+struct GeometryRecord {
+    ChromaPrint3D::CalibrationBoardMeshes data;
+    std::chrono::steady_clock::time_point created_at;
+    std::chrono::steady_clock::time_point last_accessed_at;
+};
+
 class BoardRuntimeCache {
 public:
-    BoardRuntimeCache(std::int64_t ttl_seconds, const std::string& data_dir);
+    BoardRuntimeCache(std::int64_t ttl_seconds, const std::string& data_dir,
+                      std::int64_t geometry_ttl_seconds = 600,
+                      std::int64_t geometry_max_entries = 16);
 
     std::string StoreBoard(ChromaPrint3D::CalibrationBoardResult&& result);
     std::optional<BoardSnapshot> FindBoard(const std::string& id);
@@ -59,15 +67,16 @@ public:
 
 private:
     void CleanupExpiredLocked(const std::chrono::steady_clock::time_point& now);
+    void CleanupGeometryLocked(const std::chrono::steady_clock::time_point& now);
     static std::string NewBoardId();
 
     std::int64_t ttl_seconds_;
+    std::int64_t geometry_ttl_seconds_;
+    std::size_t geometry_max_entries_;
     std::filesystem::path temp_dir_;
     std::mutex mtx_;
     std::unordered_map<std::string, BoardRecord> boards_;
-    std::unordered_map<BoardGeometryKey, ChromaPrint3D::CalibrationBoardMeshes,
-                       BoardGeometryKeyHash>
-        geometry_;
+    std::unordered_map<BoardGeometryKey, GeometryRecord, BoardGeometryKeyHash> geometry_;
 };
 
 } // namespace chromaprint3d::backend

--- a/web/backend/src/infrastructure/color_db_bytes.h
+++ b/web/backend/src/infrastructure/color_db_bytes.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "chromaprint3d/color_db.h"
+
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+
+namespace chromaprint3d::backend::detail {
+
+inline std::size_t EstimateColorDbBytes(const ChromaPrint3D::ColorDB& db) {
+    std::size_t bytes = 0;
+    for (const auto& entry : db.entries) {
+        bytes += sizeof(ChromaPrint3D::Entry) + entry.recipe.capacity();
+    }
+    for (const auto& ch : db.palette) {
+        bytes += ch.color.capacity() + ch.material.capacity() + ch.hex_color.capacity();
+    }
+    return bytes;
+}
+
+inline std::size_t EstimateColorDbMapBytes(
+    const std::unordered_map<std::string, std::shared_ptr<const ChromaPrint3D::ColorDB>>&
+        color_dbs) {
+    std::size_t bytes = 0;
+    for (const auto& [_, db] : color_dbs) {
+        if (db) { bytes += EstimateColorDbBytes(*db); }
+    }
+    return bytes;
+}
+
+} // namespace chromaprint3d::backend::detail

--- a/web/backend/src/infrastructure/session_store.cpp
+++ b/web/backend/src/infrastructure/session_store.cpp
@@ -1,8 +1,8 @@
 #include "infrastructure/session_store.h"
+#include "infrastructure/color_db_bytes.h"
 #include "infrastructure/random_utils.h"
 
 #include <regex>
-#include <sstream>
 
 namespace chromaprint3d::backend {
 
@@ -41,8 +41,13 @@ bool SessionStore::WithSession(const std::string& token,
     std::lock_guard<std::mutex> lock(mtx_);
     auto it = sessions_.find(token);
     if (it == sessions_.end()) return false;
-    it->second.last_access = std::chrono::steady_clock::now();
+    const auto before_bytes = it->second.estimated_db_bytes;
+    it->second.last_access  = std::chrono::steady_clock::now();
     mutator(it->second);
+    it->second.estimated_db_bytes = detail::EstimateColorDbMapBytes(it->second.color_dbs);
+    total_session_db_bytes_       = total_session_db_bytes_ -
+                              std::min(total_session_db_bytes_, before_bytes) +
+                              it->second.estimated_db_bytes;
     return true;
 }
 
@@ -50,21 +55,30 @@ bool SessionStore::RemoveSessionDb(const std::string& token, const std::string& 
     return WithSession(token, [&](SessionSnapshot& s) { s.color_dbs.erase(db_name); });
 }
 
-std::optional<ChromaPrint3D::ColorDB> SessionStore::GetSessionDb(const std::string& token,
-                                                                 const std::string& db_name) {
-    auto s = Snapshot(token);
-    if (!s) return std::nullopt;
-    auto it = s->color_dbs.find(db_name);
-    if (it == s->color_dbs.end()) return std::nullopt;
-    return it->second;
+std::shared_ptr<const ChromaPrint3D::ColorDB>
+SessionStore::GetSessionDb(const std::string& token, const std::string& db_name) {
+    if (token.empty()) return nullptr;
+    CleanupExpired();
+    std::lock_guard<std::mutex> lock(mtx_);
+    auto it = sessions_.find(token);
+    if (it == sessions_.end()) return nullptr;
+    it->second.last_access = std::chrono::steady_clock::now();
+    auto db_it             = it->second.color_dbs.find(db_name);
+    if (db_it == it->second.color_dbs.end()) return nullptr;
+    return db_it->second;
 }
 
-std::vector<ChromaPrint3D::ColorDB> SessionStore::ListSessionDbs(const std::string& token) {
-    auto s = Snapshot(token);
-    std::vector<ChromaPrint3D::ColorDB> out;
-    if (!s) return out;
-    out.reserve(s->color_dbs.size());
-    for (const auto& [_, db] : s->color_dbs) out.push_back(db);
+std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>>
+SessionStore::ListSessionDbs(const std::string& token) {
+    std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>> out;
+    if (token.empty()) return out;
+    CleanupExpired();
+    std::lock_guard<std::mutex> lock(mtx_);
+    auto it = sessions_.find(token);
+    if (it == sessions_.end()) return out;
+    it->second.last_access = std::chrono::steady_clock::now();
+    out.reserve(it->second.color_dbs.size());
+    for (const auto& [_, db] : it->second.color_dbs) out.push_back(db);
     return out;
 }
 
@@ -89,7 +103,16 @@ bool SessionStore::PutSessionDb(const std::string& token, ChromaPrint3D::ColorDB
         if (error) *error = "Session ColorDB limit reached";
         return false;
     }
-    s.color_dbs[db_name] = std::move(db);
+    const std::size_t before_bytes = existing != s.color_dbs.end() && existing->second
+                                         ? detail::EstimateColorDbBytes(*existing->second)
+                                         : 0;
+    auto db_ptr                    = std::make_shared<const ChromaPrint3D::ColorDB>(std::move(db));
+    const std::size_t after_bytes  = detail::EstimateColorDbBytes(*db_ptr);
+    s.color_dbs[db_name]           = std::move(db_ptr);
+    s.estimated_db_bytes =
+        s.estimated_db_bytes - std::min(s.estimated_db_bytes, before_bytes) + after_bytes;
+    total_session_db_bytes_ =
+        total_session_db_bytes_ - std::min(total_session_db_bytes_, before_bytes) + after_bytes;
     return true;
 }
 
@@ -100,11 +123,25 @@ void SessionStore::CleanupExpired() {
         auto elapsed =
             std::chrono::duration_cast<std::chrono::seconds>(now - it->second.last_access).count();
         if (elapsed > ttl_seconds_) {
+            total_session_db_bytes_ -=
+                std::min(total_session_db_bytes_, it->second.estimated_db_bytes);
             it = sessions_.erase(it);
         } else {
             ++it;
         }
     }
+}
+
+std::size_t SessionStore::EstimateSessionDbBytes(const std::string& token) const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    auto it = sessions_.find(token);
+    if (it == sessions_.end()) return 0;
+    return it->second.estimated_db_bytes;
+}
+
+std::size_t SessionStore::EstimateAllSessionDbBytes() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return total_session_db_bytes_;
 }
 
 bool SessionStore::IsValidDbName(const std::string& name) {

--- a/web/backend/src/infrastructure/session_store.h
+++ b/web/backend/src/infrastructure/session_store.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -15,8 +16,9 @@ namespace chromaprint3d::backend {
 
 struct SessionSnapshot {
     std::string token;
-    std::unordered_map<std::string, ChromaPrint3D::ColorDB> color_dbs;
+    std::unordered_map<std::string, std::shared_ptr<const ChromaPrint3D::ColorDB>> color_dbs;
     std::chrono::steady_clock::time_point last_access;
+    std::size_t estimated_db_bytes = 0;
 };
 
 class SessionStore {
@@ -28,12 +30,16 @@ public:
     bool WithSession(const std::string& token,
                      const std::function<void(SessionSnapshot&)>& mutator);
     bool RemoveSessionDb(const std::string& token, const std::string& db_name);
-    std::optional<ChromaPrint3D::ColorDB> GetSessionDb(const std::string& token,
-                                                       const std::string& db_name);
-    std::vector<ChromaPrint3D::ColorDB> ListSessionDbs(const std::string& token);
+    std::shared_ptr<const ChromaPrint3D::ColorDB> GetSessionDb(const std::string& token,
+                                                               const std::string& db_name);
+    std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>>
+    ListSessionDbs(const std::string& token);
 
     bool PutSessionDb(const std::string& token, ChromaPrint3D::ColorDB db, std::string* error);
     void CleanupExpired();
+
+    std::size_t EstimateSessionDbBytes(const std::string& token) const;
+    std::size_t EstimateAllSessionDbBytes() const;
 
     static bool IsValidDbName(const std::string& name);
     static std::string NewSecureToken();
@@ -42,8 +48,9 @@ private:
     std::int64_t ttl_seconds_;
     std::int64_t max_colordbs_;
 
-    std::mutex mtx_;
+    mutable std::mutex mtx_;
     std::unordered_map<std::string, SessionSnapshot> sessions_;
+    std::size_t total_session_db_bytes_ = 0;
 
     SessionSnapshot& GetOrCreateLocked(const std::string& token);
 };

--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -11,6 +11,8 @@
 #include <opencv2/imgproc.hpp>
 #include <spdlog/spdlog.h>
 
+#include "chromaprint3d/memory_utils.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cstring>
@@ -128,6 +130,20 @@ const char* TaskStatusToString(RuntimeTaskStatus status) {
     case RuntimeTaskStatus::Completed:
         return "completed";
     case RuntimeTaskStatus::Failed:
+        return "failed";
+    }
+    return "unknown";
+}
+
+const char* GenerationStatusToString(GenerationStatus status) {
+    switch (status) {
+    case GenerationStatus::Idle:
+        return "idle";
+    case GenerationStatus::Running:
+        return "running";
+    case GenerationStatus::Succeeded:
+        return "succeeded";
+    case GenerationStatus::Failed:
         return "failed";
     }
     return "unknown";
@@ -656,8 +672,6 @@ bool TaskRuntime::PostprocessMatting(const std::string& owner, const std::string
 
     auto result = ChromaPrint3D::ApplyMattingPostprocess(alpha, fallback_mask, original, params);
 
-    std::size_t old_bytes = it->second.artifact_bytes;
-
     cv::imencode(".png", result.mask, mp->processed_mask_png);
     if (!result.foreground.empty()) {
         cv::imencode(".png", result.foreground, mp->processed_fg_png);
@@ -669,10 +683,8 @@ bool TaskRuntime::PostprocessMatting(const std::string& owner, const std::string
     } else {
         mp->outline_png.clear();
     }
-
-    std::size_t new_bytes     = ComputeArtifactBytes(snap);
-    total_artifact_bytes_     = total_artifact_bytes_ - old_bytes + new_bytes;
-    it->second.artifact_bytes = new_bytes;
+    RefreshArtifactBytesLocked(it->second);
+    EnforceResultBudgetLocked(&id);
 
     status_code = 200;
     return true;
@@ -686,7 +698,7 @@ std::optional<nlohmann::json> TaskRuntime::GetRecipeEditorSummary(const std::str
     auto it = tasks_.find(id);
     if (it == tasks_.end() || it->second.snapshot.owner != owner) return std::nullopt;
     if (it->second.snapshot.status != RuntimeTaskStatus::Completed) return std::nullopt;
-    it->second.snapshot.completed_at = std::chrono::steady_clock::now();
+    TouchTaskLocked(it->second, std::chrono::steady_clock::now());
     return GetRecipeEditorSummaryLocked(it->second);
 }
 
@@ -696,6 +708,7 @@ TaskRuntime::GetTaskPrintProfile(const std::string& owner, const std::string& id
     auto it = tasks_.find(id);
     if (it == tasks_.end() || it->second.snapshot.owner != owner) return std::nullopt;
     if (it->second.snapshot.status != RuntimeTaskStatus::Completed) return std::nullopt;
+    TouchTaskLocked(it->second, std::chrono::steady_clock::now());
 
     const auto* cp = std::get_if<ConvertTaskPayload>(&it->second.snapshot.payload);
     if (!cp || !cp->match_only) return std::nullopt;
@@ -711,16 +724,18 @@ std::optional<std::vector<std::string>> TaskRuntime::GetTaskColorDbNames(const s
     auto it = tasks_.find(id);
     if (it == tasks_.end() || it->second.snapshot.owner != owner) return std::nullopt;
     if (it->second.snapshot.status != RuntimeTaskStatus::Completed) return std::nullopt;
+    TouchTaskLocked(it->second, std::chrono::steady_clock::now());
 
     const auto* cp = std::get_if<ConvertTaskPayload>(&it->second.snapshot.payload);
     if (!cp || !cp->match_only) return std::nullopt;
 
+    static const std::vector<std::shared_ptr<const ChromaPrint3D::ColorDB>> kEmpty;
     const auto& dbs = cp->raster_match_state   ? cp->raster_match_state->dbs
                       : cp->vector_match_state ? cp->vector_match_state->dbs
-                                               : std::vector<ChromaPrint3D::ColorDB>{};
+                                               : kEmpty;
     std::vector<std::string> names;
     names.reserve(dbs.size());
-    for (const auto& db : dbs) { names.push_back(db.name); }
+    for (const auto& db : dbs) { names.push_back(db->name); }
     return names;
 }
 
@@ -749,8 +764,11 @@ TaskRuntime::QueryRecipeAlternatives(const std::string& owner, const std::string
             is_raster ? cp->raster_match_state->match_config : cp->vector_match_state->match_config;
         const auto& model_gate_c =
             is_raster ? cp->raster_match_state->model_gate : cp->vector_match_state->model_gate;
+        std::vector<const ChromaPrint3D::ColorDB*> db_ptrs;
+        db_ptrs.reserve(dbs.size());
+        for (const auto& sp : dbs) { db_ptrs.push_back(sp.get()); }
         cp->recipe_search_cache = ChromaPrint3D::RecipeSearchCache::Build(
-            dbs, profile, match_config, model_pack, model_gate_c);
+            db_ptrs, profile, match_config, model_pack, model_gate_c);
     }
 
     std::vector<ChromaPrint3D::RecipeCandidate> candidates;
@@ -768,7 +786,7 @@ TaskRuntime::QueryRecipeAlternatives(const std::string& owner, const std::string
                                                            max_candidates, offset);
     }
 
-    it->second.snapshot.completed_at = std::chrono::steady_clock::now();
+    TouchTaskLocked(it->second, std::chrono::steady_clock::now());
 
     nlohmann::json arr = nlohmann::json::array();
     for (const auto& c : candidates) {
@@ -812,6 +830,11 @@ bool TaskRuntime::ReplaceRecipe(const std::string& owner, const std::string& id,
     if (!cp || !cp->match_only) {
         status_code = 400;
         message     = "not a match_only task";
+        return false;
+    }
+    if (IsGenerationRunningLocked(it->second)) {
+        status_code = 409;
+        message     = "generation is running";
         return false;
     }
 
@@ -864,10 +887,14 @@ bool TaskRuntime::ReplaceRecipe(const std::string& owner, const std::string& id,
         cv::Mat preview_bgra = ChromaPrint3D::DownsampleForPreview(mstate.recipe_map.ToBgraImage());
         if (!preview_bgra.empty()) {
             cp->result.preview_png = ChromaPrint3D::EncodePng(preview_bgra);
+        } else {
+            cp->result.preview_png.clear();
         }
         cv::Mat source_mask_img = mstate.recipe_map.ToSourceMaskImage();
         if (!source_mask_img.empty()) {
             cp->result.source_mask_png = ChromaPrint3D::EncodePng(source_mask_img);
+        } else {
+            cp->result.source_mask_png.clear();
         }
     } else {
         auto& vstate = *cp->vector_match_state;
@@ -892,12 +919,16 @@ bool TaskRuntime::ReplaceRecipe(const std::string& owner, const std::string& id,
             ChromaPrint3D::RenderVectorSourceMaskPng(vstate.proc_result, vstate.recipe_map);
     }
 
-    std::size_t old_bytes     = it->second.artifact_bytes;
-    std::size_t new_bytes     = ComputeArtifactBytes(it->second.snapshot);
-    total_artifact_bytes_     = total_artifact_bytes_ - old_bytes + new_bytes;
-    it->second.artifact_bytes = new_bytes;
-
-    it->second.snapshot.completed_at = std::chrono::steady_clock::now();
+    if (cp->match_only) {
+        cp->generation = {};
+        cp->result.model_3mf.clear();
+        cp->result.layer_previews = {};
+        cp->has_3mf_on_disk       = false;
+        it->second.spilled_3mf    = SpillableArtifact{};
+    }
+    RefreshArtifactBytesLocked(it->second);
+    TouchTaskLocked(it->second, std::chrono::steady_clock::now());
+    EnforceResultBudgetLocked(&id);
 
     auto summary = GetRecipeEditorSummaryLocked(it->second);
     if (summary.has_value()) { out_summary = std::move(*summary); }
@@ -907,8 +938,11 @@ bool TaskRuntime::ReplaceRecipe(const std::string& owner, const std::string& id,
 }
 
 SubmitResult TaskRuntime::SubmitGenerateModel(const std::string& owner, const std::string& id) {
+    std::size_t queue_before = 0;
+    std::size_t queue_after  = 0;
+    std::size_t owner_active = 0;
     {
-        std::lock_guard<std::mutex> lock(task_mtx_);
+        std::scoped_lock lock(queue_mtx_, task_mtx_);
         auto it = tasks_.find(id);
         if (it == tasks_.end() || it->second.snapshot.owner != owner) {
             return {false, 404, id, "task not found"};
@@ -921,119 +955,168 @@ SubmitResult TaskRuntime::SubmitGenerateModel(const std::string& owner, const st
         if (!cp->raster_match_state.has_value() && !cp->vector_match_state.has_value()) {
             return {false, 500, id, "missing match state"};
         }
+        if (cp->generation.status == GenerationStatus::Running) {
+            return {false, 409, id, "generation already running"};
+        }
+        queue_before = queue_.size();
+        if (static_cast<std::int64_t>(queue_.size()) >= max_queue_) {
+            return {false, 429, id, "Task queue is full"};
+        }
+        owner_active = ActiveTasksByOwnerLocked(owner);
+        if (static_cast<std::int64_t>(owner_active) >= max_tasks_per_owner_) {
+            return {false, 429, id, "Too many active tasks for current session"};
+        }
 
-        cp->generate_error.clear();
+        const auto now        = std::chrono::steady_clock::now();
+        cp->generation.status = GenerationStatus::Running;
+        cp->generation.error.clear();
+        cp->generation.started_at   = now;
+        cp->generation.completed_at = {};
         cp->result.model_3mf.clear();
-        it->second.spilled_3mf           = SpillableArtifact{};
-        it->second.snapshot.status       = RuntimeTaskStatus::Running;
-        it->second.snapshot.completed_at = {};
-        cp->stage                        = ChromaPrint3D::ConvertStage::BuildingModel;
-        cp->progress                     = 0.0f;
+        cp->result.layer_previews = {};
+        cp->has_3mf_on_disk       = false;
+        it->second.spilled_3mf    = SpillableArtifact{};
+        cp->stage                 = ChromaPrint3D::ConvertStage::BuildingModel;
+        cp->progress              = 0.0f;
+        RefreshArtifactBytesLocked(it->second);
+        TouchTaskLocked(it->second, now);
+        queue_.push_back(QueueEntry{
+            id,
+            [this, id](const std::string& /*tid*/) {
+                bool use_vector = false;
+                {
+                    std::lock_guard<std::mutex> lock(task_mtx_);
+                    auto it = tasks_.find(id);
+                    if (it == tasks_.end()) { throw std::runtime_error("task not found"); }
+                    auto* cp = std::get_if<ConvertTaskPayload>(&it->second.snapshot.payload);
+                    if (!cp) { throw std::runtime_error("task payload mismatch"); }
+                    use_vector = cp->vector_match_state.has_value();
+                }
+
+                ChromaPrint3D::ProgressCallback progress_cb =
+                    [this, id](ChromaPrint3D::ConvertStage stage, float progress) {
+                        UpdateTaskPayload(id, [&](TaskPayload& p) {
+                            auto* cp = std::get_if<ConvertTaskPayload>(&p);
+                            if (!cp) return;
+                            cp->stage    = stage;
+                            cp->progress = progress;
+                        });
+                    };
+
+                try {
+                    ChromaPrint3D::ConvertResult gen_result;
+
+                    if (use_vector) {
+                        ChromaPrint3D::MatchVectorResult match_copy;
+                        {
+                            std::lock_guard<std::mutex> lock(task_mtx_);
+                            auto it = tasks_.find(id);
+                            auto* cp =
+                                std::get_if<ConvertTaskPayload>(&it->second.snapshot.payload);
+                            match_copy = *cp->vector_match_state;
+                        }
+                        gen_result = ChromaPrint3D::GenerateVectorModel(match_copy, progress_cb);
+                    } else {
+                        ChromaPrint3D::MatchRasterResult match_copy;
+                        {
+                            std::lock_guard<std::mutex> lock(task_mtx_);
+                            auto it = tasks_.find(id);
+                            auto* cp =
+                                std::get_if<ConvertTaskPayload>(&it->second.snapshot.payload);
+                            match_copy = *cp->raster_match_state;
+                        }
+                        gen_result = ChromaPrint3D::GenerateRasterModel(match_copy, progress_cb);
+                    }
+
+                    PendingArtifactFile pending_3mf;
+                    SpillableArtifact spilled_3mf;
+                    if (!gen_result.model_3mf.empty()) {
+                        auto spill_path = temp_dir_ / (id + "_gen.3mf");
+                        pending_3mf     = PendingArtifactFile(spill_path);
+                        spdlog::debug("GenerateModel: writing 3MF for task {}, {} bytes to {}", id,
+                                      gen_result.model_3mf.size(), spill_path.string());
+
+                        std::ofstream ofs(spill_path, std::ios::binary | std::ios::trunc);
+                        if (!ofs.is_open()) {
+                            throw std::runtime_error("Cannot open 3MF spill file: " +
+                                                     spill_path.string());
+                        }
+                        ofs.write(reinterpret_cast<const char*>(gen_result.model_3mf.data()),
+                                  static_cast<std::streamsize>(gen_result.model_3mf.size()));
+                        if (!ofs.good()) {
+                            throw std::runtime_error("Failed to write 3MF spill file: " +
+                                                     spill_path.string());
+                        }
+                        ofs.close();
+                        if (ofs.fail()) {
+                            throw std::runtime_error("Failed to flush/close 3MF spill file: " +
+                                                     spill_path.string());
+                        }
+
+                        auto actual_size = std::filesystem::file_size(spill_path);
+                        if (actual_size != gen_result.model_3mf.size()) {
+                            spdlog::error(
+                                "GenerateModel: 3MF file size mismatch for task {}: expected={}, "
+                                "actual={}",
+                                id, gen_result.model_3mf.size(), actual_size);
+                            throw std::runtime_error("3MF file size mismatch after write");
+                        }
+
+                        spilled_3mf = pending_3mf.Commit(actual_size);
+                        gen_result.model_3mf.clear();
+                        gen_result.model_3mf.shrink_to_fit();
+                        spdlog::info("GenerateModel: 3MF written for task {}, {} bytes", id,
+                                     actual_size);
+                    }
+
+                    UpdateTaskRecord(id, [&](TaskRecord& rec) {
+                        auto* cp = std::get_if<ConvertTaskPayload>(&rec.snapshot.payload);
+                        if (!cp) return;
+                        const auto now             = std::chrono::steady_clock::now();
+                        cp->result.model_3mf       = std::move(gen_result.model_3mf);
+                        cp->result.layer_previews  = std::move(gen_result.layer_previews);
+                        cp->result.preview_png     = std::move(gen_result.preview_png);
+                        cp->result.source_mask_png = std::move(gen_result.source_mask_png);
+                        cp->progress               = 1.0f;
+                        cp->has_3mf_on_disk        = spilled_3mf.has_file();
+                        cp->generation.status      = GenerationStatus::Succeeded;
+                        cp->generation.error.clear();
+                        cp->generation.completed_at = now;
+                        rec.spilled_3mf             = std::move(spilled_3mf);
+                        this->RefreshArtifactBytesLocked(rec);
+                        this->TouchTaskLocked(rec, now);
+                    });
+                    UpdateTaskRecord(id, [&](TaskRecord& rec) {
+                        this->EnforceResultBudgetLocked(&rec.snapshot.id);
+                    });
+                } catch (const std::exception& e) {
+                    spdlog::error("GenerateModel failed for task {}: {}", id, e.what());
+                    UpdateTaskRecord(id, [&](TaskRecord& rec) {
+                        auto* cp = std::get_if<ConvertTaskPayload>(&rec.snapshot.payload);
+                        if (!cp) return;
+                        const auto now              = std::chrono::steady_clock::now();
+                        cp->generation.status       = GenerationStatus::Failed;
+                        cp->generation.error        = e.what();
+                        cp->generation.completed_at = now;
+                        cp->result.model_3mf.clear();
+                        cp->result.layer_previews = {};
+                        cp->has_3mf_on_disk       = false;
+                        cp->progress              = 0.0f;
+                        rec.spilled_3mf           = SpillableArtifact{};
+                        this->RefreshArtifactBytesLocked(rec);
+                        this->TouchTaskLocked(rec, now);
+                    });
+                }
+            },
+            false,
+        });
+        queue_after = queue_.size();
     }
-
-    RunTask(id, [this, id](const std::string& /*tid*/) {
-        bool use_vector = false;
-        {
-            std::lock_guard<std::mutex> lock(task_mtx_);
-            auto it    = tasks_.find(id);
-            auto* cp   = std::get_if<ConvertTaskPayload>(&it->second.snapshot.payload);
-            use_vector = cp->vector_match_state.has_value();
-        }
-
-        ChromaPrint3D::ProgressCallback progress_cb = [this, id](ChromaPrint3D::ConvertStage stage,
-                                                                 float progress) {
-            UpdateTaskPayload(id, [&](TaskPayload& p) {
-                auto* cp = std::get_if<ConvertTaskPayload>(&p);
-                if (!cp) return;
-                cp->stage    = stage;
-                cp->progress = progress;
-            });
-        };
-
-        try {
-            ChromaPrint3D::ConvertResult gen_result;
-
-            if (use_vector) {
-                ChromaPrint3D::MatchVectorResult match_copy;
-                {
-                    std::lock_guard<std::mutex> lock(task_mtx_);
-                    auto it    = tasks_.find(id);
-                    auto* cp   = std::get_if<ConvertTaskPayload>(&it->second.snapshot.payload);
-                    match_copy = *cp->vector_match_state;
-                }
-                gen_result = ChromaPrint3D::GenerateVectorModel(match_copy, progress_cb);
-            } else {
-                ChromaPrint3D::MatchRasterResult match_copy;
-                {
-                    std::lock_guard<std::mutex> lock(task_mtx_);
-                    auto it    = tasks_.find(id);
-                    auto* cp   = std::get_if<ConvertTaskPayload>(&it->second.snapshot.payload);
-                    match_copy = *cp->raster_match_state;
-                }
-                gen_result = ChromaPrint3D::GenerateRasterModel(match_copy, progress_cb);
-            }
-
-            PendingArtifactFile pending_3mf;
-            SpillableArtifact spilled_3mf;
-            if (!gen_result.model_3mf.empty()) {
-                auto spill_path = temp_dir_ / (id + "_gen.3mf");
-                pending_3mf     = PendingArtifactFile(spill_path);
-                spdlog::debug("GenerateModel: writing 3MF for task {}, {} bytes to {}", id,
-                              gen_result.model_3mf.size(), spill_path.string());
-
-                std::ofstream ofs(spill_path, std::ios::binary | std::ios::trunc);
-                if (!ofs.is_open()) {
-                    throw std::runtime_error("Cannot open 3MF spill file: " + spill_path.string());
-                }
-                ofs.write(reinterpret_cast<const char*>(gen_result.model_3mf.data()),
-                          static_cast<std::streamsize>(gen_result.model_3mf.size()));
-                if (!ofs.good()) {
-                    throw std::runtime_error("Failed to write 3MF spill file: " +
-                                             spill_path.string());
-                }
-                ofs.close();
-                if (ofs.fail()) {
-                    throw std::runtime_error("Failed to flush/close 3MF spill file: " +
-                                             spill_path.string());
-                }
-
-                auto actual_size = std::filesystem::file_size(spill_path);
-                if (actual_size != gen_result.model_3mf.size()) {
-                    spdlog::error("GenerateModel: 3MF file size mismatch for task {}: expected={}, "
-                                  "actual={}",
-                                  id, gen_result.model_3mf.size(), actual_size);
-                    throw std::runtime_error("3MF file size mismatch after write");
-                }
-
-                spilled_3mf = pending_3mf.Commit(actual_size);
-                gen_result.model_3mf.clear();
-                gen_result.model_3mf.shrink_to_fit();
-                spdlog::info("GenerateModel: 3MF written for task {}, {} bytes", id, actual_size);
-            }
-
-            UpdateTaskRecord(id, [&](TaskRecord& rec) {
-                auto* cp = std::get_if<ConvertTaskPayload>(&rec.snapshot.payload);
-                if (!cp) return;
-                cp->result.model_3mf       = std::move(gen_result.model_3mf);
-                cp->result.layer_previews  = std::move(gen_result.layer_previews);
-                cp->result.preview_png     = std::move(gen_result.preview_png);
-                cp->result.source_mask_png = std::move(gen_result.source_mask_png);
-                cp->progress               = 1.0f;
-                cp->has_3mf_on_disk        = spilled_3mf.has_file();
-                rec.spilled_3mf            = std::move(spilled_3mf);
-            });
-        } catch (const std::exception& e) {
-            spdlog::error("GenerateModel failed for task {}: {}", id, e.what());
-            UpdateTaskPayload(id, [&](TaskPayload& p) {
-                auto* cp = std::get_if<ConvertTaskPayload>(&p);
-                if (!cp) return;
-                cp->generate_error = e.what();
-                cp->result.model_3mf.clear();
-            });
-        }
-    });
-
-    return {true, 200, id, ""};
+    spdlog::debug("GenerateModel enqueued: id={}, owner={}, queue_before={}, queue_after={}, "
+                  "owner_active={}",
+                  id, OwnerTag(owner), queue_before, queue_after, owner_active);
+    queue_cv_.notify_one();
+    return {true, 202, id, ""};
 }
 
 std::vector<TaskSnapshot> TaskRuntime::ListTasks(const std::string& owner) const {
@@ -1062,9 +1145,7 @@ std::optional<TaskSnapshot> TaskRuntime::FindTask(const std::string& owner, cons
                      OwnerTag(it->second.snapshot.owner));
         return std::nullopt;
     }
-    if (it->second.snapshot.status == RuntimeTaskStatus::Completed) {
-        it->second.snapshot.completed_at = std::chrono::steady_clock::now();
-    }
+    TouchTaskLocked(it->second, std::chrono::steady_clock::now());
     return it->second.snapshot;
 }
 
@@ -1075,6 +1156,11 @@ bool TaskRuntime::DeleteTask(const std::string& owner, const std::string& id, in
     if (it == tasks_.end() || it->second.snapshot.owner != owner) {
         status_code = 404;
         message     = "Task not found";
+        return false;
+    }
+    if (IsGenerationRunningLocked(it->second)) {
+        status_code = 409;
+        message     = "Cannot delete task while generation is running";
         return false;
     }
     if (it->second.snapshot.status == RuntimeTaskStatus::Pending) {
@@ -1120,7 +1206,7 @@ std::optional<TaskArtifact> TaskRuntime::LoadArtifact(const std::string& owner,
         message     = "Task not completed";
         return std::nullopt;
     }
-    it->second.snapshot.completed_at = std::chrono::steady_clock::now();
+    TouchTaskLocked(it->second, std::chrono::steady_clock::now());
 
     const auto& rec = it->second;
 
@@ -1318,6 +1404,11 @@ std::optional<TaskArtifact> TaskRuntime::LoadArtifact(const std::string& owner,
 
 int TaskRuntime::ActiveTaskCount() const { return running_count_.load(std::memory_order_relaxed); }
 
+TaskRuntime::ArtifactBudgetInfo TaskRuntime::GetArtifactBudgetInfo() const {
+    std::lock_guard<std::mutex> lock(task_mtx_);
+    return {total_artifact_bytes_, static_cast<std::size_t>(max_total_result_bytes_)};
+}
+
 SubmitResult TaskRuntime::SubmitInternal(const std::string& owner, TaskKind kind,
                                          TaskPayload payload, WorkerFn worker) {
     if (owner.empty()) { return {false, 401, "", "Session is required"}; }
@@ -1345,15 +1436,17 @@ SubmitResult TaskRuntime::SubmitInternal(const std::string& owner, TaskKind kind
             return {false, 429, "", "Too many active tasks for current session"};
         }
         TaskRecord rec;
-        rec.snapshot.id         = id;
-        rec.snapshot.owner      = owner;
-        rec.snapshot.kind       = kind;
-        rec.snapshot.status     = RuntimeTaskStatus::Pending;
-        rec.snapshot.created_at = std::chrono::steady_clock::now();
-        rec.snapshot.payload    = std::move(payload);
-        tasks_[id]              = std::move(rec);
+        const auto now                = std::chrono::steady_clock::now();
+        rec.snapshot.id               = id;
+        rec.snapshot.owner            = owner;
+        rec.snapshot.kind             = kind;
+        rec.snapshot.status           = RuntimeTaskStatus::Pending;
+        rec.snapshot.created_at       = now;
+        rec.snapshot.last_accessed_at = now;
+        rec.snapshot.payload          = std::move(payload);
+        tasks_[id]                    = std::move(rec);
 
-        queue_.push_back(QueueEntry{id, std::move(worker)});
+        queue_.push_back(QueueEntry{id, std::move(worker), true});
         queue_after = queue_.size();
         total_submitted_.fetch_add(1, std::memory_order_relaxed);
     }
@@ -1372,7 +1465,7 @@ SubmitResult TaskRuntime::SubmitInternal(const std::string& owner, TaskKind kind
     return {true, 202, id, ""};
 }
 
-void TaskRuntime::RunTask(const std::string& id, WorkerFn worker) {
+void TaskRuntime::RunTask(const std::string& id, WorkerFn worker, bool manage_task_state) {
     TaskKind kind      = TaskKind::Convert;
     std::string owner  = "none";
     double queue_wait  = 0.0;
@@ -1393,13 +1486,23 @@ void TaskRuntime::RunTask(const std::string& id, WorkerFn worker) {
         spdlog::debug("Task running: id={}, kind={}, owner={}, queue_wait_ms={:.2f}", id,
                       TaskKindToString(kind), owner, queue_wait);
     }
-    MarkRunning(id);
+    if (manage_task_state) { MarkRunning(id); }
     running_count_.fetch_add(1, std::memory_order_relaxed);
     try {
         worker(id);
-        MarkCompleted(id);
-    } catch (const std::exception& e) { MarkFailed(id, e.what()); } catch (...) {
-        MarkFailed(id, "Unknown error");
+        if (manage_task_state) { MarkCompleted(id); }
+    } catch (const std::exception& e) {
+        if (manage_task_state) {
+            MarkFailed(id, e.what());
+        } else {
+            throw;
+        }
+    } catch (...) {
+        if (manage_task_state) {
+            MarkFailed(id, "Unknown error");
+        } else {
+            throw;
+        }
     }
     running_count_.fetch_sub(1, std::memory_order_relaxed);
 }
@@ -1423,7 +1526,8 @@ void TaskRuntime::WorkerLoop() {
             job = std::move(queue_.front());
             queue_.pop_front();
         }
-        RunTask(job.task_id, std::move(job.worker));
+        RunTask(job.task_id, std::move(job.worker), job.manage_task_state);
+        ChromaPrint3D::ReleaseFreedMemory();
     }
 }
 
@@ -1431,7 +1535,8 @@ void TaskRuntime::MarkRunning(const std::string& id) {
     std::lock_guard<std::mutex> lock(task_mtx_);
     auto it = tasks_.find(id);
     if (it == tasks_.end()) return;
-    it->second.snapshot.status = RuntimeTaskStatus::Running;
+    it->second.snapshot.status           = RuntimeTaskStatus::Running;
+    it->second.snapshot.last_accessed_at = std::chrono::steady_clock::now();
     spdlog::debug("Task state -> running: id={}, kind={}", id,
                   TaskKindToString(it->second.snapshot.kind));
 }
@@ -1440,11 +1545,12 @@ void TaskRuntime::MarkFailed(const std::string& id, const std::string& message) 
     std::lock_guard<std::mutex> lock(task_mtx_);
     auto it = tasks_.find(id);
     if (it == tasks_.end()) return;
-    it->second.snapshot.status       = RuntimeTaskStatus::Failed;
-    it->second.snapshot.error        = message;
-    it->second.snapshot.completed_at = std::chrono::steady_clock::now();
-    const double elapsed =
-        ElapsedMs(it->second.snapshot.created_at, it->second.snapshot.completed_at);
+    const auto now                       = std::chrono::steady_clock::now();
+    it->second.snapshot.status           = RuntimeTaskStatus::Failed;
+    it->second.snapshot.error            = message;
+    it->second.snapshot.completed_at     = now;
+    it->second.snapshot.last_accessed_at = now;
+    const double elapsed                 = ElapsedMs(it->second.snapshot.created_at, now);
     spdlog::error("Task failed: id={}, kind={}, owner={}, elapsed_ms={:.2f}, error={}", id,
                   TaskKindToString(it->second.snapshot.kind), OwnerTag(it->second.snapshot.owner),
                   elapsed, message);
@@ -1454,30 +1560,32 @@ void TaskRuntime::MarkCompleted(const std::string& id) {
     std::lock_guard<std::mutex> lock(task_mtx_);
     auto it = tasks_.find(id);
     if (it == tasks_.end()) return;
-    it->second.snapshot.status       = RuntimeTaskStatus::Completed;
-    it->second.snapshot.completed_at = std::chrono::steady_clock::now();
-    total_artifact_bytes_ -= it->second.artifact_bytes;
-    it->second.artifact_bytes = ComputeArtifactBytes(it->second.snapshot);
-    total_artifact_bytes_ += it->second.artifact_bytes;
-    const double elapsed =
-        ElapsedMs(it->second.snapshot.created_at, it->second.snapshot.completed_at);
+    const auto now                       = std::chrono::steady_clock::now();
+    it->second.snapshot.status           = RuntimeTaskStatus::Completed;
+    it->second.snapshot.completed_at     = now;
+    it->second.snapshot.last_accessed_at = now;
+    RefreshArtifactBytesLocked(it->second);
+    const double elapsed = ElapsedMs(it->second.snapshot.created_at, now);
 
     if (auto* vp = std::get_if<VectorizeTaskPayload>(&it->second.snapshot.payload)) {
         const std::size_t svg_bytes = vp->svg_bytes > 0 ? vp->svg_bytes : vp->svg_content.size();
         spdlog::info(
             "Task completed: id={}, kind={}, owner={}, elapsed_ms={:.2f}, vectorize_ms={:.2f}, "
             "pipeline_ms={:.2f}, width={}, height={}, num_shapes={}, svg_bytes={}, spilled_svg={}, "
-            "artifact_bytes={}",
+            "artifact_bytes={}, rss_mb={}",
             id, TaskKindToString(it->second.snapshot.kind), OwnerTag(it->second.snapshot.owner),
             elapsed, vp->vectorize_ms, vp->pipeline_ms, vp->width, vp->height, vp->num_shapes,
-            svg_bytes, it->second.spilled_svg.has_file(), it->second.artifact_bytes);
+            svg_bytes, it->second.spilled_svg.has_file(), it->second.artifact_bytes,
+            ChromaPrint3D::GetProcessRssBytes() / (1024 * 1024));
     } else {
         spdlog::debug(
-            "Task completed: id={}, kind={}, owner={}, elapsed_ms={:.2f}, artifact_bytes={}", id,
-            TaskKindToString(it->second.snapshot.kind), OwnerTag(it->second.snapshot.owner),
-            elapsed, it->second.artifact_bytes);
+            "Task completed: id={}, kind={}, owner={}, elapsed_ms={:.2f}, artifact_bytes={}, "
+            "rss_mb={}",
+            id, TaskKindToString(it->second.snapshot.kind), OwnerTag(it->second.snapshot.owner),
+            elapsed, it->second.artifact_bytes,
+            ChromaPrint3D::GetProcessRssBytes() / (1024 * 1024));
     }
-    EnforceResultBudgetLocked();
+    EnforceResultBudgetLocked(&id);
 }
 
 std::size_t TaskRuntime::ComputeArtifactBytes(const TaskSnapshot& snapshot) const {
@@ -1667,6 +1775,10 @@ void TaskRuntime::CleanupLoop() {
 void TaskRuntime::CleanupExpiredLocked(const std::chrono::steady_clock::time_point& now) {
     for (auto it = tasks_.begin(); it != tasks_.end();) {
         const auto& t = it->second.snapshot;
+        if (IsGenerationRunningLocked(it->second)) {
+            ++it;
+            continue;
+        }
         if (t.status == RuntimeTaskStatus::Completed || t.status == RuntimeTaskStatus::Failed) {
             auto elapsed =
                 std::chrono::duration_cast<std::chrono::seconds>(now - t.completed_at).count();
@@ -1681,15 +1793,17 @@ void TaskRuntime::CleanupExpiredLocked(const std::chrono::steady_clock::time_poi
     EnforceResultBudgetLocked();
 }
 
-void TaskRuntime::EnforceResultBudgetLocked() {
+void TaskRuntime::EnforceResultBudgetLocked(const std::string* protected_task_id) {
     if (max_total_result_bytes_ <= 0) return;
     while (static_cast<std::int64_t>(total_artifact_bytes_) > max_total_result_bytes_) {
         auto oldest = tasks_.end();
         for (auto it = tasks_.begin(); it != tasks_.end(); ++it) {
             auto st = it->second.snapshot.status;
             if (st != RuntimeTaskStatus::Completed && st != RuntimeTaskStatus::Failed) continue;
+            if (IsGenerationRunningLocked(it->second)) continue;
+            if (protected_task_id && it->first == *protected_task_id) continue;
             if (oldest == tasks_.end() ||
-                it->second.snapshot.completed_at < oldest->second.snapshot.completed_at) {
+                it->second.snapshot.last_accessed_at < oldest->second.snapshot.last_accessed_at) {
                 oldest = it;
             }
         }
@@ -1704,12 +1818,28 @@ void TaskRuntime::EnforceResultBudgetLocked() {
     }
 }
 
+void TaskRuntime::RefreshArtifactBytesLocked(TaskRecord& rec) {
+    total_artifact_bytes_ -= std::min(total_artifact_bytes_, rec.artifact_bytes);
+    rec.artifact_bytes = ComputeArtifactBytes(rec.snapshot);
+    total_artifact_bytes_ += rec.artifact_bytes;
+}
+
+bool TaskRuntime::IsGenerationRunningLocked(const TaskRecord& rec) const {
+    const auto* cp = std::get_if<ConvertTaskPayload>(&rec.snapshot.payload);
+    return cp && cp->match_only && cp->generation.status == GenerationStatus::Running;
+}
+
+void TaskRuntime::TouchTaskLocked(TaskRecord& rec,
+                                  const std::chrono::steady_clock::time_point& now) {
+    rec.snapshot.last_accessed_at = now;
+}
+
 std::size_t TaskRuntime::ActiveTasksByOwnerLocked(const std::string& owner) const {
     std::size_t count = 0;
     for (const auto& [_, task] : tasks_) {
         if (task.snapshot.owner != owner) continue;
         if (task.snapshot.status == RuntimeTaskStatus::Pending ||
-            task.snapshot.status == RuntimeTaskStatus::Running) {
+            task.snapshot.status == RuntimeTaskStatus::Running || IsGenerationRunningLocked(task)) {
             ++count;
         }
     }

--- a/web/backend/src/infrastructure/task_runtime.h
+++ b/web/backend/src/infrastructure/task_runtime.h
@@ -31,9 +31,18 @@ namespace chromaprint3d::backend {
 
 enum class TaskKind { Convert, Matting, Vectorize };
 enum class RuntimeTaskStatus : std::uint8_t { Pending, Running, Completed, Failed };
+enum class GenerationStatus : std::uint8_t { Idle, Running, Succeeded, Failed };
 
 const char* TaskKindToString(TaskKind kind);
 const char* TaskStatusToString(RuntimeTaskStatus status);
+const char* GenerationStatusToString(GenerationStatus status);
+
+struct GenerationState {
+    GenerationStatus status = GenerationStatus::Idle;
+    std::string error;
+    std::chrono::steady_clock::time_point started_at;
+    std::chrono::steady_clock::time_point completed_at;
+};
 
 struct ConvertTaskPayload {
     std::string input_name;
@@ -43,7 +52,7 @@ struct ConvertTaskPayload {
     bool has_3mf_on_disk = false;
 
     bool match_only = false;
-    std::string generate_error;
+    GenerationState generation;
     std::optional<ChromaPrint3D::MatchRasterResult> raster_match_state;
     std::optional<ChromaPrint3D::RasterRegionMap> raster_region_map;
     std::vector<uint8_t> region_map_binary;
@@ -104,6 +113,7 @@ struct TaskSnapshot {
 
     std::chrono::steady_clock::time_point created_at;
     std::chrono::steady_clock::time_point completed_at;
+    std::chrono::steady_clock::time_point last_accessed_at;
     TaskPayload payload;
 };
 
@@ -197,6 +207,13 @@ public:
 
     int TotalTaskCount() const { return total_submitted_.load(std::memory_order_relaxed); }
 
+    struct ArtifactBudgetInfo {
+        std::size_t used_bytes  = 0;
+        std::size_t limit_bytes = 0;
+    };
+
+    ArtifactBudgetInfo GetArtifactBudgetInfo() const;
+
 private:
     using WorkerFn = std::function<void(const std::string& task_id)>;
 
@@ -210,11 +227,12 @@ private:
     struct QueueEntry {
         std::string task_id;
         WorkerFn worker;
+        bool manage_task_state = true;
     };
 
     SubmitResult SubmitInternal(const std::string& owner, TaskKind kind, TaskPayload payload,
                                 WorkerFn worker);
-    void RunTask(const std::string& id, WorkerFn worker);
+    void RunTask(const std::string& id, WorkerFn worker, bool manage_task_state = true);
     void StartWorkers(std::int64_t worker_count);
     void WorkerLoop();
 
@@ -242,7 +260,10 @@ private:
     std::optional<nlohmann::json> GetRecipeEditorSummaryLocked(const TaskRecord& rec) const;
     void CleanupLoop();
     void CleanupExpiredLocked(const std::chrono::steady_clock::time_point& now);
-    void EnforceResultBudgetLocked();
+    void EnforceResultBudgetLocked(const std::string* protected_task_id = nullptr);
+    void RefreshArtifactBytesLocked(TaskRecord& rec);
+    bool IsGenerationRunningLocked(const TaskRecord& rec) const;
+    void TouchTaskLocked(TaskRecord& rec, const std::chrono::steady_clock::time_point& now);
     std::size_t ActiveTasksByOwnerLocked(const std::string& owner) const;
     static std::string NewTaskId();
 

--- a/web/backend/tests/CMakeLists.txt
+++ b/web/backend/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
-    test_server_facade.cpp)
+    test_server_facade.cpp
+    test_task_runtime.cpp)
 
 add_executable(chromaprint3d_backend_tests ${TEST_SOURCES})
 

--- a/web/backend/tests/test_server_facade.cpp
+++ b/web/backend/tests/test_server_facade.cpp
@@ -4,6 +4,8 @@
 #include "chromaprint3d/calib.h"
 
 #include <filesystem>
+#include <fstream>
+#include <optional>
 #include <string>
 
 namespace chromaprint3d::backend {
@@ -19,6 +21,19 @@ ServerConfig MakeTestConfig() {
     cfg.max_tasks_per_owner = 4;
     cfg.max_task_result_mb  = 256;
     return cfg;
+}
+
+ServerFacade& SharedFacade() {
+    static auto* facade = new ServerFacade(MakeTestConfig());
+    return *facade;
+}
+
+std::string ReadFileText(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open test file: " + path.string());
+    }
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
 }
 
 json MakeGenerateBoardRequest() {
@@ -39,7 +54,7 @@ json MakeGenerateBoardRequest() {
 } // namespace
 
 TEST(ServerFacadeTest, DownloadBoardMetaReturnsInlineJsonArtifact) {
-    ServerFacade facade(MakeTestConfig());
+    auto& facade = SharedFacade();
 
     const auto generate = facade.GenerateBoard(MakeGenerateBoardRequest());
     ASSERT_TRUE(generate.ok) << generate.message;
@@ -67,6 +82,45 @@ TEST(ServerFacadeTest, DownloadBoardMetaReturnsInlineJsonArtifact) {
     ASSERT_EQ(meta.config.palette.size(), 2u);
     EXPECT_EQ(meta.config.palette[0].color, "White");
     EXPECT_EQ(meta.config.palette[1].color, "Black");
+}
+
+TEST(ServerFacadeTest, HealthColordbPoolTracksSessionDatabaseBytes) {
+    auto& facade = SharedFacade();
+
+    bool created     = false;
+    const auto token = facade.EnsureSession(std::nullopt, &created);
+    ASSERT_TRUE(created);
+    ASSERT_FALSE(token.empty());
+
+    const auto baseline_health = facade.Health();
+    ASSERT_TRUE(baseline_health.ok) << baseline_health.message;
+    ASSERT_TRUE(baseline_health.data.contains("memory"));
+    const auto baseline_pool =
+        baseline_health.data.at("memory").at("colordb_pool_bytes").get<std::size_t>();
+    EXPECT_FALSE(baseline_health.data.at("memory").at("allocator").get<std::string>().empty());
+
+    const auto db_json = ReadFileText(std::filesystem::path(CHROMAPRINT3D_TEST_DATA_DIR) / "dbs" /
+                                      "PLA" / "BambuLab" / "RYBW_008_5L.json");
+
+    constexpr auto kSessionDbName = "session_health_test_db";
+    const auto upload =
+        facade.UploadSessionDatabase(token, db_json, std::optional<std::string>{kSessionDbName});
+    ASSERT_TRUE(upload.ok) << upload.message;
+
+    const auto uploaded_health = facade.Health();
+    ASSERT_TRUE(uploaded_health.ok) << uploaded_health.message;
+    const auto uploaded_pool =
+        uploaded_health.data.at("memory").at("colordb_pool_bytes").get<std::size_t>();
+    EXPECT_GT(uploaded_pool, baseline_pool);
+
+    const auto remove = facade.DeleteSessionDatabase(token, kSessionDbName);
+    ASSERT_TRUE(remove.ok) << remove.message;
+
+    const auto restored_health = facade.Health();
+    ASSERT_TRUE(restored_health.ok) << restored_health.message;
+    const auto restored_pool =
+        restored_health.data.at("memory").at("colordb_pool_bytes").get<std::size_t>();
+    EXPECT_EQ(restored_pool, baseline_pool);
 }
 
 } // namespace chromaprint3d::backend

--- a/web/backend/tests/test_task_runtime.cpp
+++ b/web/backend/tests/test_task_runtime.cpp
@@ -1,0 +1,226 @@
+#include <gtest/gtest.h>
+
+#include "application/task_service.h"
+#include "chromaprint3d/color_db.h"
+#include "chromaprint3d/pipeline.h"
+#include "infrastructure/task_runtime.h"
+
+#include <opencv2/imgcodecs.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace chromaprint3d::backend {
+namespace {
+
+using namespace std::chrono_literals;
+using ChromaPrint3D::ColorDB;
+using ChromaPrint3D::ConvertRasterRequest;
+
+std::filesystem::path MakeUniqueTempDir() {
+    static std::atomic<unsigned long long> counter{0};
+    const auto suffix =
+        std::to_string(counter.fetch_add(1, std::memory_order_relaxed) +
+                       static_cast<unsigned long long>(
+                           std::chrono::steady_clock::now().time_since_epoch().count()));
+    const auto dir =
+        std::filesystem::temp_directory_path() / ("chromaprint3d-task-runtime-" + suffix);
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+std::shared_ptr<const ColorDB> LoadTestColorDb() {
+    static const auto db = std::make_shared<const ColorDB>(
+        ColorDB::LoadFromJson((std::filesystem::path(CHROMAPRINT3D_TEST_DATA_DIR) / "dbs" / "PLA" /
+                               "BambuLab" / "RYBW_008_5L.json")
+                                  .string()));
+    return db;
+}
+
+std::vector<uint8_t> EncodeTestPng() {
+    cv::Mat image(8, 8, CV_8UC3, cv::Scalar(32, 64, 192));
+    std::vector<uint8_t> bytes;
+    if (!cv::imencode(".png", image, bytes)) {
+        throw std::runtime_error("failed to encode test PNG");
+    }
+    return bytes;
+}
+
+const ConvertTaskPayload& RequireConvertPayload(const TaskSnapshot& snapshot) {
+    const auto* payload = std::get_if<ConvertTaskPayload>(&snapshot.payload);
+    if (!payload) throw std::runtime_error("task payload is not convert");
+    return *payload;
+}
+
+template <typename Predicate>
+TaskSnapshot WaitForSnapshot(TaskRuntime& runtime, const std::string& owner, const std::string& id,
+                             Predicate&& predicate, std::chrono::milliseconds timeout = 5s) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto snapshot = runtime.FindTask(owner, id);
+        if (snapshot && predicate(*snapshot)) { return *snapshot; }
+        std::this_thread::sleep_for(10ms);
+    }
+    throw std::runtime_error("timeout waiting for task snapshot");
+}
+
+class SharedTaskRuntimeHarness {
+public:
+    SharedTaskRuntimeHarness()
+        : data_dir_(MakeUniqueTempDir()),
+          runtime_(std::make_unique<TaskRuntime>(1, 16, 3600, 16, 256 * 1024 * 1024,
+                                                 data_dir_.string())),
+          db_(LoadTestColorDb()) {}
+
+    TaskRuntime& runtime() { return *runtime_; }
+
+    std::filesystem::path temp_results_dir() const { return data_dir_ / "tmp" / "results"; }
+
+    SubmitResult SubmitRasterMatchOnly(const std::string& owner, const std::string& input_name) {
+        ConvertRasterRequest request;
+        request.image_buffer         = EncodeTestPng();
+        request.image_name           = input_name + ".png";
+        request.preloaded_dbs        = {db_};
+        request.color_layers         = 5;
+        request.generate_preview     = true;
+        request.generate_source_mask = true;
+        request.model_enable         = false;
+        request.max_width            = 8;
+        request.max_height           = 8;
+        return runtime_->SubmitConvertRasterMatchOnly(owner, std::move(request), input_name);
+    }
+
+private:
+    std::filesystem::path data_dir_;
+    std::unique_ptr<TaskRuntime> runtime_;
+    std::shared_ptr<const ColorDB> db_;
+};
+
+SharedTaskRuntimeHarness& GetSharedHarness() {
+    static auto* harness = new SharedTaskRuntimeHarness();
+    return *harness;
+}
+
+TEST(TaskRuntimeTest, MatchOnlyGenerationFailurePreservesTaskStateAndAllowsRetry) {
+    auto& harness           = GetSharedHarness();
+    auto& runtime           = harness.runtime();
+    const std::string owner = "runtime-retry-owner";
+
+    const auto submit = harness.SubmitRasterMatchOnly(owner, "retryable-match-only");
+    ASSERT_TRUE(submit.ok) << submit.message;
+
+    const auto matched =
+        WaitForSnapshot(runtime, owner, submit.task_id, [](const TaskSnapshot& snapshot) {
+            return snapshot.status == RuntimeTaskStatus::Completed ||
+                   snapshot.status == RuntimeTaskStatus::Failed;
+        });
+    ASSERT_EQ(matched.status, RuntimeTaskStatus::Completed);
+
+    const auto initial_completed_at = matched.completed_at;
+    const auto& initial_payload     = RequireConvertPayload(matched);
+    EXPECT_TRUE(initial_payload.match_only);
+    EXPECT_EQ(initial_payload.generation.status, GenerationStatus::Idle);
+    EXPECT_FALSE(initial_payload.result.preview_png.empty());
+    EXPECT_FALSE(initial_payload.result.source_mask_png.empty());
+
+    std::error_code ec;
+    std::filesystem::remove_all(harness.temp_results_dir(), ec);
+    ASSERT_FALSE(ec) << ec.message();
+
+    const auto first_generate = runtime.SubmitGenerateModel(owner, submit.task_id);
+    ASSERT_TRUE(first_generate.ok) << first_generate.message;
+
+    const auto failed =
+        WaitForSnapshot(runtime, owner, submit.task_id, [](const TaskSnapshot& snapshot) {
+            const auto& payload = RequireConvertPayload(snapshot);
+            return payload.generation.status == GenerationStatus::Failed;
+        });
+
+    EXPECT_EQ(failed.status, RuntimeTaskStatus::Completed);
+    EXPECT_EQ(failed.completed_at, initial_completed_at);
+
+    const auto& failed_payload = RequireConvertPayload(failed);
+    EXPECT_EQ(failed_payload.generation.status, GenerationStatus::Failed);
+    EXPECT_FALSE(failed_payload.generation.error.empty());
+    EXPECT_FALSE(failed_payload.has_3mf_on_disk);
+    EXPECT_TRUE(runtime.GetRecipeEditorSummary(owner, submit.task_id).has_value());
+
+    TaskService task_service(runtime);
+    const auto failed_task_json = task_service.GetTask(owner, submit.task_id);
+    ASSERT_TRUE(failed_task_json.ok) << failed_task_json.message;
+    EXPECT_EQ(failed_task_json.data.at("status"), "completed");
+    EXPECT_EQ(failed_task_json.data.at("generation").at("status"), "failed");
+    EXPECT_FALSE(failed_task_json.data.at("result").at("has_3mf").get<bool>());
+
+    std::filesystem::create_directories(harness.temp_results_dir(), ec);
+    ASSERT_FALSE(ec) << ec.message();
+
+    const auto retry_generate = runtime.SubmitGenerateModel(owner, submit.task_id);
+    ASSERT_TRUE(retry_generate.ok) << retry_generate.message;
+
+    const auto succeeded = WaitForSnapshot(
+        runtime, owner, submit.task_id,
+        [](const TaskSnapshot& snapshot) {
+            const auto& payload = RequireConvertPayload(snapshot);
+            return payload.generation.status == GenerationStatus::Succeeded;
+        },
+        15s);
+
+    EXPECT_EQ(succeeded.status, RuntimeTaskStatus::Completed);
+    EXPECT_EQ(succeeded.completed_at, initial_completed_at);
+
+    const auto& succeeded_payload = RequireConvertPayload(succeeded);
+    EXPECT_EQ(succeeded_payload.generation.status, GenerationStatus::Succeeded);
+    EXPECT_TRUE(succeeded_payload.generation.error.empty());
+    EXPECT_TRUE(succeeded_payload.has_3mf_on_disk || !succeeded_payload.result.model_3mf.empty());
+    EXPECT_FALSE(succeeded_payload.result.layer_previews.layer_pngs.empty());
+
+    const auto succeeded_task_json = task_service.GetTask(owner, submit.task_id);
+    ASSERT_TRUE(succeeded_task_json.ok) << succeeded_task_json.message;
+    EXPECT_EQ(succeeded_task_json.data.at("status"), "completed");
+    EXPECT_EQ(succeeded_task_json.data.at("generation").at("status"), "succeeded");
+    EXPECT_TRUE(succeeded_task_json.data.at("result").at("has_3mf").get<bool>());
+
+    TaskArtifact downloaded_artifact;
+    const auto download_result =
+        task_service.DownloadTaskArtifact(owner, submit.task_id, "result", downloaded_artifact);
+    ASSERT_TRUE(download_result.ok) << download_result.message;
+    EXPECT_EQ(download_result.status_code, 200);
+    EXPECT_TRUE(downloaded_artifact.is_file_based() || !downloaded_artifact.bytes.empty());
+}
+
+TEST(TaskRuntimeTest, FindTaskRefreshesLastAccessedWithoutMovingCompletedAt) {
+    auto& harness           = GetSharedHarness();
+    auto& runtime           = harness.runtime();
+    const std::string owner = "runtime-access-owner";
+
+    const auto submit = harness.SubmitRasterMatchOnly(owner, "access-tracking");
+    ASSERT_TRUE(submit.ok) << submit.message;
+
+    const auto matched =
+        WaitForSnapshot(runtime, owner, submit.task_id, [](const TaskSnapshot& snapshot) {
+            return snapshot.status == RuntimeTaskStatus::Completed ||
+                   snapshot.status == RuntimeTaskStatus::Failed;
+        });
+    ASSERT_EQ(matched.status, RuntimeTaskStatus::Completed);
+
+    const auto first = runtime.FindTask(owner, submit.task_id);
+    ASSERT_TRUE(first.has_value());
+
+    std::this_thread::sleep_for(15ms);
+
+    const auto second = runtime.FindTask(owner, submit.task_id);
+    ASSERT_TRUE(second.has_value());
+
+    EXPECT_EQ(second->completed_at, first->completed_at);
+    EXPECT_GT(second->last_accessed_at, first->last_accessed_at);
+}
+
+} // namespace
+} // namespace chromaprint3d::backend

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -18,7 +18,6 @@ import {
   NMessageProvider,
   NSwitch,
   NButton,
-  NTooltip,
   darkTheme,
   zhCN,
   dateZhCN,
@@ -63,39 +62,10 @@ const {
   serverVersion,
   activeTasks,
   totalTasks,
-  serverMemory,
   isDark,
   recipeEditorTaskId,
   completedTask,
 } = storeToRefs(appStore)
-
-const MB = 1024 * 1024
-const memoryPct = computed(() => {
-  const m = serverMemory.value
-  if (!m || m.memory_limit_bytes <= 0) return -1
-  return Math.round((m.rss_bytes / m.memory_limit_bytes) * 100)
-})
-const memoryTagType = computed(() => {
-  const p = memoryPct.value
-  if (p < 0) return 'default'
-  if (p < 60) return 'success'
-  if (p <= 80) return 'warning'
-  return 'error'
-})
-const memoryTooltipText = computed(() => {
-  const m = serverMemory.value
-  if (!m) return ''
-  return t('common.memoryTooltip', {
-    rss: Math.round(m.rss_bytes / MB),
-    limit: m.memory_limit_bytes > 0 ? Math.round(m.memory_limit_bytes / MB) : '∞',
-    heapAlloc: Math.round(m.heap_allocated_bytes / MB),
-    heapRes: Math.round(m.heap_resident_bytes / MB),
-    budgetUsed: Math.round(m.artifact_budget_bytes / MB),
-    budgetLimit: Math.round(m.artifact_budget_limit_bytes / MB),
-    colordbPool: Math.round(m.colordb_pool_bytes / MB),
-    allocator: m.allocator,
-  })
-})
 
 const activeTheme = computed(() => (isDark.value ? darkTheme : null))
 const activeThemeOverrides = computed(() =>
@@ -259,14 +229,6 @@ function toggleLocale() {
               <NButton size="small" quaternary @click="toggleLocale">
                 {{ locale === 'zh-CN' ? 'EN' : '中' }}
               </NButton>
-              <NTooltip v-if="serverOnline && memoryPct >= 0" :style="{ whiteSpace: 'pre-line' }">
-                <template #trigger>
-                  <NTag :type="memoryTagType" size="small" round>
-                    {{ t('common.memoryUsage', { pct: memoryPct }) }}
-                  </NTag>
-                </template>
-                {{ memoryTooltipText }}
-              </NTooltip>
               <NTag :type="serverOnline ? 'success' : 'error'" size="small" round>
                 {{ serverOnline ? t('common.serverOnline') : t('common.serverOffline') }}
               </NTag>

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -18,6 +18,7 @@ import {
   NMessageProvider,
   NSwitch,
   NButton,
+  NTooltip,
   darkTheme,
   zhCN,
   dateZhCN,
@@ -62,10 +63,39 @@ const {
   serverVersion,
   activeTasks,
   totalTasks,
+  serverMemory,
   isDark,
   recipeEditorTaskId,
   completedTask,
 } = storeToRefs(appStore)
+
+const MB = 1024 * 1024
+const memoryPct = computed(() => {
+  const m = serverMemory.value
+  if (!m || m.memory_limit_bytes <= 0) return -1
+  return Math.round((m.rss_bytes / m.memory_limit_bytes) * 100)
+})
+const memoryTagType = computed(() => {
+  const p = memoryPct.value
+  if (p < 0) return 'default'
+  if (p < 60) return 'success'
+  if (p <= 80) return 'warning'
+  return 'error'
+})
+const memoryTooltipText = computed(() => {
+  const m = serverMemory.value
+  if (!m) return ''
+  return t('common.memoryTooltip', {
+    rss: Math.round(m.rss_bytes / MB),
+    limit: m.memory_limit_bytes > 0 ? Math.round(m.memory_limit_bytes / MB) : '∞',
+    heapAlloc: Math.round(m.heap_allocated_bytes / MB),
+    heapRes: Math.round(m.heap_resident_bytes / MB),
+    budgetUsed: Math.round(m.artifact_budget_bytes / MB),
+    budgetLimit: Math.round(m.artifact_budget_limit_bytes / MB),
+    colordbPool: Math.round(m.colordb_pool_bytes / MB),
+    allocator: m.allocator,
+  })
+})
 
 const activeTheme = computed(() => (isDark.value ? darkTheme : null))
 const activeThemeOverrides = computed(() =>
@@ -229,6 +259,14 @@ function toggleLocale() {
               <NButton size="small" quaternary @click="toggleLocale">
                 {{ locale === 'zh-CN' ? 'EN' : '中' }}
               </NButton>
+              <NTooltip v-if="serverOnline && memoryPct >= 0" :style="{ whiteSpace: 'pre-line' }">
+                <template #trigger>
+                  <NTag :type="memoryTagType" size="small" round>
+                    {{ t('common.memoryUsage', { pct: memoryPct }) }}
+                  </NTag>
+                </template>
+                {{ memoryTooltipText }}
+              </NTooltip>
               <NTag :type="serverOnline ? 'success' : 'error'" size="small" round>
                 {{ serverOnline ? t('common.serverOnline') : t('common.serverOffline') }}
               </NTag>

--- a/web/frontend/src/components/recipeEditor/CustomRecipeDialog.vue
+++ b/web/frontend/src/components/recipeEditor/CustomRecipeDialog.vue
@@ -16,7 +16,7 @@ import {
 } from 'naive-ui'
 import type { LabColor, PaletteChannel } from '../../types'
 import { hexToLab, labToHex } from '../../utils/colorConvert'
-import { predictRecipeColor } from '../../api/recipeEditor'
+import { predictRecipeColor } from '../../services/recipeEditorService'
 
 const MAX_COLOR_LAYERS = 10
 

--- a/web/frontend/src/components/recipeEditor/RecipeCandidatePanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeCandidatePanel.vue
@@ -14,7 +14,7 @@ import {
   NTooltip,
 } from 'naive-ui'
 import type { RecipeCandidate, LabColor, PaletteChannel } from '../../types'
-import { fetchRecipeAlternatives } from '../../api/recipeEditor'
+import { fetchRecipeAlternatives } from '../../services/recipeEditorService'
 import { hexToLab } from '../../utils/colorConvert'
 import { buildPaletteHint, validateRecipePattern } from '../../utils/recipePattern'
 import RecipeLayerBar from './RecipeLayerBar.vue'

--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -15,11 +15,13 @@ import {
 } from 'naive-ui'
 import type { RecipeEditorSummary, RecipeCandidate, LabColor, RecipeInfo } from '../../types'
 import {
+  fetchRecipeEditorPreview,
   fetchRecipeEditorSummary,
+  fetchRecipeTaskStatus,
   replaceRecipe,
   submitGenerateModel,
-} from '../../api/recipeEditor'
-import { fetchTaskStatus } from '../../api/tasks'
+  waitForRecipeGeneration,
+} from '../../services/recipeEditorService'
 import { useRegionMap } from '../../composables/useRegionMap'
 import { usePanZoom } from '../../composables/usePanZoom'
 import { useAppStore } from '../../stores/app'
@@ -29,10 +31,8 @@ import CustomRecipeDialog from './CustomRecipeDialog.vue'
 import CustomRecipeListPanel from './CustomRecipeListPanel.vue'
 import RegionOverlayCanvas from './RegionOverlayCanvas.vue'
 import ZoomableImageViewport from '../common/ZoomableImageViewport.vue'
-import { fetchBlobWithSession } from '../../runtime/protectedRequest'
-import { getPreviewPath, getResultPath } from '../../api/tasks'
-import { buildApiUrl } from '../../runtime/env'
 import { useBlobDownload } from '../../composables/useBlobDownload'
+import { getResultPath } from '../../services/resultService'
 
 const props = defineProps<{
   taskId: string
@@ -118,6 +118,7 @@ async function loadSummary() {
     summary.value = await fetchRecipeEditorSummary(props.taskId)
     await loadRegionMap(props.taskId, summary.value.width, summary.value.height)
     await loadPreview()
+    await syncCompletedTask()
     startKeepalive()
   } catch (e) {
     summaryError.value = e instanceof Error ? e.message : String(e)
@@ -129,10 +130,19 @@ async function loadSummary() {
 async function loadPreview() {
   if (previewBlobUrl.value) URL.revokeObjectURL(previewBlobUrl.value)
   try {
-    const blob = await fetchBlobWithSession(buildApiUrl(getPreviewPath(props.taskId)))
+    const blob = await fetchRecipeEditorPreview(props.taskId)
     previewBlobUrl.value = URL.createObjectURL(blob)
   } catch {
     previewBlobUrl.value = ''
+  }
+}
+
+async function syncCompletedTask() {
+  try {
+    const status = await fetchRecipeTaskStatus(props.taskId)
+    appStore.setCompletedTask(status)
+  } catch {
+    appStore.clearCompletedTask()
   }
 }
 
@@ -288,6 +298,7 @@ function handleSelectRecipe(index: number) {
 // ── Replace recipe ───────────────────────────────────────────────────────────
 
 async function handleCandidateSelect(candidate: RecipeCandidate) {
+  if (replacing.value || generating.value) return
   if (!summary.value || selectedRegionIds.value.size === 0 || selectedRecipeIndex.value === null) {
     message.warning(t('recipeEditor.noRegionSelected'))
     return
@@ -312,6 +323,7 @@ async function handleCandidateSelect(candidate: RecipeCandidate) {
 
     summary.value = newSummary
     await loadPreview()
+    await syncCompletedTask()
 
     const selectedSet = selectedRegionIds.value
     const firstRegion = newSummary.regions.find((r) => selectedSet.has(r.region_id))
@@ -329,6 +341,7 @@ async function handleCandidateSelect(candidate: RecipeCandidate) {
 }
 
 async function handleUndo() {
+  if (replacing.value || generating.value) return
   if (undoStack.value.length === 0 || !summary.value) return
   const entry = undoStack.value.pop()!
   replacing.value = true
@@ -342,6 +355,7 @@ async function handleUndo() {
     )
     summary.value = newSummary
     await loadPreview()
+    await syncCompletedTask()
 
     const undoSet = new Set(entry.regionIds)
     const firstRegion = newSummary.regions.find((r) => undoSet.has(r.region_id))
@@ -386,6 +400,7 @@ const customRecipeInitialHex = computed<string>(() => {
 })
 
 function openCustomRecipeDialog() {
+  if (replacing.value || generating.value) return
   if (!summary.value || selectedRegionIds.value.size === 0 || selectedRecipeIndex.value === null) {
     message.warning(t('recipeEditor.noRegionSelected'))
     return
@@ -430,25 +445,12 @@ async function handleGenerate() {
   appStore.clearCompletedTask()
   try {
     await submitGenerateModel(props.taskId)
-
-    for (let i = 0; i < 300; i++) {
-      await new Promise((r) => setTimeout(r, 1000))
-      const status = await fetchTaskStatus(props.taskId)
-      if (status.status === 'completed') {
-        if (status.generate_error) {
-          generateError.value = status.generate_error
-        } else {
-          appStore.setCompletedTask(status)
-          generateDone.value = true
-        }
-        return
-      }
-      if (status.status === 'failed') {
-        generateError.value = status.error ?? t('recipeEditor.generateFailed')
-        return
-      }
-    }
-    generateError.value = t('recipeEditor.generateTimeout')
+    const status = await waitForRecipeGeneration(props.taskId, {
+      failedMessage: t('recipeEditor.generateFailed'),
+      timeoutMessage: t('recipeEditor.generateTimeout'),
+    })
+    appStore.setCompletedTask(status)
+    generateDone.value = true
   } catch (e) {
     generateError.value = e instanceof Error ? e.message : String(e)
   } finally {
@@ -544,7 +546,7 @@ onUnmounted(() => {
         <NButton
           size="small"
           quaternary
-          :disabled="replacing"
+          :disabled="replacing || generating"
           :style="canUndo ? undefined : { visibility: 'hidden', pointerEvents: 'none' }"
           @click="handleUndo"
         >
@@ -686,7 +688,7 @@ onUnmounted(() => {
       <NButton
         type="primary"
         :loading="generating"
-        :disabled="generating || !summary"
+        :disabled="generating || replacing || !summary"
         @click="handleGenerate"
       >
         {{

--- a/web/frontend/src/composables/feature/useAppLifecycle.ts
+++ b/web/frontend/src/composables/feature/useAppLifecycle.ts
@@ -1,5 +1,7 @@
 import { onMounted, onUnmounted, watch } from 'vue'
 import { useAppStore } from '../../stores/app'
+import type { HealthMemory } from '../../types'
+import { useLeaderLease } from './useLeaderLease'
 
 let themeSwitchCleanupTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -22,9 +24,42 @@ async function syncTheme(dark: boolean, appStore: ReturnType<typeof useAppStore>
   await window.electron?.theme?.setWindowBackground?.(dark)
 }
 
+const MEMORY_REPORT_INTERVAL_MS = 5 * 60 * 1000
+const LEADER_CHANNEL_NAME = 'chromaprint3d-memory-reporter'
+const MB = 1048576
+
+let memoryReportTimer: ReturnType<typeof setInterval> | null = null
+
+function reportMemoryToUmami(memory: HealthMemory, isLeader: boolean) {
+  if (!isLeader || !window.umami) return
+  window.umami.track('memory-status', {
+    rss_mb: Math.round(memory.rss_bytes / MB),
+    heap_mb: Math.round(memory.heap_resident_bytes / MB),
+    artifact_pct:
+      memory.artifact_budget_limit_bytes > 0
+        ? Math.round((memory.artifact_budget_bytes / memory.artifact_budget_limit_bytes) * 100)
+        : -1,
+    usage_pct:
+      memory.memory_limit_bytes > 0
+        ? Math.round((memory.rss_bytes / memory.memory_limit_bytes) * 100)
+        : -1,
+    allocator: memory.allocator,
+  })
+}
+
+function cleanupLeader() {
+  if (memoryReportTimer) {
+    clearInterval(memoryReportTimer)
+    memoryReportTimer = null
+  }
+}
+
 export function useAppLifecycle() {
   const appStore = useAppStore()
   let healthTimer: ReturnType<typeof setInterval> | null = null
+  const { isLeader } = useLeaderLease({
+    channelName: LEADER_CHANNEL_NAME,
+  })
 
   onMounted(async () => {
     await appStore.initTheme()
@@ -35,10 +70,16 @@ export function useAppLifecycle() {
     healthTimer = setInterval(() => {
       void appStore.checkHealth()
     }, 15000)
+
+    memoryReportTimer = setInterval(() => {
+      const m = appStore.serverMemory
+      if (m) reportMemoryToUmami(m, isLeader.value)
+    }, MEMORY_REPORT_INTERVAL_MS)
   })
 
   onUnmounted(() => {
     if (healthTimer) clearInterval(healthTimer)
+    cleanupLeader()
     if (themeSwitchCleanupTimer) {
       clearTimeout(themeSwitchCleanupTimer)
       themeSwitchCleanupTimer = null

--- a/web/frontend/src/composables/feature/useLeaderLease.test.ts
+++ b/web/frontend/src/composables/feature/useLeaderLease.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createLeaderLeaseController } from './useLeaderLease'
+
+type LeaseMessage =
+  | { type: 'heartbeat'; tabId: string; expiresAt: number }
+  | { type: 'resign'; tabId: string }
+
+class FakeBroadcastChannel {
+  static channels = new Map<string, Set<FakeBroadcastChannel>>()
+
+  onmessage: ((event: MessageEvent<LeaseMessage>) => void) | null = null
+  private readonly name: string
+
+  constructor(name: string) {
+    this.name = name
+    const peers = FakeBroadcastChannel.channels.get(name) ?? new Set<FakeBroadcastChannel>()
+    peers.add(this)
+    FakeBroadcastChannel.channels.set(name, peers)
+  }
+
+  postMessage(message: LeaseMessage) {
+    const peers = FakeBroadcastChannel.channels.get(this.name)
+    if (!peers) return
+    for (const peer of peers) {
+      if (peer === this) continue
+      peer.onmessage?.({ data: message } as MessageEvent<LeaseMessage>)
+    }
+  }
+
+  close() {
+    const peers = FakeBroadcastChannel.channels.get(this.name)
+    peers?.delete(this)
+    if (peers && peers.size === 0) {
+      FakeBroadcastChannel.channels.delete(this.name)
+    }
+  }
+
+  static reset() {
+    FakeBroadcastChannel.channels.clear()
+  }
+}
+
+describe('createLeaderLeaseController', () => {
+  it('在不支持 BroadcastChannel 时自动成为 leader', () => {
+    const controller = createLeaderLeaseController({
+      channelName: 'memory',
+      BroadcastChannelCtor: undefined,
+      createTabId: () => 'tab-a',
+    })
+
+    controller.start()
+    expect(controller.isLeader.value).toBe(true)
+    controller.stop()
+  })
+
+  it('多个 tab 中只保留字典序更小的 leader', async () => {
+    vi.useFakeTimers()
+    FakeBroadcastChannel.reset()
+
+    const common = {
+      channelName: 'memory',
+      leaseMs: 100,
+      heartbeatMs: 20,
+      electionDelayMs: 0,
+      randomBackoffMs: 0,
+      random: () => 0,
+      BroadcastChannelCtor: FakeBroadcastChannel,
+    } as const
+
+    const leader = createLeaderLeaseController({
+      ...common,
+      createTabId: () => 'tab-a',
+    })
+    const follower = createLeaderLeaseController({
+      ...common,
+      createTabId: () => 'tab-b',
+    })
+
+    leader.start()
+    follower.start()
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(leader.isLeader.value).toBe(true)
+    expect(follower.isLeader.value).toBe(false)
+
+    leader.stop()
+    follower.stop()
+    vi.useRealTimers()
+  })
+
+  it('leader 停止后其他 tab 会自动接棒', async () => {
+    vi.useFakeTimers()
+    FakeBroadcastChannel.reset()
+
+    const common = {
+      channelName: 'memory',
+      leaseMs: 120,
+      heartbeatMs: 20,
+      electionDelayMs: 0,
+      randomBackoffMs: 0,
+      random: () => 0,
+      BroadcastChannelCtor: FakeBroadcastChannel,
+    } as const
+
+    const first = createLeaderLeaseController({
+      ...common,
+      createTabId: () => 'tab-a',
+    })
+    const second = createLeaderLeaseController({
+      ...common,
+      createTabId: () => 'tab-b',
+    })
+
+    first.start()
+    second.start()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(first.isLeader.value).toBe(true)
+    expect(second.isLeader.value).toBe(false)
+
+    first.stop()
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(second.isLeader.value).toBe(true)
+
+    second.stop()
+    vi.useRealTimers()
+  })
+})

--- a/web/frontend/src/composables/feature/useLeaderLease.ts
+++ b/web/frontend/src/composables/feature/useLeaderLease.ts
@@ -1,0 +1,265 @@
+import { onMounted, onUnmounted, readonly, ref } from 'vue'
+
+type LeaderHeartbeatMessage = {
+  type: 'heartbeat'
+  tabId: string
+  expiresAt: number
+}
+
+type LeaderResignMessage = {
+  type: 'resign'
+  tabId: string
+}
+
+type LeaderLeaseMessage = LeaderHeartbeatMessage | LeaderResignMessage
+
+type BroadcastChannelLike = {
+  onmessage: ((event: MessageEvent<LeaderLeaseMessage>) => void) | null
+  postMessage: (message: LeaderLeaseMessage) => void
+  close: () => void
+}
+
+type BroadcastChannelCtor = new (name: string) => BroadcastChannelLike
+
+export type LeaderLeaseOptions = {
+  channelName: string
+  leaseMs?: number
+  heartbeatMs?: number
+  electionDelayMs?: number
+  randomBackoffMs?: number
+  now?: () => number
+  random?: () => number
+  createTabId?: () => string
+  BroadcastChannelCtor?: BroadcastChannelCtor | undefined
+}
+
+const DEFAULT_LEASE_MS = 15000
+const DEFAULT_HEARTBEAT_MS = 5000
+const DEFAULT_ELECTION_DELAY_MS = 1200
+const DEFAULT_RANDOM_BACKOFF_MS = 800
+
+function defaultNow(): number {
+  return Date.now()
+}
+
+function defaultRandom(): number {
+  return Math.random()
+}
+
+function defaultCreateTabId(): string {
+  const randomUuid = globalThis.crypto?.randomUUID?.()
+  if (randomUuid) return randomUuid
+  return `tab-${Date.now()}-${Math.floor(Math.random() * 1e9)}`
+}
+
+function compareTabIds(a: string, b: string): number {
+  if (a === b) return 0
+  return a < b ? -1 : 1
+}
+
+function isHeartbeatMessage(data: LeaderLeaseMessage): data is LeaderHeartbeatMessage {
+  return data.type === 'heartbeat'
+}
+
+function resolveBroadcastChannelCtor(
+  options: LeaderLeaseOptions,
+): BroadcastChannelCtor | undefined {
+  if ('BroadcastChannelCtor' in options) return options.BroadcastChannelCtor
+  if (typeof BroadcastChannel === 'undefined') return undefined
+  return BroadcastChannel as unknown as BroadcastChannelCtor
+}
+
+export function createLeaderLeaseController(options: LeaderLeaseOptions) {
+  const leaseMs = options.leaseMs ?? DEFAULT_LEASE_MS
+  const heartbeatMs = options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS
+  const electionDelayMs = options.electionDelayMs ?? DEFAULT_ELECTION_DELAY_MS
+  const randomBackoffMs = options.randomBackoffMs ?? DEFAULT_RANDOM_BACKOFF_MS
+  const now = options.now ?? defaultNow
+  const random = options.random ?? defaultRandom
+  const tabId = (options.createTabId ?? defaultCreateTabId)()
+
+  const isLeader = ref(false)
+
+  let started = false
+  let channel: BroadcastChannelLike | null = null
+  let knownLeaderId: string | null = null
+  let knownLeaderExpiresAt = 0
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  let electionTimer: ReturnType<typeof setTimeout> | null = null
+
+  function clearElectionTimer() {
+    if (electionTimer !== null) {
+      clearTimeout(electionTimer)
+      electionTimer = null
+    }
+  }
+
+  function clearHeartbeatTimer() {
+    if (heartbeatTimer !== null) {
+      clearInterval(heartbeatTimer)
+      heartbeatTimer = null
+    }
+  }
+
+  function nextBackoffMs(baseDelayMs = electionDelayMs): number {
+    return baseDelayMs + Math.floor(random() * randomBackoffMs)
+  }
+
+  function publishHeartbeat() {
+    if (!started || !channel) return
+    const expiresAt = now() + leaseMs
+    knownLeaderId = tabId
+    knownLeaderExpiresAt = expiresAt
+    channel.postMessage({
+      type: 'heartbeat',
+      tabId,
+      expiresAt,
+    })
+  }
+
+  function startHeartbeatLoop() {
+    clearHeartbeatTimer()
+    publishHeartbeat()
+    heartbeatTimer = setInterval(() => {
+      publishHeartbeat()
+    }, heartbeatMs)
+  }
+
+  function scheduleElection(delayMs = electionDelayMs) {
+    if (!started || isLeader.value) return
+    clearElectionTimer()
+    electionTimer = setTimeout(() => {
+      attemptLeadership()
+    }, nextBackoffMs(delayMs))
+  }
+
+  function scheduleElectionAtLeaseExpiry() {
+    if (!started || isLeader.value) return
+    const delayMs = Math.max(0, knownLeaderExpiresAt - now())
+    scheduleElection(delayMs)
+  }
+
+  function preferCandidate(candidateId: string, candidateExpiresAt: number): boolean {
+    const currentTime = now()
+    if (!knownLeaderId || knownLeaderExpiresAt <= currentTime) return true
+    if (candidateId === knownLeaderId) return candidateExpiresAt >= knownLeaderExpiresAt
+    return compareTabIds(candidateId, knownLeaderId) < 0
+  }
+
+  function stepDownToLeader(leaderId: string, expiresAt: number) {
+    clearHeartbeatTimer()
+    isLeader.value = false
+    knownLeaderId = leaderId
+    knownLeaderExpiresAt = expiresAt
+    scheduleElectionAtLeaseExpiry()
+  }
+
+  function claimLeadership() {
+    clearElectionTimer()
+    isLeader.value = true
+    startHeartbeatLoop()
+  }
+
+  function handleHeartbeat(message: LeaderHeartbeatMessage) {
+    if (message.tabId === tabId) {
+      knownLeaderId = tabId
+      knownLeaderExpiresAt = message.expiresAt
+      return
+    }
+    if (message.expiresAt <= now()) return
+
+    if (isLeader.value) {
+      if (compareTabIds(message.tabId, tabId) < 0) {
+        stepDownToLeader(message.tabId, message.expiresAt)
+      } else {
+        publishHeartbeat()
+      }
+      return
+    }
+
+    if (preferCandidate(message.tabId, message.expiresAt)) {
+      knownLeaderId = message.tabId
+      knownLeaderExpiresAt = message.expiresAt
+    }
+    scheduleElectionAtLeaseExpiry()
+  }
+
+  function handleResign(tabIdToResign: string) {
+    if (tabIdToResign !== knownLeaderId) return
+    knownLeaderId = null
+    knownLeaderExpiresAt = 0
+    scheduleElection(0)
+  }
+
+  function handleMessage(event: MessageEvent<LeaderLeaseMessage>) {
+    const message = event.data
+    if (!message) return
+    if (isHeartbeatMessage(message)) {
+      handleHeartbeat(message)
+      return
+    }
+    handleResign(message.tabId)
+  }
+
+  function attemptLeadership() {
+    if (!started || isLeader.value) return
+    const currentTime = now()
+    if (knownLeaderId !== null && knownLeaderId !== tabId && knownLeaderExpiresAt > currentTime) {
+      scheduleElectionAtLeaseExpiry()
+      return
+    }
+    claimLeadership()
+  }
+
+  function start() {
+    if (started) return
+    started = true
+
+    const BroadcastCtor = resolveBroadcastChannelCtor(options)
+    if (!BroadcastCtor) {
+      knownLeaderId = tabId
+      knownLeaderExpiresAt = Number.POSITIVE_INFINITY
+      isLeader.value = true
+      return
+    }
+
+    channel = new BroadcastCtor(options.channelName)
+    channel.onmessage = handleMessage
+    scheduleElection(0)
+  }
+
+  function stop() {
+    if (!started) return
+    started = false
+    clearElectionTimer()
+    clearHeartbeatTimer()
+    if (isLeader.value && channel) {
+      channel.postMessage({
+        type: 'resign',
+        tabId,
+      })
+    }
+    channel?.close()
+    channel = null
+    knownLeaderId = null
+    knownLeaderExpiresAt = 0
+    isLeader.value = false
+  }
+
+  return {
+    isLeader: readonly(isLeader),
+    start,
+    stop,
+  }
+}
+
+export function useLeaderLease(options: LeaderLeaseOptions) {
+  const controller = createLeaderLeaseController(options)
+  onMounted(() => {
+    controller.start()
+  })
+  onUnmounted(() => {
+    controller.stop()
+  })
+  return controller
+}

--- a/web/frontend/src/locales/en.ts
+++ b/web/frontend/src/locales/en.ts
@@ -23,9 +23,6 @@ export default {
     pollFailed: 'Task polling failed, please retry ({message})',
     downloadFailed: 'Download failed, please retry',
     videoTutorial: 'Video Tutorial',
-    memoryUsage: 'Mem {pct}%',
-    memoryTooltip:
-      'RSS: {rss} MB / {limit} MB\nHeap Allocated: {heapAlloc} MB\nHeap Resident: {heapRes} MB\nArtifact Budget: {budgetUsed} MB / {budgetLimit} MB\nColorDB Pool: {colordbPool} MB\nAllocator: {allocator}',
   },
 
   taskErrors: {

--- a/web/frontend/src/locales/en.ts
+++ b/web/frontend/src/locales/en.ts
@@ -23,6 +23,9 @@ export default {
     pollFailed: 'Task polling failed, please retry ({message})',
     downloadFailed: 'Download failed, please retry',
     videoTutorial: 'Video Tutorial',
+    memoryUsage: 'Mem {pct}%',
+    memoryTooltip:
+      'RSS: {rss} MB / {limit} MB\nHeap Allocated: {heapAlloc} MB\nHeap Resident: {heapRes} MB\nArtifact Budget: {budgetUsed} MB / {budgetLimit} MB\nColorDB Pool: {colordbPool} MB\nAllocator: {allocator}',
   },
 
   taskErrors: {

--- a/web/frontend/src/locales/zh-CN.ts
+++ b/web/frontend/src/locales/zh-CN.ts
@@ -53,6 +53,9 @@ export default {
     pollFailed: '任务状态轮询失败，请重试（{message}）',
     downloadFailed: '下载失败，请重试',
     videoTutorial: '视频教程',
+    memoryUsage: '内存 {pct}%',
+    memoryTooltip:
+      'RSS: {rss} MB / {limit} MB\n堆已分配: {heapAlloc} MB\n堆驻留: {heapRes} MB\n任务预算: {budgetUsed} MB / {budgetLimit} MB\nColorDB 池: {colordbPool} MB\n分配器: {allocator}',
   },
 
   taskErrors: {

--- a/web/frontend/src/locales/zh-CN.ts
+++ b/web/frontend/src/locales/zh-CN.ts
@@ -53,9 +53,6 @@ export default {
     pollFailed: '任务状态轮询失败，请重试（{message}）',
     downloadFailed: '下载失败，请重试',
     videoTutorial: '视频教程',
-    memoryUsage: '内存 {pct}%',
-    memoryTooltip:
-      'RSS: {rss} MB / {limit} MB\n堆已分配: {heapAlloc} MB\n堆驻留: {heapRes} MB\n任务预算: {budgetUsed} MB / {budgetLimit} MB\nColorDB 池: {colordbPool} MB\n分配器: {allocator}',
   },
 
   taskErrors: {

--- a/web/frontend/src/services/recipeEditorService.test.ts
+++ b/web/frontend/src/services/recipeEditorService.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { waitForRecipeGeneration } from './recipeEditorService'
+import type { TaskStatus } from '../types'
+
+function makeTaskStatus(overrides: Partial<TaskStatus> & Pick<TaskStatus, 'status'>): TaskStatus {
+  const { status, ...rest } = overrides
+  return {
+    id: 'task-1',
+    status,
+    stage: 'building_model',
+    progress: 0,
+    created_at_ms: 0,
+    error: null,
+    result: null,
+    ...rest,
+  }
+}
+
+describe('waitForRecipeGeneration', () => {
+  it('在 generation 成功后返回最新任务状态', async () => {
+    const fetchStatus = vi
+      .fn<(_: string) => Promise<TaskStatus>>()
+      .mockResolvedValueOnce(
+        makeTaskStatus({
+          status: 'completed',
+          generation: { status: 'running', error: null },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeTaskStatus({
+          status: 'completed',
+          generation: { status: 'succeeded', error: null },
+          result: {
+            input_width: 10,
+            input_height: 10,
+            resolved_pixel_mm: 0.1,
+            physical_width_mm: 1,
+            physical_height_mm: 1,
+            stats: {
+              clusters_total: 1,
+              db_only: 1,
+              model_fallback: 0,
+              model_queries: 0,
+              avg_db_de: 0,
+              avg_model_de: 0,
+            },
+            has_3mf: true,
+            has_preview: true,
+            has_source_mask: true,
+          },
+        }),
+      )
+
+    const status = await waitForRecipeGeneration('task-1', {
+      pollIntervalMs: 0,
+      maxAttempts: 5,
+      sleep: async () => {},
+      fetchStatus,
+    })
+
+    expect(fetchStatus).toHaveBeenCalledTimes(2)
+    expect(status.generation?.status).toBe('succeeded')
+    expect(status.result?.has_3mf).toBe(true)
+  })
+
+  it('在 generation 失败时抛出 generation.error', async () => {
+    const fetchStatus = vi.fn<(_: string) => Promise<TaskStatus>>().mockResolvedValue(
+      makeTaskStatus({
+        status: 'completed',
+        generation: { status: 'failed', error: 'model export failed' },
+      }),
+    )
+
+    await expect(
+      waitForRecipeGeneration('task-1', {
+        pollIntervalMs: 0,
+        maxAttempts: 1,
+        sleep: async () => {},
+        fetchStatus,
+        failedMessage: 'fallback failed',
+      }),
+    ).rejects.toThrow('model export failed')
+  })
+
+  it('在顶层任务失败时抛出顶层错误', async () => {
+    const fetchStatus = vi.fn<(_: string) => Promise<TaskStatus>>().mockResolvedValue(
+      makeTaskStatus({
+        status: 'failed',
+        error: 'task crashed',
+        generation: { status: 'running', error: null },
+      }),
+    )
+
+    await expect(
+      waitForRecipeGeneration('task-1', {
+        pollIntervalMs: 0,
+        maxAttempts: 1,
+        sleep: async () => {},
+        fetchStatus,
+        failedMessage: 'fallback failed',
+      }),
+    ).rejects.toThrow('task crashed')
+  })
+})

--- a/web/frontend/src/services/recipeEditorService.ts
+++ b/web/frontend/src/services/recipeEditorService.ts
@@ -1,0 +1,72 @@
+import {
+  fetchRecipeAlternatives as fetchRecipeAlternativesApi,
+  fetchRecipeEditorSummary as fetchRecipeEditorSummaryApi,
+  predictRecipeColor as predictRecipeColorApi,
+  replaceRecipe as replaceRecipeApi,
+  submitGenerateModel as submitGenerateModelApi,
+} from '../api/recipeEditor'
+import { fetchTaskStatus, getPreviewPath } from '../api/tasks'
+import { fetchBlobWithSession } from '../runtime/protectedRequest'
+import type { LabColor, RecipeCandidate, RecipeEditorSummary, TaskStatus } from '../types'
+
+const DEFAULT_GENERATION_POLL_INTERVAL_MS = 1000
+const DEFAULT_GENERATION_MAX_ATTEMPTS = 300
+
+type SleepFn = (ms: number) => Promise<void>
+type FetchStatusFn = (taskId: string) => Promise<TaskStatus>
+
+export type WaitForRecipeGenerationOptions = {
+  pollIntervalMs?: number
+  maxAttempts?: number
+  failedMessage?: string
+  timeoutMessage?: string
+  sleep?: SleepFn
+  fetchStatus?: FetchStatusFn
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export const fetchRecipeEditorSummary = fetchRecipeEditorSummaryApi
+export const fetchRecipeAlternatives = fetchRecipeAlternativesApi
+export const replaceRecipe = replaceRecipeApi
+export const submitGenerateModel = submitGenerateModelApi
+export const predictRecipeColor = predictRecipeColorApi
+
+export async function fetchRecipeTaskStatus(taskId: string): Promise<TaskStatus> {
+  return fetchTaskStatus(taskId)
+}
+
+export async function fetchRecipeEditorPreview(taskId: string): Promise<Blob> {
+  return fetchBlobWithSession(getPreviewPath(taskId))
+}
+
+export async function waitForRecipeGeneration(
+  taskId: string,
+  options: WaitForRecipeGenerationOptions = {},
+): Promise<TaskStatus> {
+  const sleep = options.sleep ?? defaultSleep
+  const fetchStatus = options.fetchStatus ?? fetchRecipeTaskStatus
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_GENERATION_POLL_INTERVAL_MS
+  const maxAttempts = options.maxAttempts ?? DEFAULT_GENERATION_MAX_ATTEMPTS
+  const failedMessage = options.failedMessage ?? 'Generation failed'
+  const timeoutMessage = options.timeoutMessage ?? 'Generation timed out'
+
+  for (let i = 0; i < maxAttempts; i++) {
+    await sleep(pollIntervalMs)
+    const status = await fetchStatus(taskId)
+    const generationStatus = status.generation?.status ?? 'idle'
+    if (generationStatus === 'succeeded') return status
+    if (generationStatus === 'failed') {
+      throw new Error(status.generation?.error ?? failedMessage)
+    }
+    if (status.status === 'failed') {
+      throw new Error(status.error ?? failedMessage)
+    }
+  }
+
+  throw new Error(timeoutMessage)
+}
+
+export type { LabColor, RecipeCandidate, RecipeEditorSummary }

--- a/web/frontend/src/stores/app.test.ts
+++ b/web/frontend/src/stores/app.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useAppStore } from './app'
+
+vi.mock('../api/health', () => ({
+  fetchHealth: vi.fn(),
+}))
+
+import { fetchHealth } from '../api/health'
+
+describe('app store health state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('health 请求成功时应视为在线并更新统计', async () => {
+    vi.mocked(fetchHealth).mockResolvedValueOnce({
+      status: 'degraded',
+      version: '1.2.3',
+      active_tasks: 2,
+      total_tasks: 5,
+      memory: {
+        rss_bytes: 1,
+        heap_allocated_bytes: 2,
+        heap_resident_bytes: 3,
+        artifact_budget_bytes: 4,
+        artifact_budget_limit_bytes: 5,
+        colordb_pool_bytes: 6,
+        memory_limit_bytes: 7,
+        allocator: 'jemalloc',
+      },
+    })
+
+    const store = useAppStore()
+    await store.checkHealth()
+
+    expect(store.serverOnline).toBe(true)
+    expect(store.serverVersion).toBe('1.2.3')
+    expect(store.activeTasks).toBe(2)
+    expect(store.totalTasks).toBe(5)
+    expect(store.serverMemory?.allocator).toBe('jemalloc')
+  })
+
+  it('health 请求失败时应清空在线状态和旧统计', async () => {
+    const store = useAppStore()
+    store.serverOnline = true
+    store.serverVersion = '1.2.3'
+    store.activeTasks = 3
+    store.totalTasks = 9
+    store.serverMemory = {
+      rss_bytes: 1,
+      heap_allocated_bytes: 2,
+      heap_resident_bytes: 3,
+      artifact_budget_bytes: 4,
+      artifact_budget_limit_bytes: 5,
+      colordb_pool_bytes: 6,
+      memory_limit_bytes: 7,
+      allocator: 'glibc',
+    }
+
+    vi.mocked(fetchHealth).mockRejectedValueOnce(new Error('network error'))
+
+    await store.checkHealth()
+
+    expect(store.serverOnline).toBe(false)
+    expect(store.serverVersion).toBe('')
+    expect(store.activeTasks).toBe(0)
+    expect(store.totalTasks).toBe(0)
+    expect(store.serverMemory).toBeNull()
+  })
+})

--- a/web/frontend/src/stores/app.ts
+++ b/web/frontend/src/stores/app.ts
@@ -6,7 +6,13 @@ import { detectSystemDarkMode } from '../runtime/theme'
 import type { WritableComputedRef } from 'vue'
 import i18n from '../locales'
 import { LOCALE_STORAGE_KEY, type SupportedLocale } from '../locales'
-import type { ConvertAnyParams, ImageDimensions, InputType, TaskStatus } from '../types'
+import type {
+  ConvertAnyParams,
+  HealthMemory,
+  ImageDimensions,
+  InputType,
+  TaskStatus,
+} from '../types'
 
 export const THEME_STORAGE_KEY = 'chromaprint3d-theme'
 
@@ -23,6 +29,7 @@ export const useAppStore = defineStore('app', () => {
   const serverVersion = ref('')
   const activeTasks = ref(0)
   const totalTasks = ref(0)
+  const serverMemory = ref<HealthMemory | null>(null)
 
   const isDark = ref(false)
   const recipeEditorTaskId = ref<string | null>(null)
@@ -77,12 +84,17 @@ export const useAppStore = defineStore('app', () => {
   async function checkHealth() {
     try {
       const h = await fetchHealth()
-      serverOnline.value = h.status === 'ok'
+      serverOnline.value = true
       serverVersion.value = h.version ?? ''
       activeTasks.value = h.active_tasks ?? 0
       totalTasks.value = h.total_tasks ?? 0
+      serverMemory.value = h.memory ?? null
     } catch {
       serverOnline.value = false
+      serverVersion.value = ''
+      activeTasks.value = 0
+      totalTasks.value = 0
+      serverMemory.value = null
     }
   }
 
@@ -129,6 +141,7 @@ export const useAppStore = defineStore('app', () => {
     serverVersion,
     activeTasks,
     totalTasks,
+    serverMemory,
     isDark,
     recipeEditorTaskId,
     setSelectedFile,

--- a/web/frontend/src/types.ts
+++ b/web/frontend/src/types.ts
@@ -134,6 +134,13 @@ export type ConvertStage =
   | 'exporting'
   | 'unknown'
 
+export type GenerationStatusValue = 'idle' | 'running' | 'succeeded' | 'failed'
+
+export interface GenerationState {
+  status: GenerationStatusValue
+  error: string | null
+}
+
 export interface TaskStatus {
   id: string
   status: TaskStatusValue
@@ -143,7 +150,7 @@ export interface TaskStatus {
   error: string | null
   result: TaskResult | null
   match_only?: boolean
-  generate_error?: string
+  generation?: GenerationState
   warnings?: string[]
 }
 
@@ -211,11 +218,23 @@ export interface Generate8ColorBoardRequest {
 
 // ---- Health response ----
 
+export interface HealthMemory {
+  rss_bytes: number
+  heap_allocated_bytes: number
+  heap_resident_bytes: number
+  artifact_budget_bytes: number
+  artifact_budget_limit_bytes: number
+  colordb_pool_bytes: number
+  memory_limit_bytes: number
+  allocator: string
+}
+
 export interface HealthResponse {
   status: string
   version: string
   active_tasks: number
   total_tasks: number
+  memory?: HealthMemory
 }
 
 // ---- Matting ----


### PR DESCRIPTION
## Summary

- **方向一：分配器集成** — 新增 `memory_utils.h/.cpp` 跨平台内存工具层，支持 jemalloc 可选集成（CMake `CHROMAPRINT3D_USE_JEMALLOC`）；`ReleaseFreedMemory` 带 RAII scope guard 的 lock-free 节流机制，集成到 `WorkerLoop` 每个任务完成后自动归还碎片页
- **方向二：智能指针迁移** — `ColorDBCache`、`SessionStore`、`ModelPackageRegistry` 全部改为 `shared_ptr<const T>` 持有；`pipeline.h` 中 `ConvertRasterRequest`/`ConvertVectorRequest` 的 `preloaded_dbs` 从裸指针改为 `shared_ptr`，删除冗余的 `session_owned_dbs`；`MatchRasterResult::dbs` / `MatchVectorResult::dbs` 从值类型改为 `shared_ptr`（消除 ColorDB 深拷贝含 KD 树重建）；新增 `MatchFromRasterPtrs` / `MatchVectorPtrs` 指针重载避免 span 要求连续内存的约束
- **方向三：内存监控** — `/api/v1/health` 新增 `memory` 对象（RSS、heap stats、artifact budget、ColorDB pool、memory limit、allocator）；前端 `useLeaderLease` BroadcastChannel leader election + 每 5 分钟上报 `memory-status` 到 Umami；任务完成日志附带 RSS 快照
- **附加优化** — `GenerateRasterModel` / `GenerateVectorModel` 分阶段释放 recipe_map 和 voxel_grids；`ModelPackage::Load` 解析后立即释放原始 bytes；`BoardRuntimeCache` geometry 缓存加 TTL + LRU 淘汰；`EstimateBytes()` 修正为只计 shared_ptr 指针开销
- **配方编辑器改进** — 新增 `GenerationState` 状态机防止生成与编辑并发冲突；`EnforceResultBudgetLocked` 支持 `protected_task_id` 和 `last_accessed_at` 淘汰策略；提取 `recipeEditorService.ts` 封装轮询逻辑
- **CI 稳定性补充** — `test_memory_utils.cpp` 的并发回归用例改为 `std::latch` 同步起跑并使用明确节流窗口，避免 `min_interval_ms=0` 在慢调度环境下产生假阳性失败

## Test plan

- [x] core 单元测试全部通过（140 tests，含 6 个 MemoryUtils 测试）
- [x] `MemoryUtils.ReleaseFreedMemoryConcurrentCallsRespectThrottle` 连跑 10 次通过（`ctest --repeat until-fail:10`）
- [x] backend 单元测试通过（含新增 task_runtime 测试）
- [x] 前端 lint + typecheck + build + tests 全部通过（含 useLeaderLease、recipeEditorService、app store 新增测试）
- [ ] Docker 部署后通过 `/api/v1/health` 验证 memory 字段返回
- [ ] 配方编辑器中替换配方 → 生成模型流程端到端验证
- [ ] 对比迁移前后同批转换任务的峰值 RSS