### PR TITLE
fix: 禁用光栅预览默认上采样，避免坐标映射偏移

### DIFF
--- a/core/include/chromaprint3d/encoding.h
+++ b/core/include/chromaprint3d/encoding.h
@@ -35,8 +35,12 @@ constexpr int kPreviewMaxDim = 2048;
 /// Downsamples with INTER_AREA; upsamples with INTER_NEAREST to preserve
 /// discrete color boundaries in recipe maps.
 /// Returns the original image unmodified when already in range.
-cv::Mat ResizeForPreview(const cv::Mat& image, int min_dim = kPreviewMinDim,
-                         int max_dim = kPreviewMaxDim);
+///
+/// \note Upsampling (min_dim > 0) must NOT be used when the output image must
+/// stay pixel-aligned with a coordinate map of fixed resolution (e.g. raster
+/// recipe editor where the region map matches the recipe map dimensions).
+/// The default min_dim is 0 (downscale only) for this reason.
+cv::Mat ResizeForPreview(const cv::Mat& image, int min_dim = 0, int max_dim = kPreviewMaxDim);
 
 /// Compute an adaptive pixels-per-mm value so the longest side of a
 /// \p width_mm x \p height_mm model hits exactly \p max_dim pixels.


### PR DESCRIPTION
## Summary

修复 #82 引入的潜在回归：`ResizeForPreview` 默认 `min_dim=512` 会对小尺寸光栅 recipe map 进行上采样，导致预览 PNG 分辨率与 region map / summary.width 不一致，前端 `object-fit: none` 会裁切图片造成坐标严重错位。

- 将 `min_dim` 默认值从 `kPreviewMinDim (512)` 改为 `0`（仅缩小、不放大）
- 上采样能力保留在函数签名中，需要时可显式传入 `min_dim > 0`
- 矢量路径不受影响（通过自适应 ppm 在渲染阶段就已控制分辨率）

## Test plan

- [x] 编译通过
- [ ] 验证小尺寸光栅模型（max_width < 512）在配方编辑器中点击选区坐标正确