### PR TITLE
feat(recipe-editor): 为选中区域添加缩放不变的描边

### DIFF
--- a/web/frontend/src/components/common/ZoomableImageViewport.vue
+++ b/web/frontend/src/components/common/ZoomableImageViewport.vue
@@ -71,6 +71,11 @@ const fitParams = computed(() => {
 const internalPanZoom = usePanZoom()
 const panZoom = computed<PanZoomController>(() => props.controller ?? internalPanZoom)
 
+const effectiveScale = computed(() => {
+  const fp = fitParams.value
+  return fp ? fp.fitScale * panZoom.value.scale.value : panZoom.value.scale.value
+})
+
 const transformValue = computed(() => {
   const pz = panZoom.value
   const s = pz.scale.value
@@ -153,7 +158,7 @@ defineExpose({
       draggable="false"
       :alt="alt"
     />
-    <slot :transform="transformValue" />
+    <slot :transform="transformValue" :effective-scale="effectiveScale" />
   </div>
 </template>
 

--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -580,11 +580,12 @@ onUnmounted(() => {
           :content-width="summary?.width ?? 0"
           :content-height="summary?.height ?? 0"
         >
-          <template #default="{ transform }">
+          <template #default="{ transform, effectiveScale }">
             <RegionOverlayCanvas
               :region-map="regionMap"
               :selected-region-ids="selectedRegionIds"
               :transform="transform"
+              :effective-scale="effectiveScale"
               :source-width="summary?.width ?? 0"
               :source-height="summary?.height ?? 0"
             />

--- a/web/frontend/src/components/recipeEditor/RegionOverlayCanvas.vue
+++ b/web/frontend/src/components/recipeEditor/RegionOverlayCanvas.vue
@@ -6,17 +6,90 @@ const props = defineProps<{
   regionMap: RegionMapData | null
   selectedRegionIds: Set<number>
   transform: string
+  effectiveScale: number
   sourceWidth: number
   sourceHeight: number
 }>()
 
 const canvasRef = ref<HTMLCanvasElement | null>(null)
 const MASK_ALPHA = 102
+const BORDER_SCREEN_PX = 1.5
+const BORDER_COLOR = 'rgba(255, 255, 255, 0.85)'
+const MAX_BORDER_CANVAS_PX = 8
+
+let cachedMaskCanvas: HTMLCanvasElement | null = null
+let cachedEdges: Float64Array | null = null
+let cachedEdgeCount = 0
+
+function isPixelSelected(regionIds: Uint32Array, idx: number, selected: Set<number>): boolean {
+  const rid = regionIds[idx]
+  return rid !== undefined && rid !== 0xffffffff && selected.has(rid)
+}
+
+function buildMaskAndEdges() {
+  const map = props.regionMap
+  if (!map || props.selectedRegionIds.size === 0) {
+    cachedMaskCanvas = null
+    cachedEdges = null
+    cachedEdgeCount = 0
+    return
+  }
+
+  const w = map.width
+  const h = map.height
+  const regionIds = map.regionIds
+  const selected = props.selectedRegionIds
+
+  const tmpCanvas = document.createElement('canvas')
+  tmpCanvas.width = w
+  tmpCanvas.height = h
+  const tmpCtx = tmpCanvas.getContext('2d')!
+  const imageData = tmpCtx.createImageData(w, h)
+  const data = imageData.data
+
+  for (let i = 0; i < regionIds.length; i++) {
+    if (isPixelSelected(regionIds, i, selected)) continue
+    data[i * 4 + 3] = MASK_ALPHA
+  }
+  tmpCtx.putImageData(imageData, 0, 0)
+  cachedMaskCanvas = tmpCanvas
+
+  const sw = props.sourceWidth
+  const sh = props.sourceHeight
+  const scaleX = sw / w
+  const scaleY = sh / h
+
+  const edges: number[] = []
+
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = y * w + x
+      const sel = isPixelSelected(regionIds, i, selected)
+
+      if (sel) {
+        if (x === 0) edges.push(0, y * scaleY, 0, (y + 1) * scaleY)
+        if (x === w - 1) edges.push(w * scaleX, y * scaleY, w * scaleX, (y + 1) * scaleY)
+        if (y === 0) edges.push(x * scaleX, 0, (x + 1) * scaleX, 0)
+        if (y === h - 1) edges.push(x * scaleX, h * scaleY, (x + 1) * scaleX, h * scaleY)
+      }
+
+      if (x < w - 1 && sel !== isPixelSelected(regionIds, i + 1, selected)) {
+        edges.push((x + 1) * scaleX, y * scaleY, (x + 1) * scaleX, (y + 1) * scaleY)
+      }
+
+      if (y < h - 1 && sel !== isPixelSelected(regionIds, i + w, selected)) {
+        edges.push(x * scaleX, (y + 1) * scaleY, (x + 1) * scaleX, (y + 1) * scaleY)
+      }
+    }
+  }
+
+  cachedEdges = new Float64Array(edges)
+  cachedEdgeCount = edges.length / 4
+}
 
 function redraw() {
   const canvas = canvasRef.value
-  const map = props.regionMap
-  if (!canvas || !map) return
+  if (!canvas) return
 
   const ctx = canvas.getContext('2d')
   if (!ctx) return
@@ -24,37 +97,44 @@ function redraw() {
   const sw = props.sourceWidth
   const sh = props.sourceHeight
 
-  if (props.selectedRegionIds.size === 0) {
-    ctx.clearRect(0, 0, sw, sh)
-    return
-  }
-
-  const tmpCanvas = document.createElement('canvas')
-  tmpCanvas.width = map.width
-  tmpCanvas.height = map.height
-  const tmpCtx = tmpCanvas.getContext('2d')!
-  const imageData = tmpCtx.createImageData(map.width, map.height)
-  const data = imageData.data
-  const regionIds = map.regionIds
-  const selected = props.selectedRegionIds
-
-  for (let i = 0; i < regionIds.length; i++) {
-    const rid = regionIds[i]
-    if (rid !== undefined && rid !== 0xffffffff && selected.has(rid)) continue
-    data[i * 4 + 3] = MASK_ALPHA
-  }
-
-  tmpCtx.putImageData(imageData, 0, 0)
-
   ctx.clearRect(0, 0, sw, sh)
+
+  if (!cachedMaskCanvas || !cachedEdges || cachedEdgeCount === 0) return
+
   ctx.imageSmoothingEnabled = false
-  ctx.drawImage(tmpCanvas, 0, 0, sw, sh)
+  ctx.drawImage(cachedMaskCanvas, 0, 0, sw, sh)
+
+  const scale = props.effectiveScale
+  if (scale <= 0) return
+
+  const lineWidth = Math.min(BORDER_SCREEN_PX / scale, MAX_BORDER_CANVAS_PX)
+  const edges = cachedEdges
+
+  ctx.beginPath()
+  for (let i = 0; i < cachedEdgeCount; i++) {
+    const base = i * 4
+    ctx.moveTo(edges[base], edges[base + 1])
+    ctx.lineTo(edges[base + 2], edges[base + 3])
+  }
+  ctx.lineWidth = lineWidth
+  ctx.strokeStyle = BORDER_COLOR
+  ctx.lineCap = 'square'
+  ctx.stroke()
 }
 
 watch(
   () => [props.regionMap, props.selectedRegionIds] as const,
-  () => redraw(),
+  () => {
+    buildMaskAndEdges()
+    redraw()
+  },
   { flush: 'post', immediate: true },
+)
+
+watch(
+  () => props.effectiveScale,
+  () => redraw(),
+  { flush: 'post' },
 )
 </script>
 

--- a/web/frontend/src/components/recipeEditor/RegionOverlayCanvas.vue
+++ b/web/frontend/src/components/recipeEditor/RegionOverlayCanvas.vue
@@ -113,8 +113,8 @@ function redraw() {
   ctx.beginPath()
   for (let i = 0; i < cachedEdgeCount; i++) {
     const base = i * 4
-    ctx.moveTo(edges[base], edges[base + 1])
-    ctx.lineTo(edges[base + 2], edges[base + 3])
+    ctx.moveTo(edges[base]!, edges[base + 1]!)
+    ctx.lineTo(edges[base + 2]!, edges[base + 3]!)
   }
   ctx.lineWidth = lineWidth
   ctx.strokeStyle = BORDER_COLOR


### PR DESCRIPTION
## Summary

- 解决配方编辑器中深色选中区域与压暗的未选中区域难以区分的问题
- 在现有半透明遮罩基础上，为选中区域边界添加白色描边（屏幕恒定 1.5px）
- 描边宽度通过 `lineWidth = targetScreenPx / effectiveScale` 反向补偿 CSS 缩放，缩放时宽度不变

## 改动说明

| 文件 | 改动 |
|------|------|
| `ZoomableImageViewport.vue` | slot scope 新增 `effectiveScale` 输出（`fitScale * userZoom`） |
| `RecipeEditorPanel.vue` | 透传 `effectiveScale` 到 `RegionOverlayCanvas` |
| `RegionOverlayCanvas.vue` | 核心：边缘检测 + Canvas 路径描边 + 边缘缓存 |

### 技术细节

- 在 region-map 栅格（最大 1024x1024）上做边缘检测，提取选中区域与非选中区域之间的网格边
- 边缘线段缓存为 `Float64Array`，仅在选区变化时重算；缩放变化只触发重绘
- `lineWidth` 设上限 `8px`（canvas 空间）防止极度缩小时描边过粗

## Test plan

- [ ] 选中浅色区域，确认描边可见且不影响原有遮罩效果
- [ ] 选中深色区域，确认描边提供了足够的视觉区分度
- [ ] 缩放（滚轮放大/缩小），确认描边在屏幕上宽度基本不变
- [ ] 切换选中区域 / 取消选中，确认描边及时更新和清除
- [ ] Global 模式下选中配方，确认所有关联区域都有描边