### PR TITLE
fix: 预览图自适应分辨率——保证基础精度并避免过高开销

### DIFF
--- a/core/include/chromaprint3d/encoding.h
+++ b/core/include/chromaprint3d/encoding.h
@@ -28,9 +28,18 @@ std::vector<uint8_t> EncodeJpeg(const cv::Mat& image, int quality = 95);
 /// \return True if successful, false otherwise
 bool SaveImage(const cv::Mat& image, const std::string& path);
 
-/// Downsample an image if either dimension exceeds \p max_dim.
-/// Uses area interpolation and preserves aspect ratio.
-/// Returns the original image unmodified when no downsampling is needed.
-cv::Mat DownsampleForPreview(const cv::Mat& image, int max_dim = 2048);
+constexpr int kPreviewMinDim = 512;
+constexpr int kPreviewMaxDim = 2048;
+
+/// Resize an image so its longest side falls within [\p min_dim, \p max_dim].
+/// Downsamples with INTER_AREA; upsamples with INTER_NEAREST to preserve
+/// discrete color boundaries in recipe maps.
+/// Returns the original image unmodified when already in range.
+cv::Mat ResizeForPreview(const cv::Mat& image, int min_dim = kPreviewMinDim,
+                         int max_dim = kPreviewMaxDim);
+
+/// Compute an adaptive pixels-per-mm value so the longest side of a
+/// \p width_mm x \p height_mm model hits exactly \p max_dim pixels.
+float ComputePreviewPixelsPerMm(float width_mm, float height_mm, int max_dim = kPreviewMaxDim);
 
 } // namespace ChromaPrint3D

--- a/core/src/encoding/encoding.cpp
+++ b/core/src/encoding/encoding.cpp
@@ -43,17 +43,36 @@ bool SaveImage(const cv::Mat& image, const std::string& path) {
     return cv::imwrite(path, image);
 }
 
-cv::Mat DownsampleForPreview(const cv::Mat& image, int max_dim) {
+cv::Mat ResizeForPreview(const cv::Mat& image, int min_dim, int max_dim) {
     if (image.empty() || max_dim <= 0) return image;
     const int max_side = std::max(image.cols, image.rows);
-    if (max_side <= max_dim) return image;
-    const double scale = static_cast<double>(max_dim) / max_side;
-    const int new_w    = std::max(1, static_cast<int>(std::round(image.cols * scale)));
-    const int new_h    = std::max(1, static_cast<int>(std::round(image.rows * scale)));
-    cv::Mat dst;
-    cv::resize(image, dst, cv::Size(new_w, new_h), 0, 0, cv::INTER_AREA);
-    spdlog::debug("DownsampleForPreview: {}x{} -> {}x{}", image.cols, image.rows, new_w, new_h);
-    return dst;
+    if (max_side > max_dim) {
+        const double scale = static_cast<double>(max_dim) / max_side;
+        const int new_w    = std::max(1, static_cast<int>(std::round(image.cols * scale)));
+        const int new_h    = std::max(1, static_cast<int>(std::round(image.rows * scale)));
+        cv::Mat dst;
+        cv::resize(image, dst, cv::Size(new_w, new_h), 0, 0, cv::INTER_AREA);
+        spdlog::debug("ResizeForPreview: {}x{} -> {}x{} (downsample)", image.cols, image.rows,
+                      new_w, new_h);
+        return dst;
+    }
+    if (min_dim > 0 && max_side < min_dim) {
+        const double scale = static_cast<double>(min_dim) / max_side;
+        const int new_w    = std::max(1, static_cast<int>(std::round(image.cols * scale)));
+        const int new_h    = std::max(1, static_cast<int>(std::round(image.rows * scale)));
+        cv::Mat dst;
+        cv::resize(image, dst, cv::Size(new_w, new_h), 0, 0, cv::INTER_NEAREST);
+        spdlog::debug("ResizeForPreview: {}x{} -> {}x{} (upsample)", image.cols, image.rows, new_w,
+                      new_h);
+        return dst;
+    }
+    return image;
+}
+
+float ComputePreviewPixelsPerMm(float width_mm, float height_mm, int max_dim) {
+    const float long_side = std::max(width_mm, height_mm);
+    if (long_side <= 0.0f || max_dim <= 0) return 5.0f;
+    return static_cast<float>(max_dim) / long_side;
 }
 
 } // namespace ChromaPrint3D

--- a/core/src/pipeline/pipeline.cpp
+++ b/core/src/pipeline/pipeline.cpp
@@ -311,7 +311,7 @@ ConvertResult GenerateRasterModel(MatchRasterResult& mr, ProgressCallback progre
 
     // === Generate preview and source mask ===
     if (mr.generate_preview) {
-        cv::Mat preview_bgra = DownsampleForPreview(mr.recipe_map.ToBgraImage());
+        cv::Mat preview_bgra = ResizeForPreview(mr.recipe_map.ToBgraImage());
         if (!preview_bgra.empty()) { result.preview_png = EncodePng(preview_bgra); }
     }
     if (mr.generate_source_mask) {
@@ -341,7 +341,7 @@ ConvertResult GenerateRasterModel(MatchRasterResult& mr, ProgressCallback progre
 
         try {
             cv::Mat layer_bgra =
-                DownsampleForPreview(mr.recipe_map.ToLayerBgraImage(layer_idx, mr.profile.palette));
+                ResizeForPreview(mr.recipe_map.ToLayerBgraImage(layer_idx, mr.profile.palette));
             if (layer_bgra.empty()) {
                 throw InputError("Failed to render raster layer preview image");
             }

--- a/core/src/pipeline/vector_pipeline.cpp
+++ b/core/src/pipeline/vector_pipeline.cpp
@@ -7,6 +7,7 @@
 #include "chromaprint3d/slicer_preset.h"
 #include "chromaprint3d/color_db.h"
 #include "chromaprint3d/print_profile.h"
+#include "chromaprint3d/encoding.h"
 #include "chromaprint3d/error.h"
 #include "match/detail/match_utils.h"
 
@@ -47,8 +48,6 @@ ResolvedGeometryOptions ResolveGeometryOptions(const ConvertVectorRequest& reque
     out.double_sided = request.double_sided;
     return out;
 }
-
-constexpr float kLayerPreviewPixelsPerMm = 5.0f;
 
 } // namespace
 
@@ -286,19 +285,21 @@ ConvertResult GenerateVectorModel(MatchVectorResult& mr, ProgressCallback progre
     result.physical_width_mm  = vimg.width_mm;
     result.physical_height_mm = vimg.height_mm;
 
+    const float preview_ppm = ComputePreviewPixelsPerMm(vimg.width_mm, vimg.height_mm);
+
     if (mr.generate_preview) {
-        result.preview_png = RenderVectorPreviewPng(vimg, recipe_map, profile.palette);
+        result.preview_png = RenderVectorPreviewPng(vimg, recipe_map, profile.palette, preview_ppm);
     }
     if (mr.generate_source_mask) {
-        result.source_mask_png = RenderVectorSourceMaskPng(vimg, recipe_map);
+        result.source_mask_png = RenderVectorSourceMaskPng(vimg, recipe_map, preview_ppm);
     }
 
     result.layer_previews.layers      = recipe_map.color_layers;
     result.layer_previews.layer_order = recipe_map.layer_order;
     result.layer_previews.width =
-        std::max(1, static_cast<int>(std::ceil(vimg.width_mm * kLayerPreviewPixelsPerMm)));
+        std::max(1, static_cast<int>(std::ceil(vimg.width_mm * preview_ppm)));
     result.layer_previews.height =
-        std::max(1, static_cast<int>(std::ceil(vimg.height_mm * kLayerPreviewPixelsPerMm)));
+        std::max(1, static_cast<int>(std::ceil(vimg.height_mm * preview_ppm)));
     result.layer_previews.palette.reserve(profile.palette.size());
     for (std::size_t i = 0; i < profile.palette.size(); ++i) {
         const auto& channel = profile.palette[i];
@@ -306,7 +307,7 @@ ConvertResult GenerateVectorModel(MatchVectorResult& mr, ProgressCallback progre
             LayerPreviewChannel{static_cast<int>(i), channel.color, channel.material});
     }
     result.layer_previews.layer_pngs =
-        RenderVectorLayerPreviewPngs(vimg, recipe_map, profile.palette, kLayerPreviewPixelsPerMm);
+        RenderVectorLayerPreviewPngs(vimg, recipe_map, profile.palette, preview_ppm);
 
     PrintProfile export_profile = profile;
     export_profile.base_layers  = resolved_base_layers;

--- a/web/backend/src/infrastructure/task_runtime.cpp
+++ b/web/backend/src/infrastructure/task_runtime.cpp
@@ -364,7 +364,7 @@ SubmitResult TaskRuntime::SubmitConvertRasterMatchOnly(const std::string& owner,
             auto region_map = ChromaPrint3D::RasterRegionMap::Build(match_result.recipe_map);
 
             cv::Mat preview_bgra =
-                ChromaPrint3D::DownsampleForPreview(match_result.recipe_map.ToBgraImage());
+                ChromaPrint3D::ResizeForPreview(match_result.recipe_map.ToBgraImage());
             std::vector<uint8_t> preview_png;
             if (!preview_bgra.empty()) { preview_png = ChromaPrint3D::EncodePng(preview_bgra); }
 
@@ -433,17 +433,21 @@ SubmitResult TaskRuntime::SubmitConvertVectorMatchOnly(const std::string& owner,
                     std::to_string(kMaxUniqueRecipes));
             }
 
-            cv::Mat region_ids_mat  = ChromaPrint3D::RenderVectorRegionIds(match_result.proc_result,
-                                                                           match_result.recipe_map);
+            const float preview_ppm = ChromaPrint3D::ComputePreviewPixelsPerMm(
+                match_result.proc_result.width_mm, match_result.proc_result.height_mm);
+
+            cv::Mat region_ids_mat = ChromaPrint3D::RenderVectorRegionIds(
+                match_result.proc_result, match_result.recipe_map, preview_ppm);
             const std::size_t total = static_cast<std::size_t>(region_ids_mat.rows) *
                                       static_cast<std::size_t>(region_ids_mat.cols);
             std::vector<uint8_t> region_binary(total * sizeof(uint32_t));
             std::memcpy(region_binary.data(), region_ids_mat.data, region_binary.size());
 
             auto preview_png = ChromaPrint3D::RenderVectorPreviewPng(
-                match_result.proc_result, match_result.recipe_map, match_result.profile.palette);
+                match_result.proc_result, match_result.recipe_map, match_result.profile.palette,
+                preview_ppm);
             auto source_mask_png = ChromaPrint3D::RenderVectorSourceMaskPng(
-                match_result.proc_result, match_result.recipe_map);
+                match_result.proc_result, match_result.recipe_map, preview_ppm);
 
             const int img_w = region_ids_mat.cols;
             const int img_h = region_ids_mat.rows;
@@ -884,7 +888,7 @@ bool TaskRuntime::ReplaceRecipe(const std::string& owner, const std::string& id,
             info.from_model   = new_from_model;
         }
 
-        cv::Mat preview_bgra = ChromaPrint3D::DownsampleForPreview(mstate.recipe_map.ToBgraImage());
+        cv::Mat preview_bgra = ChromaPrint3D::ResizeForPreview(mstate.recipe_map.ToBgraImage());
         if (!preview_bgra.empty()) {
             cp->result.preview_png = ChromaPrint3D::EncodePng(preview_bgra);
         } else {
@@ -913,10 +917,12 @@ bool TaskRuntime::ReplaceRecipe(const std::string& owner, const std::string& id,
             return false;
         }
 
+        const float preview_ppm = ChromaPrint3D::ComputePreviewPixelsPerMm(
+            vstate.proc_result.width_mm, vstate.proc_result.height_mm);
         cp->result.preview_png = ChromaPrint3D::RenderVectorPreviewPng(
-            vstate.proc_result, vstate.recipe_map, vstate.profile.palette);
-        cp->result.source_mask_png =
-            ChromaPrint3D::RenderVectorSourceMaskPng(vstate.proc_result, vstate.recipe_map);
+            vstate.proc_result, vstate.recipe_map, vstate.profile.palette, preview_ppm);
+        cp->result.source_mask_png = ChromaPrint3D::RenderVectorSourceMaskPng(
+            vstate.proc_result, vstate.recipe_map, preview_ppm);
     }
 
     if (cp->match_only) {
@@ -1325,7 +1331,7 @@ std::optional<TaskArtifact> TaskRuntime::LoadArtifact(const std::string& owner,
             const ChromaPrint3D::RecipeMap* rmap = nullptr;
             if (cp->raster_match_state.has_value()) { rmap = &cp->raster_match_state->recipe_map; }
             if (rmap && !channels.empty()) {
-                cv::Mat layer_bgra = ChromaPrint3D::DownsampleForPreview(
+                cv::Mat layer_bgra = ChromaPrint3D::ResizeForPreview(
                     rmap->ToLayerBgraImage(static_cast<int>(idx), channels));
                 if (!layer_bgra.empty()) {
                     auto rendered = ChromaPrint3D::EncodePng(layer_bgra);


### PR DESCRIPTION
## Summary

- 光栅路径：`DownsampleForPreview` 重命名为 `ResizeForPreview`，新增 `min_dim=512` 下限，保证小尺寸 recipe map 的预览不低于 512px（INTER_NEAREST 上采样保持离散色块边界）
- 矢量路径：删除固定 `kLayerPreviewPixelsPerMm = 5.0f`，改为自适应 `ppm = max_dim / long_side_mm`，预览长边恒定 2048px；小模型分辨率大幅提升（30mm: 150px -> 2048px），大模型资源占用显著降低（800mm region map: 64MB -> 16MB）
- 新增共享函数 `ComputePreviewPixelsPerMm`，矢量路径各调用点（初始匹配、配方编辑、模型生成）均使用一致的自适应 ppm

## 变更文件

| 文件 | 变更 |
|---|---|
| `core/include/chromaprint3d/encoding.h` | 重命名函数 + 新增 `ComputePreviewPixelsPerMm` 声明 + 常量 `kPreviewMinDim`/`kPreviewMaxDim` |
| `core/src/encoding/encoding.cpp` | `ResizeForPreview` 实现（双向缩放）+ `ComputePreviewPixelsPerMm` 实现 |
| `core/src/pipeline/pipeline.cpp` | 光栅预览 2 处调用替换 |
| `core/src/pipeline/vector_pipeline.cpp` | 删除固定常量，使用自适应 ppm |
| `web/backend/src/infrastructure/task_runtime.cpp` | 光栅 3 处 + 矢量 2 处调用更新 |

## Test plan

- [x] `cmake --build . -j$(nproc)` 编译通过（306/306）
- [x] `chromaprint3d_tests` 全部通过（133 passed, 7 skipped）
- [x] `chromaprint3d_backend_tests` 全部通过（4 passed）
- [ ] 手动验证：小尺寸矢量模型（<50mm）预览清晰度提升
- [ ] 手动验证：大尺寸矢量模型（>500mm）预览加载速度改善
- [ ] 手动验证：小尺寸光栅模型（max_width<300）预览不再模糊