### PR TITLE
fix(analytics): 优化 Umami 统计事件——去噪、去重、丰富业务指标

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -883,7 +883,33 @@ VITE_UMAMI_WEBSITE_ID=<预览版 website-id>
 
 `website-id` 在 Umami 管理后台添加网站后获取。
 
-### 8.4 多标签 `memory-status` 去重
+### 8.4 自定义事件清单
+
+前端通过 `window.umami.track()` 上报以下自定义事件，用于用户旅程分析和性能监控。
+
+**用户旅程漏斗**：`image-select` → `convert-start` → `convert-complete` → `download-3mf`
+
+**配方编辑漏斗**：`match-preview-start` → `match-preview-complete` / `recipe-editor-open` → `recipe-replace` → `generate-model-complete` → `download-3mf`
+
+| 事件名 | 触发点 | 关键字段 |
+|--------|--------|----------|
+| image-select | 选择文件 | type |
+| convert-start | 点击转换 | inputType, color_layers, model_enable |
+| convert-complete | 转换成功 | inputType, has3mf, elapsed_s, width, height, avg_de |
+| convert-fail | 转换失败 | inputType, error |
+| match-preview-start | 点击配方预览 | inputType, color_layers, model_enable |
+| match-preview-complete | 预览完成 | inputType, elapsed_s, width, height, avg_de |
+| match-preview-fail | 预览失败 | inputType, error |
+| recipe-editor-open | 进入编辑器 | （无） |
+| recipe-replace | 替换配方 | regionCount |
+| generate-model-complete | 模型生成完成 | （无） |
+| generate-model-fail | 模型生成失败 | error |
+| download-3mf | 下载成功 | filename |
+| memory-status | 每 5 分钟 / leader | rss_mb, heap_mb, artifact_pct, usage_pct, allocator |
+
+此外，前端会对主 Tab 和子 Tab 切换发送**虚拟 pageview**（如 `/convert`、`/preprocess/vectorize`），使 Umami 后台能区分各功能页面的访问量。
+
+### 8.5 多标签 `memory-status` 去重
 
 前端会额外上报一个自定义事件 `memory-status`，用于观测服务端内存占用趋势。部署时建议理解它的去重策略：
 
@@ -892,15 +918,7 @@ VITE_UMAMI_WEBSITE_ID=<预览版 website-id>
 - leader tab 关闭或失联后，其它标签页会在 lease 超时后自动接管，无需人工刷新。
 - 当 `/api/v1/health` 请求失败时，前端会清空缓存的 health 状态并停止该事件上报，避免继续发送过期内存值。
 
-事件字段：
-
-- `rss_mb`
-- `heap_mb`
-- `artifact_pct`
-- `usage_pct`
-- `allocator`
-
-### 8.5 备份
+### 8.6 备份
 
 ```bash
 # 手动备份

--- a/web/backend/src/application/json_serialization.cpp
+++ b/web/backend/src/application/json_serialization.cpp
@@ -139,6 +139,9 @@ json TaskToJson(const TaskSnapshot& task) {
         };
         if (!cp->result.warnings.empty()) { j["warnings"] = cp->result.warnings; }
         if (task.status == RuntimeTaskStatus::Completed) {
+            j["elapsed_ms"] = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  task.completed_at - task.created_at)
+                                  .count();
             j["result"] = {
                 {"input_width", cp->result.input_width},
                 {"input_height", cp->result.input_height},

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -133,20 +133,32 @@ function trackVirtualPageview(url: string) {
   window.umami?.track((props: Record<string, unknown>) => ({ ...props, url }))
 }
 
-watch(activeTab, (tab) => {
-  const url = TAB_VIRTUAL_URLS[tab]
-  if (url) trackVirtualPageview(url)
-})
+watch(
+  activeTab,
+  (tab) => {
+    const url = TAB_VIRTUAL_URLS[tab]
+    if (url) trackVirtualPageview(url)
+  },
+  { immediate: true },
+)
 
-watch(activePreprocessTab, (sub) => {
-  const url = SUB_TAB_VIRTUAL_URLS['preprocess']?.[sub]
-  if (url) trackVirtualPageview(url)
-})
+watch(
+  activePreprocessTab,
+  (sub) => {
+    const url = SUB_TAB_VIRTUAL_URLS['preprocess']?.[sub]
+    if (url) trackVirtualPageview(url)
+  },
+  { immediate: true },
+)
 
-watch(activeCalibrationTab, (sub) => {
-  const url = SUB_TAB_VIRTUAL_URLS['calibration-tools']?.[sub]
-  if (url) trackVirtualPageview(url)
-})
+watch(
+  activeCalibrationTab,
+  (sub) => {
+    const url = SUB_TAB_VIRTUAL_URLS['calibration-tools']?.[sub]
+    if (url) trackVirtualPageview(url)
+  },
+  { immediate: true },
+)
 
 useAppLifecycle()
 

--- a/web/frontend/src/api/base.test.ts
+++ b/web/frontend/src/api/base.test.ts
@@ -1,82 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { isAutomatedRequest, normalizeEndpoint, request } from './base'
+import { request } from './base'
 import { setSessionToken } from '../runtime/session'
 
-describe('normalizeEndpoint', () => {
-  it('strips the /api/v1/ prefix', () => {
-    expect(normalizeEndpoint('/api/v1/databases')).toBe('databases')
-  })
-
-  it('replaces UUIDs with :id', () => {
-    expect(normalizeEndpoint('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(
-      'tasks/:id',
-    )
-  })
-
-  it('replaces artifact keys with :key', () => {
-    expect(
-      normalizeEndpoint('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890/artifacts/layer-top'),
-    ).toBe('tasks/:id/artifacts/:key')
-  })
-
-  it('handles recipe-editor paths', () => {
-    expect(
-      normalizeEndpoint('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890/recipe-editor/summary'),
-    ).toBe('tasks/:id/recipe-editor/summary')
-  })
-
-  it('leaves paths without dynamic segments unchanged', () => {
-    expect(normalizeEndpoint('/api/v1/convert/raster')).toBe('convert/raster')
-    expect(normalizeEndpoint('/api/v1/convert/vector/analyze-width')).toBe(
-      'convert/vector/analyze-width',
-    )
-  })
-
-  it('handles multiple UUIDs in one path', () => {
-    expect(
-      normalizeEndpoint(
-        '/api/v1/tasks/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/artifacts/ffffffff-1111-2222-3333-444444444444',
-      ),
-    ).toBe('tasks/:id/artifacts/:key')
-  })
-})
-
-describe('isAutomatedRequest', () => {
-  it('excludes task status polling (GET /api/v1/tasks/:id)', () => {
-    expect(isAutomatedRequest('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'GET')).toBe(
-      true,
-    )
-  })
-
-  it('excludes health check', () => {
-    expect(isAutomatedRequest('/api/v1/health', 'GET')).toBe(true)
-  })
-
-  it('allows task list (GET /api/v1/tasks)', () => {
-    expect(isAutomatedRequest('/api/v1/tasks', 'GET')).toBe(false)
-  })
-
-  it('allows task deletion (DELETE /api/v1/tasks/:id)', () => {
-    expect(isAutomatedRequest('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'DELETE')).toBe(
-      false,
-    )
-  })
-
-  it('allows POST conversion', () => {
-    expect(isAutomatedRequest('/api/v1/convert/raster', 'POST')).toBe(false)
-  })
-
-  it('allows recipe-editor sub-paths', () => {
-    expect(
-      isAutomatedRequest(
-        '/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890/recipe-editor/summary',
-        'GET',
-      ),
-    ).toBe(false)
-  })
-})
-
-describe('request() tracking', () => {
+describe('request()', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     setSessionToken(null)
@@ -93,60 +19,21 @@ describe('request() tracking', () => {
     return fetchMock
   }
 
-  it('calls umami.track on successful non-automated request', async () => {
+  it('returns data on success', async () => {
     mockFetch({ ok: true, data: { databases: [] } })
-    const trackMock = vi.fn()
-    vi.stubGlobal('umami', { track: trackMock })
-    window.umami = { track: trackMock }
-
-    await request('/api/v1/databases')
-
-    expect(trackMock).toHaveBeenCalledTimes(1)
-    const [event, data] = trackMock.mock.calls[0] as [string, Record<string, unknown>]
-    expect(event).toBe('api-call')
-    expect(data.endpoint).toBe('databases')
-    expect(data.method).toBe('GET')
-    expect(data.success).toBe(true)
-    expect(typeof data.duration).toBe('number')
+    const result = await request('/api/v1/databases')
+    expect(result).toEqual({ databases: [] })
   })
 
-  it('does not call umami.track for automated requests (polling)', async () => {
-    mockFetch({ ok: true, data: { id: 't1', status: 'completed' } })
-    const trackMock = vi.fn()
-    window.umami = { track: trackMock }
-
-    await request('/api/v1/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890')
-
-    expect(trackMock).not.toHaveBeenCalled()
-  })
-
-  it('does not call umami.track for health check', async () => {
-    mockFetch({ ok: true, data: { status: 'ok' } })
-    const trackMock = vi.fn()
-    window.umami = { track: trackMock }
-
-    await request('/api/v1/health')
-
-    expect(trackMock).not.toHaveBeenCalled()
-  })
-
-  it('reports success=false when request fails', async () => {
+  it('throws on HTTP error', async () => {
     mockFetch({ ok: false, error: 'bad request' }, 400)
-    const trackMock = vi.fn()
-    window.umami = { track: trackMock }
-
-    await expect(request('/api/v1/convert/raster', { method: 'POST' })).rejects.toThrow()
-
-    expect(trackMock).toHaveBeenCalledTimes(1)
-    const [, data] = trackMock.mock.calls[0] as [string, Record<string, unknown>]
-    expect(data.success).toBe(false)
-    expect(data.method).toBe('POST')
+    await expect(request('/api/v1/convert/raster', { method: 'POST' })).rejects.toThrow(
+      'bad request',
+    )
   })
 
-  it('does not throw when window.umami is undefined', async () => {
-    mockFetch({ ok: true, data: [] })
-    window.umami = undefined
-
-    await expect(request('/api/v1/databases')).resolves.toEqual([])
+  it('throws on envelope error', async () => {
+    mockFetch({ ok: false, error: { message: 'not found' } })
+    await expect(request('/api/v1/tasks/some-id')).rejects.toThrow('not found')
   })
 })

--- a/web/frontend/src/api/base.ts
+++ b/web/frontend/src/api/base.ts
@@ -19,54 +19,21 @@ function parseErrorMessage(payload: ApiErrorPayload | undefined, fallback: strin
   return payload.message ?? payload.code ?? fallback
 }
 
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
-
-export function normalizeEndpoint(url: string): string {
-  return url
-    .replace(/^\/api\/v1\//, '')
-    .replace(UUID_RE, ':id')
-    .replace(/\/artifacts\/[^/?]+/, '/artifacts/:key')
-}
-
-export function isAutomatedRequest(url: string, method: string): boolean {
-  if (method === 'GET' && /^\/api\/v1\/tasks\/[^/]+$/.test(url)) return true
-  if (url === '/api/v1/health') return true
-  return false
-}
-
 export async function request<T>(url: string, init?: RequestInit): Promise<T> {
-  const method = init?.method?.toUpperCase() ?? 'GET'
-  const shouldTrack = !isAutomatedRequest(url, method)
-  const start = shouldTrack ? performance.now() : 0
+  const res = await fetchWithSession(url, init)
 
-  let success = true
+  let envelope: ApiEnvelope<T> | null = null
   try {
-    const res = await fetchWithSession(url, init)
-
-    let envelope: ApiEnvelope<T> | null = null
-    try {
-      envelope = (await res.json()) as ApiEnvelope<T>
-    } catch {
-      // ignore parse errors, fallback to HTTP status
-    }
-
-    if (!res.ok) {
-      success = false
-      throw new Error(parseErrorMessage(envelope?.error, `HTTP ${res.status}`))
-    }
-    if (!envelope?.ok) {
-      success = false
-      throw new Error(parseErrorMessage(envelope?.error, 'Request failed'))
-    }
-    return envelope.data as T
-  } catch (err) {
-    success = false
-    throw err
-  } finally {
-    if (shouldTrack) {
-      const duration = Math.round(performance.now() - start)
-      const endpoint = normalizeEndpoint(url)
-      window.umami?.track('api-call', { endpoint, method, success, duration })
-    }
+    envelope = (await res.json()) as ApiEnvelope<T>
+  } catch {
+    // ignore parse errors, fallback to HTTP status
   }
+
+  if (!res.ok) {
+    throw new Error(parseErrorMessage(envelope?.error, `HTTP ${res.status}`))
+  }
+  if (!envelope?.ok) {
+    throw new Error(parseErrorMessage(envelope?.error, 'Request failed'))
+  }
+  return envelope.data as T
 }

--- a/web/frontend/src/components/ConvertPanel.vue
+++ b/web/frontend/src/components/ConvertPanel.vue
@@ -62,11 +62,20 @@ const {
   onCompleted(s) {
     appStore.setCompletedTask(s)
     window.umami?.track('convert-complete', {
+      inputType: inputType.value,
       has3mf: Boolean(s.result?.has_3mf),
+      elapsed_s: s.elapsed_ms != null ? Math.round(s.elapsed_ms / 1000) : -1,
+      width: s.result?.input_width ?? 0,
+      height: s.result?.input_height ?? 0,
+      avg_de: s.result?.stats?.avg_db_de ?? -1,
     })
   },
-  onFailed() {
+  onFailed(s) {
     appStore.markTaskFailed()
+    window.umami?.track('convert-fail', {
+      inputType: inputType.value,
+      error: (s.error ?? 'unknown').slice(0, 120),
+    })
   },
 })
 
@@ -140,7 +149,11 @@ const download3mfFilename = computed(() => {
 
 async function handleConvert() {
   if (!selectedFile.value) return
-  window.umami?.track('convert-start', { inputType: inputType.value })
+  window.umami?.track('convert-start', {
+    inputType: inputType.value,
+    color_layers: params.value.color_layers ?? 0,
+    model_enable: Boolean(params.value.model_enable),
+  })
   appStore.markTaskStarted()
   await submitTask()
 }
@@ -160,10 +173,21 @@ const {
   onCompleted(s) {
     appStore.setCompletedTask(s)
     appStore.setRecipeEditorTaskId(s.id)
+    window.umami?.track('match-preview-complete', {
+      inputType: inputType.value,
+      elapsed_s: s.elapsed_ms != null ? Math.round(s.elapsed_ms / 1000) : -1,
+      width: s.result?.input_width ?? 0,
+      height: s.result?.input_height ?? 0,
+      avg_de: s.result?.stats?.avg_db_de ?? -1,
+    })
     window.umami?.track('recipe-editor-open')
   },
-  onFailed() {
+  onFailed(s) {
     appStore.markTaskFailed()
+    window.umami?.track('match-preview-fail', {
+      inputType: inputType.value,
+      error: (s.error ?? 'unknown').slice(0, 120),
+    })
   },
 })
 
@@ -192,6 +216,11 @@ const canMatchPreview = computed(() => {
 
 async function handleMatchPreview() {
   if (!selectedFile.value) return
+  window.umami?.track('match-preview-start', {
+    inputType: inputType.value,
+    color_layers: params.value.color_layers ?? 0,
+    model_enable: Boolean(params.value.model_enable),
+  })
   appStore.markTaskStarted()
   await submitMatch()
 }
@@ -199,9 +228,10 @@ async function handleMatchPreview() {
 async function handleDownload3MF() {
   if (!canDownload3mf.value || isDownloading3mf.value) return
   isDownloading3mf.value = true
-  window.umami?.track('download-3mf')
+  const filename = download3mfFilename.value
   try {
-    await downloadByUrl(getResultPath(completedTaskId.value), download3mfFilename.value)
+    await downloadByUrl(getResultPath(completedTaskId.value), filename)
+    window.umami?.track('download-3mf', { filename })
   } catch {
     // error is already handled by runtime abstraction caller when needed
   } finally {

--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -332,6 +332,7 @@ async function handleCandidateSelect(candidate: RecipeCandidate) {
     }
 
     if (generateDone.value) editedAfterGenerate.value = true
+    window.umami?.track('recipe-replace', { regionCount: regionIds.length })
     message.success(t('recipeEditor.replaceSuccess'))
   } catch (e) {
     message.error(e instanceof Error ? e.message : String(e))
@@ -451,8 +452,11 @@ async function handleGenerate() {
     })
     appStore.setCompletedTask(status)
     generateDone.value = true
+    window.umami?.track('generate-model-complete')
   } catch (e) {
-    generateError.value = e instanceof Error ? e.message : String(e)
+    const msg = e instanceof Error ? e.message : String(e)
+    generateError.value = msg
+    window.umami?.track('generate-model-fail', { error: msg.slice(0, 120) })
   } finally {
     generating.value = false
   }

--- a/web/frontend/src/runtime/download.ts
+++ b/web/frontend/src/runtime/download.ts
@@ -30,7 +30,6 @@ export async function downloadFromUrl(url: string, filename: string): Promise<vo
     } else {
       clickDownloadLink(blobUrl, filename)
     }
-    window.umami?.track('file-download', { filename })
   } finally {
     revokeBlobUrl(blobUrl)
   }

--- a/web/frontend/src/types.ts
+++ b/web/frontend/src/types.ts
@@ -147,6 +147,7 @@ export interface TaskStatus {
   stage: ConvertStage
   progress: number
   created_at_ms: number
+  elapsed_ms?: number
   error: string | null
   result: TaskResult | null
   match_only?: boolean


### PR DESCRIPTION
## Summary

- 移除 `api-call` 事件（每次 API 请求都触发，噪音淹没业务事件）
- 合并 `download-3mf` + `file-download` 重复为单一 `download-3mf`（下载成功后触发，附 `filename`）
- 后端 convert 任务完成响应新增 `elapsed_ms` 字段，前端 `TaskStatus` 类型同步
- 丰富 `convert-start`（`color_layers`, `model_enable`）和 `convert-complete`（`inputType`, `elapsed_s`, `width`, `height`, `avg_de`）
- 新增 `convert-fail`、`match-preview-start/complete/fail` 事件覆盖完整转换与配方预览流程
- 新增配方编辑器 `recipe-replace`、`generate-model-complete/fail` 事件
- 修复首次加载页面时虚拟 pageview 不上报（`watch` 缺 `immediate: true`）
- `docs/deployment.md` 新增 §8.4 完整事件清单与用户旅程漏斗说明

## Test plan

- [x] 后端编译通过（json_serialization.cpp 改动）
- [x] 后端单元测试通过（4 tests）
- [x] 前端 TypeCheck 通过
- [x] 前端 lint 通过
- [x] 前端单元测试通过
- [ ] 部署后在 Umami 后台确认事件清单与漏斗数据正确