### PR TITLE
feat(announcement): 新增用户公告系统

### DIFF
--- a/.cursor/hooks/protect-secrets.sh
+++ b/.cursor/hooks/protect-secrets.sh
@@ -22,6 +22,9 @@ case "$filename" in
     .env.*.local)
         deny_with "本地环境变量文件可能包含密钥"
         ;;
+    announcement.env|.chromaprint3d-announcement-token)
+        deny_with "公告 token 文件"
+        ;;
     credentials.json|service-account*.json)
         deny_with "凭据文件"
         ;;

--- a/.cursor/skills/publish-announcement/SKILL.md
+++ b/.cursor/skills/publish-announcement/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: publish-announcement
+description: Help the operator publish, list, and remove user-visible announcements on ChromaPrint3D. Use when the user mentions publishing an announcement, posting a notice, scheduling a maintenance banner, creating an announcement, or anything related to the `/api/v1/announcements` API and the `scripts/announce.sh` tool. This skill should NOT be used to deploy new versions — pair it with `release-version` when notifying users ahead of a scheduled upgrade.
+---
+
+# 发布公告（Announcement）工作流
+
+## 概述
+
+公告是用户打开 ChromaPrint3D 时顶部看到的 banner，**面向海内外用户同时展示**。
+发布流程由后端 `/api/v1/announcements` 和 `scripts/announce.sh` 驱动：
+
+1. 后端存储：`${data_dir}/announcements.json`（原子写，单文件）
+2. 鉴权：所有写操作需要 `x-announcement-token` 头，且只能通过 HTTPS
+3. 前端：启动时拉取一次；`/api/v1/health` 携带 `announcements_version`，
+   该值变化时前端自动重新拉取
+4. 用户侧：可选"不再提醒"（按 `id + updated_at` 维度持久化到 `localStorage`）
+
+## Agent 职责
+
+每次被触发时，Agent 必须依次完成：
+
+1. 与用户确认目标：是**新发**、**修改**、**延期**、**撤回**，还是仅**查看**当前公告
+2. 撰写中英双语内容，面向用户使用
+3. 选择正确的 `type` / `severity` / `ends_at`（UTC，ISO8601）
+4. 必要时提供 `scheduled_update_at`（用于前端倒计时）
+5. 调用 `scripts/announce.sh`，**绝不把 token 明文写入聊天或 commit**
+6. 核对服务端返回，必要时再次 `list` 验证
+
+## 字段规范
+
+| 字段 | 说明 |
+|---|---|
+| `id` | 幂等键，正则 `^[a-zA-Z0-9_-]{1,64}$`；同 `id` 再发会覆盖 |
+| `type` | `info` / `warning` / `maintenance` |
+| `severity` | `info` / `warning` / `error`；决定 banner 配色 |
+| `title.zh` / `title.en` | 至少一种语言必填，≤ 2000 字符 |
+| `body.zh` / `body.en` | 至少一种语言必填，≤ 2000 字符；支持多行，**禁止 HTML** |
+| `starts_at` | 可选，ISO8601 UTC；省略表示立即生效 |
+| `ends_at` | 必填，ISO8601 UTC，必须在未来且大于 `starts_at` |
+| `scheduled_update_at` | 可选，升级窗口时间点，前端据此渲染倒计时 |
+| `dismissible` | 默认 `true`；若需强制可见（如进行中的紧急维护）设为 `false` |
+
+### 写作原则
+
+- **面向用户**：告诉用户"会发生什么、对你有什么影响"
+- **有明确时间锚点**：维护通知必须给出 `scheduled_update_at`
+- **双语对齐**：中英文保持信息一致，不互相增减
+- **别泄露内部语汇**：不提到模块名、commit、PR 编号
+- **维护通知应提前 ≥ 1h**：方便跨时区用户看见
+
+## 快速流程
+
+### 1. 查看现有公告
+
+```bash
+./scripts/announce.sh list
+```
+
+`list` 不需要 token（GET 是公开的）。
+
+### 2. 发布一条维护预告
+
+先确保 token 已经通过环境变量导入（**不要写进命令行历史**）：
+
+```bash
+# 推荐做法：读文件，不回显
+export CHROMAPRINT3D_ANNOUNCEMENT_TOKEN="$(cat ~/.chromaprint3d-announcement-token)"
+# 或用专用文件变量（脚本会按需读取）：
+export CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE=~/.chromaprint3d-announcement-token
+```
+
+再发布：
+
+```bash
+./scripts/announce.sh create \
+    maintenance-2026-04-20 \
+    maintenance \
+    warning \
+    '2026-04-20T10:30:00Z' \
+    --title-zh '2026-04-20 维护通知' \
+    --title-en 'Maintenance notice · 2026-04-20' \
+    --body-zh '我们将在 UTC 10:00 进行约 10 分钟的升级，期间请保存您的工作。' \
+    --body-en 'We will upgrade at 10:00 UTC for ~10 minutes. Please save your work.' \
+    --starts-at '2026-04-19T10:00:00Z' \
+    --scheduled-update-at '2026-04-20T10:00:00Z'
+```
+
+### 3. 用文件发布（推荐复杂文案）
+
+```yaml
+# announcements/maintenance-2026-04-20.yaml
+id: maintenance-2026-04-20
+type: maintenance
+severity: warning
+title_zh: '2026-04-20 维护通知'
+title_en: 'Maintenance notice · 2026-04-20'
+body_zh: |
+  我们将在 UTC 10:00 进行约 10 分钟的升级。
+  请在此之前保存您的工作，升级期间部分任务可能中断。
+body_en: |
+  We will upgrade at 10:00 UTC for ~10 minutes.
+  Please save your work before then — in-flight tasks may be interrupted.
+starts_at: '2026-04-19T10:00:00Z'
+ends_at: '2026-04-20T10:30:00Z'
+scheduled_update_at: '2026-04-20T10:00:00Z'
+dismissible: true
+```
+
+```bash
+./scripts/announce.sh from-file announcements/maintenance-2026-04-20.yaml
+```
+
+> 草稿 YAML 放在 `announcements/*.local.yaml`，已在 `.gitignore` 覆盖。
+
+### 4. 延期 / 修改
+
+同 `id` 重新 `create` 或 `from-file` 即可，服务端会保留 `created_at`、
+刷新 `updated_at`，前端检测到 `announcements_version` 变化后重新拉取，
+已"不再提醒"的用户在 `updated_at` 变动时会重新看到。
+
+### 5. 撤回
+
+```bash
+./scripts/announce.sh delete maintenance-2026-04-20
+```
+
+撤回后前端在下一次 `health` 轮询（约 15 秒）内消失。
+
+## 与发版（release-version）协作
+
+若公告目的是"预告版本升级"，推荐顺序：
+
+1. 本 skill 发公告，`scheduled_update_at` = 计划升级时间
+2. 到点后使用 `release-version` skill 执行真正的发版
+3. 升级完成后 `./scripts/announce.sh delete <id>` 撤回
+
+## 安全自检（每次都做）
+
+- [ ] 命令行里没有明文 token（用环境变量 / 文件）
+- [ ] 不要在 PR / commit / chat 里贴 token
+- [ ] 公告内容是**纯文本**，没有 HTML 或脚本
+- [ ] 生产环境上传到的 URL 是 HTTPS
+- [ ] 若操作失败返回 `404 not_found`：后端未配置 token，联系运维
+- [ ] 若返回 `403 insecure_transport`：请求走了明文 HTTP，改走 HTTPS
+- [ ] 若返回 `401 unauthorized`：token 错误 / 过期，联系运维轮换
+
+## 参考
+
+- 后端入口：`web/backend/src/presentation/announcement_auth_advice.cpp`
+- 领域模型：`web/backend/src/application/announcement_service.{h,cpp}`
+- 前端挂载：`web/frontend/src/components/AnnouncementBanner.vue`
+- 运维文档：`docs/deployment.md`（token 部署章节）
+- 契约：`docs/development.md`（API 契约章节）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,3 +222,20 @@ jobs:
           fi
 
           echo "All changed C++ files are correctly formatted."
+
+  # ---------------------------------------------------------------------------
+  # Secret scanning — gitleaks on the full history of the PR/branch
+  # ---------------------------------------------------------------------------
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_ENABLE_COMMENTS: false

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,12 @@ scripts/deploy_split*.env
 scripts/deploy_split.local.env
 scripts/*.local.env
 
+# Announcement secrets / payload drafts
+announcement.env
+.env.local
+.chromaprint3d-announcement-token
+announcements/*.local.yaml
+announcements/*.local.yml
+announcements/*.local.json
+
 test_data/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,35 @@
+title = "ChromaPrint3D gitleaks config"
+
+# Extend the upstream default ruleset.
+# See: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
+[extend]
+useDefault = true
+
+[[rules]]
+id = "chromaprint3d-announcement-token"
+description = "ChromaPrint3D announcement token literal"
+regex = '''(?i)(chromaprint3d[_-]?announcement[_-]?token|x-announcement-token)\s*[:=]\s*["'`][A-Za-z0-9_\-]{16,}["'`]'''
+tags = ["secret", "token", "chromaprint3d"]
+
+[allowlist]
+description = "Paths that are ok to ignore — tests, docs, lockfiles, bundled deps."
+paths = [
+    '''(^|/)3dparty/''',
+    '''(^|/)node_modules/''',
+    '''(^|/)web/frontend/dist/''',
+    '''(^|/)build/''',
+    # Documented placeholders (never literal secrets):
+    '''(^|/)docs/.*\.md$''',
+    '''(^|/)README.md$''',
+    '''(^|/).cursor/skills/''',
+    # Tooling we control:
+    '''(^|/)scripts/announce\.sh$''',
+]
+
+# Common placeholders / env var names that look like literals but aren't.
+regexTarget = "match"
+regexes = [
+    '''CHROMAPRINT3D_ANNOUNCEMENT_TOKEN=["']?\$\{?[A-Z_]+\}?''',
+    '''CHROMAPRINT3D_ANNOUNCEMENT_TOKEN=<your[- _]?token>''',
+    '''x-announcement-token:\s*\$TOKEN''',
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 | 修改前端页面与参数面板 | [docs/agents/web/frontend/README.md](docs/agents/web/frontend/README.md) |
 | 矢量化质量评估与回归检测 | [neroued_vectorizer](https://github.com/neroued/neroued_vectorizer)（已迁移） |
 | 更新建模拟合流程 | [docs/agents/modeling/README.md](docs/agents/modeling/README.md) |
+| 发布/撤回运维公告 | [docs/agents/tasks/publish_announcement.md](docs/agents/tasks/publish_announcement.md) + [.cursor/skills/publish-announcement/SKILL.md](.cursor/skills/publish-announcement/SKILL.md) |
 
 ## 模块索引入口
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ docker run -d -p 8080:8080 --name chromaprint3d neroued/chromaprint3d:latest
 - 本地开发与调试：[docs/development.md](docs/development.md)
 - 发布流程：[docs/development.md#8-发布流程](docs/development.md#8-发布流程)
 - 部署：[docs/deployment.md](docs/deployment.md)
+- 运维公告（升级预告/维护通知）：[docs/deployment.md#公告系统announcements](docs/deployment.md#公告系统announcements)
 - 协作导航：[AGENTS.md](AGENTS.md)
 - 模块索引：[docs/agents/README.md](docs/agents/README.md)
 - 任务手册：[docs/agents/tasks/README.md](docs/agents/tasks/README.md)

--- a/docs/agents/tasks/README.md
+++ b/docs/agents/tasks/README.md
@@ -19,4 +19,5 @@
 - [tune_color_match.md](tune_color_match.md)
 - [update_frontend_param.md](update_frontend_param.md)
 - [sync_docs_after_behavior_change.md](sync_docs_after_behavior_change.md)
+- [publish_announcement.md](publish_announcement.md)
 

--- a/docs/agents/tasks/publish_announcement.md
+++ b/docs/agents/tasks/publish_announcement.md
@@ -1,0 +1,74 @@
+# 发布运维公告
+
+## 适用场景
+
+- 计划维护 / 版本升级前需要提前向用户展示 banner
+- 紧急状态（降级、临时变更）需要对海内外在线用户同时宣告
+- 撤回已发布的公告
+
+本手册只覆盖"写入与撤回"流程，不覆盖实际代码部署；部署流程见 [release-version skill](../../../.cursor/skills/release-version/SKILL.md) 与 [docs/deployment.md](../../deployment.md)。
+
+## 影响文件（按优先级）
+
+- `scripts/announce.sh` — CLI 工具（list / create / delete / from-file）
+- `.cursor/skills/publish-announcement/SKILL.md` — Agent 协作 SOP
+- `docs/deployment.md#公告系统announcements` — 部署契约与 token 管理
+- 运行时数据：`${data_dir}/announcements.json`（后端原子写入，无需手改）
+
+## 前置条件
+
+1. 后端启动参数带 `--announcement-token <TOKEN>`（或等效 env：`CHROMAPRINT3D_ANNOUNCEMENT_TOKEN`）
+2. 生产环境走 HTTPS，反代透传 `X-Forwarded-Proto: https`
+3. 运维机 IP 在 Nginx `location /api/v1/announcements` 的 `allow` 白名单内
+4. 本地：
+   ```bash
+   export CHROMAPRINT3D_API_URL=https://api.chromaprint3d.com:9443
+   export CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE=~/.chromaprint3d-announcement-token
+   ```
+
+## 实施步骤
+
+1. 拉取当前公告，避免重复：
+   ```bash
+   ./scripts/announce.sh list
+   ```
+2. 起草中英双语标题/正文（面向用户视角）。
+3. 选定：
+   - `type`（`info` / `warning` / `maintenance`）
+   - `severity`（`info` / `warning` / `error`，决定 banner 配色）
+   - `ends_at`（UTC，未来时间）
+   - 可选：`starts_at`、`scheduled_update_at`、`dismissible`
+4. 执行创建：
+   ```bash
+   ./scripts/announce.sh create <id> <type> <severity> <ends_at> \
+     --title-zh '...' --title-en '...' \
+     --body-zh  '...' --body-en  '...' \
+     --scheduled-update-at '...'   # 维护通知时强烈建议
+   ```
+5. 再次 `list` 核对落盘结果。
+6. 公告失效或升级完成后撤回：
+   ```bash
+   ./scripts/announce.sh delete <id>
+   ```
+
+## 风险点
+
+- **token 泄露**：绝不把 token 明文粘到 PR / commit / chat，使用 `CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE`。
+- **无 token 配置**：后端对 POST/DELETE 会返回 `404 not_found`，不是 `401`；不要误判为"路由挂了"。
+- **明文 HTTP**：生产写入请求走 HTTP 会返回 `403 insecure_transport`，本地联调可加 `--announcement-allow-http`。
+- **body 超限**：单条请求 ≤ 16 KiB；触发时返回 `413 payload_too_large`。
+- **用户已 dismiss 旧版本**：修改内容时 `updated_at` 会自动刷新，前端 dismiss 按 `{id, updated_at}` 存储，会自动再次展示。
+- **跨时区用户**：维护通知至少提前 1 小时发布，`scheduled_update_at` 必填。
+
+## 回归检查
+
+- 发布后冒烟：
+  ```bash
+  curl -s "$CHROMAPRINT3D_API_URL/api/v1/announcements" | jq
+  curl -s "$CHROMAPRINT3D_API_URL/api/v1/health"          | jq '.data.announcements_version, .data.active_announcement_count'
+  ```
+- 前端浏览器端在新标签打开正式站点，确认 banner 出现且可 dismiss。
+- 撤回公告后，确认 `announcements` 列表为空且 `active_announcement_count` 为 0。
+- 文档检查：
+  - 是否更新 [README.md](../../../README.md) / [docs/development.md](../../development.md) / [docs/deployment.md](../../deployment.md)（仅在行为/契约变化时）
+  - 是否更新 [.cursor/skills/publish-announcement/SKILL.md](../../../.cursor/skills/publish-announcement/SKILL.md)

--- a/docs/agents/web/backend/README.md
+++ b/docs/agents/web/backend/README.md
@@ -24,6 +24,7 @@
     - `matting_vectorize_service.*` — 抠图与矢量化任务
     - `recipe_editor_service.*` — 配方编辑器（摘要/候选/替换/生成/预测）
     - `calibration_service.*` — 校准板生成/定位/ColorDB 构建
+    - `announcement_service.*` — 公告 CRUD、schema 校验、原子持久化、版本戳
   - 共享内核：
     - `request_parsing.*` — 请求解析与校验工具
     - `json_serialization.*` — JSON 序列化辅助函数
@@ -32,6 +33,7 @@
   - 路由与请求处理：`api_v1_controller.*`
   - 运行时注册：`backend_runtime.*`
   - CORS 处理：`cors_advice.*`
+  - 公告写入鉴权与传输 / body-size 前置 advice：`announcement_auth_advice.*`
 
 ## 常见改动落点
 
@@ -64,6 +66,20 @@
 ## Health 指标
 
 `GET /api/v1/health` 中的 `memory.colordb_pool_bytes` 表示“全局 ColorDB 缓存 + 会话 ColorDB”的总估算体量，由 `ColorDBCache` 与 `SessionStore` 增量维护，读取路径保持 O(1)。它是容量近似值，不是 RSS 的精确拆分。
+
+响应同时带有 `announcements_version`（公告内容的 8 位 FNV-1a 指纹）与 `active_announcement_count`，前端通过 watch 前者变化触发重拉。
+
+## 公告系统
+
+- 路由：
+  - `GET /api/v1/announcements`（公开）
+  - `POST /api/v1/announcements`（需 `x-announcement-token` 头 + HTTPS + body ≤ 16KB）
+  - `DELETE /api/v1/announcements/{id}`（需 token）
+- 鉴权：`presentation/announcement_auth_advice.cpp` 前置 advice，未配置 token 时写入路由统一返回 `404 not_found`；非 HTTPS 返回 `403 insecure_transport`；token 用常量时间比较。
+- 领域：`application/announcement_service.{h,cpp}` 提供 schema 校验（id 正则、双语至少一种、时间窗口合法）、原子持久化（`${data_dir}/announcements.json` 写 tmp + rename）、FNV-1a 版本戳、按严重度排序的有效列表。
+- Facade：`ServerFacade::ListAnnouncements/UpsertAnnouncement/DeleteAnnouncement` 三个方法。
+- 单测：`web/backend/tests/test_announcement_service.cpp` 覆盖 schema、时间窗口、原子写、版本戳、幂等与跨进程 reload。
+- 详细契约与部署：[docs/development.md#543-health](../../../development.md)、[docs/deployment.md#公告系统announcements](../../../deployment.md)。
 
 ## 配方编辑器
 

--- a/docs/agents/web/frontend/README.md
+++ b/docs/agents/web/frontend/README.md
@@ -28,6 +28,7 @@
 | 调整自定义配方与颜色预测 | `src/components/recipeEditor/CustomRecipeDialog.vue` + `src/services/recipeEditorService.ts` |
 | 调整多标签健康上报/leader 选举 | `src/composables/feature/useLeaderLease.ts` + `src/composables/feature/useAppLifecycle.ts` |
 | 调整 Browser/Electron 行为差异 | `src/runtime/*.ts` + `src/electron.d.ts` |
+| 调整公告 banner 展示 / dismiss 行为 | `src/components/AnnouncementBanner.vue` + `src/composables/useAnnouncements.ts` + `src/api/announcements.ts` + `src/locales/{zh-CN,en}.ts` |
 
 ## 分层边界（强约束）
 
@@ -45,6 +46,14 @@
 - 上传约束变化时，检查：
   - `src/domain/upload/imageUploadValidation.ts`
   - `src/runtime/env.ts`
+
+## 公告系统（只读端）
+
+- 前端只消费公告，不写入；写入由 `scripts/announce.sh` + 后端完成。
+- 健康检查中 `announcements_version` 变化驱动重拉：`src/stores/app.ts` 暴露 ref → `src/composables/useAnnouncements.ts` 监听 → `fetchAnnouncements()`。
+- Dismiss 持久化在 `localStorage`，键为 `chromaprint3d-dismissed-announcements`，按 `{id: updated_at}` 存储。修改 `updated_at` 即可重新唤起。
+- 渲染严禁 `v-html`，所有 body 行走 `{{ line }}` 插值。多语言 fallback：优先当前 locale，再降级到另一语言。
+- 相关翻译 key：`app.announcements.*`，新增字段时同步 zh-CN 与 en 两份。
 
 ## 最小验证
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -258,6 +258,28 @@ server {
         proxy_read_timeout 10s;
     }
 
+    # --- 公告 API：GET 对所有 IP 开放（前端拉取 banner），
+    #     POST/DELETE 只允许受控网段，额外加一层网络层防御。
+    #     将下方 CIDR 替换为运维机 / VPN 出口的地址段。
+    location /api/v1/announcements {
+        limit_req zone=api_limit burst=20 nodelay;
+
+        limit_except GET OPTIONS {
+            allow 10.0.0.0/8;           # 示例：内部管理网
+            allow 192.168.0.0/16;       # 示例：家庭/办公网
+            # allow <VPN 出口 IP>/32;
+            deny all;
+        }
+
+        proxy_pass http://chromaprint3d:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 15s;
+        client_max_body_size 32k;       # 配合后端 16KB body 上限，留少量头余量
+    }
+
     # --- 校准板生成：计算量大，需要长超时 ---
     location /api/v1/calibration/boards {
         limit_req zone=upload_limit burst=5 nodelay;
@@ -941,3 +963,102 @@ docker compose pull && docker compose up -d
 ```
 
 升级前建议先执行一次手动备份。
+
+---
+
+## 公告系统（Announcements）
+
+公告系统用于在用户面前以 banner 形式宣告维护、升级、临时状态等信息。写入通道受 token 保护，读取公开、对前端低延迟。设计目标：
+
+- **不打扰在线用户**：公告内容与在线用户的任务状态完全解耦，发布/撤回不会触发后端重启。
+- **跨时区可见**：公告使用 ISO8601 UTC 时间戳，前端按本地时区渲染倒计时。
+- **防误触**：Kerckhoffs 原则，所有防御依赖 token 机密与网络/传输层控制；源码公开不构成风险。
+
+### 威胁模型与防御层次（概览）
+
+| 层级 | 对抗能力 | 关键配置 |
+|---|---|---|
+| 网络 | 限制 POST/DELETE 只从管理网段进入 | Nginx `limit_except GET OPTIONS` + `allow`/`deny` |
+| 传输 | 非 loopback 来源必须 HTTPS（或反代带 `X-Forwarded-Proto: https`） | 后端默认启用；`--announcement-allow-http` 放宽 |
+| 身份 | token 机密 + 常量时间比较 | `--announcement-token` + `x-announcement-token` 头 |
+| Schema | id 正则 / 时间合法 / 长度 / body size 16KB | `AnnouncementService::ValidateAndBuild` |
+| 渲染 | 前端纯文本、禁用 `v-html` | `AnnouncementBanner.vue` |
+| 秘密 | gitleaks CI + .gitignore + beforeReadFile 钩子 | 见 `.gitleaks.toml`、`.cursor/hooks/protect-secrets.sh` |
+
+> 传输层说明：为了适配"Nginx 终端 TLS，通过 docker 网络代理到后端"的典型部署，
+> 后端把 `peerAddr().isLoopbackIp()` 视为安全来源（容器内 Nginx → 后端 127.0.0.1 明文也被允许）。
+> 这与"攻击者已经拿到后端容器 shell"是同一威胁假设；token 与网络层白名单仍保留防御价值。
+> 跨机流量必须走 HTTPS（浏览器 TLS 或反代注入 `X-Forwarded-Proto: https`），
+> 否则返回 `403 insecure_transport`。
+
+### 启用步骤
+
+1. 在家庭主机上生成 ≥ 32 字节随机 token：
+   ```bash
+   openssl rand -hex 32 > ~/.chromaprint3d-announcement-token
+   chmod 600 ~/.chromaprint3d-announcement-token
+   ```
+2. 把 token 写入部署环境（`.env`，**不入 Git**）：
+   ```env
+   # ~/chromaprint3d-deploy/.env
+   CHROMAPRINT3D_ANNOUNCEMENT_TOKEN=<上一步的 token>
+   ```
+3. 修改 `docker-compose.yml` 的 `chromaprint3d` 服务：
+   ```yaml
+       environment:
+         - CHROMAPRINT3D_ANNOUNCEMENT_TOKEN=${CHROMAPRINT3D_ANNOUNCEMENT_TOKEN}
+       command:
+         # 其他参数保持不变
+         # --announcement-token 会被容器进程读取；也可改用上面的环境变量
+   ```
+4. 滚动更新：
+   ```bash
+   docker compose up -d chromaprint3d
+   ```
+5. 在 Nginx 的 `api.chromaprint3d.com` server block 中，对公告路由开启网段白名单（见本文档 2.4 章的 `location /api/v1/announcements` 块）。
+
+> 未配置 token 时后端会把 POST/DELETE 一律返回 `404 not_found`，从外部观察不到"公告功能存在"。这是有意为之，降低指纹化探测的价值。
+
+### 发布 / 撤回
+
+推荐使用 `scripts/announce.sh`（详见 `.cursor/skills/publish-announcement/SKILL.md`）：
+
+```bash
+export CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE=~/.chromaprint3d-announcement-token
+export CHROMAPRINT3D_API_URL=https://api.chromaprint3d.com:9443
+
+./scripts/announce.sh list
+./scripts/announce.sh create maint-2026-04-20 maintenance warning \
+  '2026-04-20T10:30:00Z' \
+  --title-zh '2026-04-20 维护通知' --title-en 'Maintenance 2026-04-20' \
+  --body-zh '我们将在 UTC 10:00 升级，约 10 分钟。' \
+  --body-en  'Upgrade at 10:00 UTC for ~10 minutes.' \
+  --starts-at '2026-04-19T10:00:00Z' \
+  --scheduled-update-at '2026-04-20T10:00:00Z'
+
+./scripts/announce.sh delete maint-2026-04-20
+```
+
+### 存储与备份
+
+- 数据文件：`${data_dir}/announcements.json`
+- 写入：先写 `.tmp` 再 `rename`（原子）
+- 建议纳入现有备份计划（与 `data_dir` 其他状态一起备份即可）
+
+### Token 轮换建议
+
+- 每季度或怀疑泄露时轮换：
+  1. 生成新 token，写入 `~/.chromaprint3d-announcement-token`
+  2. `docker compose up -d chromaprint3d`（读取新环境变量）
+  3. 旧 token 即刻失效
+- 轮换历史建议登记到独立安全笔记，**不要提交到代码仓库**。
+
+### 故障排除
+
+| 现象 | 可能原因 | 处置 |
+|---|---|---|
+| `404 not_found` 对 POST/DELETE | 后端未配置 token | 补 `--announcement-token` 或 `CHROMAPRINT3D_ANNOUNCEMENT_TOKEN` |
+| `403 insecure_transport` | 请求走明文 HTTP | 检查 Nginx 是否透传 `X-Forwarded-Proto: https` |
+| `401 unauthorized` | token 错误 / 轮换后未同步 | 用 `openssl rand -hex 32` 重新生成并重启 |
+| `413 payload_too_large` | 公告 body > 16 KiB | 精简文案或拆条 |
+| 前端没看到新公告 | `announcements_version` 没变化 或被本地 dismiss | `./scripts/announce.sh list` 核对；编辑 `updated_at` 会重新唤起 |

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,6 +100,19 @@ npm run typecheck
 curl -s http://127.0.0.1:8080/api/v1/health
 curl -s http://127.0.0.1:8080/api/v1/convert/defaults
 curl -s http://127.0.0.1:8080/api/v1/vectorize/defaults
+curl -s http://127.0.0.1:8080/api/v1/announcements
+```
+
+本地联调公告写入（需附 `--announcement-token dev-token --announcement-allow-http`）：
+
+```bash
+./scripts/announce.sh list
+
+CHROMAPRINT3D_API_URL=http://127.0.0.1:8080 \
+CHROMAPRINT3D_ANNOUNCEMENT_TOKEN=dev-token \
+./scripts/announce.sh create test-001 info info '2026-12-31T23:59:59Z' \
+  --title-zh '测试公告' --title-en 'Test announcement' \
+  --body-zh '这是一条测试公告。' --body-en 'A test announcement.'
 ```
 
 ### 3.3 常用 CLI 调试命令
@@ -172,7 +185,7 @@ npm run dev
 
 ### 5.3 Health 端点响应格式
 
-`GET /api/v1/health` 响应包含 `memory` 对象，提供服务端内存状态：
+`GET /api/v1/health` 响应包含 `memory` 对象以及公告版本戳，提供服务端内存状态与公告变更指示：
 
 ```json
 {
@@ -191,7 +204,9 @@ npm run dev
       "colordb_pool_bytes": 52428800,
       "memory_limit_bytes": 4294967296,
       "allocator": "jemalloc"
-    }
+    },
+    "announcements_version": "39bd1beb",
+    "active_announcement_count": 1
   }
 }
 ```
@@ -206,6 +221,8 @@ npm run dev
 | `colordb_pool_bytes` | ColorDB 缓存 + 会话 DB 的总估算体量 |
 | `memory_limit_bytes` | 容器内存限制（cgroup）或物理内存总量 |
 | `allocator` | 编译时链接的分配器（`jemalloc` / `glibc` / `system`） |
+| `announcements_version` | 公告内容的 8 位 hex 指纹（FNV-1a）；变化表示公告增删改，前端据此重新拉取 |
+| `active_announcement_count` | 当前有效公告条数（按 `starts_at` ≤ now < `ends_at` 过滤） |
 
 补充说明：
 
@@ -223,6 +240,24 @@ npm run dev
 | 配方编辑器 | `GET /api/v1/tasks/{id}/recipe-editor/summary`、`POST /api/v1/tasks/{id}/recipe-editor/alternatives`、`POST /api/v1/tasks/{id}/recipe-editor/replace`、`POST /api/v1/tasks/{id}/recipe-editor/generate`、`POST /api/v1/tasks/{id}/recipe-editor/predict` |
 | 任务查询与产物 | `GET /api/v1/tasks`、`GET /api/v1/tasks/{id}`、`GET /api/v1/tasks/{id}/artifacts/{artifact}` |
 | 校准链路 | `POST /api/v1/calibration/boards`、`POST /api/v1/calibration/boards/8color`、`POST /api/v1/calibration/locate`、`POST /api/v1/calibration/colordb` |
+| 公告 | `GET /api/v1/announcements`（公开）、`POST /api/v1/announcements`（需 token）、`DELETE /api/v1/announcements/{id}`（需 token） |
+
+### 5.4.1 公告 API 契约
+
+- 写入身份：`x-announcement-token` 头 + HTTPS；未配置 token 时 POST/DELETE 一律返回 `404 not_found`（避免向外暴露功能存在性）。
+- 传输：生产环境写入必须走 HTTPS（通过 TLS 或反代带 `X-Forwarded-Proto: https`），否则返回 `403 insecure_transport`。
+  本地联调可启动时附加 `--announcement-allow-http` 临时放宽。
+- Body 上限：`POST` 请求体 ≤ 16 KiB，否则返回 `413 payload_too_large`。
+- Schema：
+  - `id`：`^[a-zA-Z0-9_-]{1,64}$`，同 `id` 重复 POST 即等同于更新。
+  - `type`：`info` / `warning` / `maintenance`
+  - `severity`：`info` / `warning` / `error`（决定前端 banner 配色）
+  - `title` / `body`：对象形式 `{ "zh": "...", "en": "..." }`，两语言至少一项非空，单语言 ≤ 2000 字符。**纯文本**，前端禁用 `v-html`，URL 不自动链接化。
+  - `starts_at`（可选）、`ends_at`（必填）、`scheduled_update_at`（可选）：全部 ISO8601 UTC，均与当前时间字符串比较，无需客户端解析时区。
+  - `dismissible`：默认 `true`；`false` 时前端不展示"不再提醒"按钮。
+- 成功响应：POST / DELETE / GET 均返回 `announcements_version`（与 health 同步），便于前端局部更新。
+- 持久化：`${data_dir}/announcements.json`，原子写（临时文件 rename）。
+- 有关部署与 token 分发策略，见 [docs/deployment.md#公告系统announcements](deployment.md#公告系统announcements)。
 
 ### 5.4 Bambu Studio 预设参数
 

--- a/scripts/announce.sh
+++ b/scripts/announce.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+#
+# ChromaPrint3D announcement management CLI.
+#
+# Usage:
+#   ./scripts/announce.sh list
+#   ./scripts/announce.sh create <id> <type> <severity> <ends_at> \
+#       [--title-zh TEXT] [--title-en TEXT] \
+#       [--body-zh TEXT]  [--body-en TEXT] \
+#       [--starts-at ISO] [--scheduled-update-at ISO] \
+#       [--dismissible true|false]
+#   ./scripts/announce.sh delete <id>
+#   ./scripts/announce.sh from-file <path.yaml|path.json>
+#
+# Environment (all optional, with sane defaults for local dev):
+#   CHROMAPRINT3D_API_URL            default: https://chromaprint3d.com
+#   CHROMAPRINT3D_ANNOUNCEMENT_TOKEN required for create/delete/from-file
+#   CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE
+#                                    alt. path to a file holding the token
+#   CURL_EXTRA_ARGS                  extra args passed through to curl
+#
+# The script NEVER prints the token to stdout/stderr and only sends it
+# via the `x-announcement-token` header, strictly as documented in the
+# backend advice in web/backend/src/presentation/announcement_auth_advice.cpp.
+
+set -euo pipefail
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+# ---------- Argument helpers ----------
+
+sub_usage() {
+    grep -E '^#' "$0" | sed -E 's/^# ?//'
+    exit 0
+}
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+resolve_api_url() {
+    local url="${CHROMAPRINT3D_API_URL:-https://chromaprint3d.com}"
+    url="${url%/}"
+    printf '%s' "$url"
+}
+
+resolve_token() {
+    if [[ -n "${CHROMAPRINT3D_ANNOUNCEMENT_TOKEN:-}" ]]; then
+        printf '%s' "$CHROMAPRINT3D_ANNOUNCEMENT_TOKEN"
+        return 0
+    fi
+    if [[ -n "${CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE:-}" ]]; then
+        [[ -f "$CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE" ]] ||
+            die "token file not found: $CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE"
+        tr -d '\r\n' <"$CHROMAPRINT3D_ANNOUNCEMENT_TOKEN_FILE"
+        return 0
+    fi
+    die "announcement token not configured (set CHROMAPRINT3D_ANNOUNCEMENT_TOKEN)"
+}
+
+curl_with_header() {
+    # Call curl with --fail-with-body so non-2xx responses still print body
+    # without leaking the token via the command line.
+    local token
+    token="$(resolve_token)"
+    local extra=()
+    if [[ -n "${CURL_EXTRA_ARGS:-}" ]]; then
+        # shellcheck disable=SC2206
+        extra=($CURL_EXTRA_ARGS)
+    fi
+    curl --fail-with-body \
+         --silent --show-error \
+         -H "x-announcement-token: $token" \
+         "${extra[@]}" \
+         "$@"
+}
+
+# ---------- Commands ----------
+
+cmd_list() {
+    local api_url
+    api_url="$(resolve_api_url)"
+    # GET is public — no token needed.
+    local extra=()
+    if [[ -n "${CURL_EXTRA_ARGS:-}" ]]; then
+        # shellcheck disable=SC2206
+        extra=($CURL_EXTRA_ARGS)
+    fi
+    curl --fail-with-body --silent --show-error "${extra[@]}" \
+         "$api_url/api/v1/announcements" |
+        pretty_json
+}
+
+cmd_delete() {
+    local id="${1:-}"
+    [[ -n "$id" ]] || die "id is required"
+    local api_url
+    api_url="$(resolve_api_url)"
+    curl_with_header -X DELETE "$api_url/api/v1/announcements/$id" |
+        pretty_json
+}
+
+cmd_create() {
+    local id="${1:-}" type="${2:-}" severity="${3:-}" ends_at="${4:-}"
+    [[ -n "$id" && -n "$type" && -n "$severity" && -n "$ends_at" ]] ||
+        die "usage: announce.sh create <id> <type> <severity> <ends_at> [flags]"
+    shift 4
+
+    local title_zh=""; local title_en=""
+    local body_zh="";  local body_en=""
+    local starts_at="" scheduled_update_at="" dismissible=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --title-zh) title_zh="$2"; shift 2;;
+            --title-en) title_en="$2"; shift 2;;
+            --body-zh)  body_zh="$2";  shift 2;;
+            --body-en)  body_en="$2";  shift 2;;
+            --starts-at) starts_at="$2"; shift 2;;
+            --scheduled-update-at) scheduled_update_at="$2"; shift 2;;
+            --dismissible) dismissible="$2"; shift 2;;
+            *) die "unknown flag: $1";;
+        esac
+    done
+
+    [[ -n "$title_zh" || -n "$title_en" ]] ||
+        die "at least one of --title-zh or --title-en is required"
+    [[ -n "$body_zh" || -n "$body_en" ]] ||
+        die "at least one of --body-zh or --body-en is required"
+
+    local payload
+    payload="$(build_payload_json \
+        "$id" "$type" "$severity" "$ends_at" \
+        "$title_zh" "$title_en" \
+        "$body_zh" "$body_en" \
+        "$starts_at" "$scheduled_update_at" "$dismissible")"
+
+    local api_url
+    api_url="$(resolve_api_url)"
+    printf '%s' "$payload" |
+        curl_with_header -X POST \
+            -H 'content-type: application/json' \
+            --data-binary @- \
+            "$api_url/api/v1/announcements" |
+        pretty_json
+}
+
+cmd_from_file() {
+    local path="${1:-}"
+    [[ -n "$path" && -f "$path" ]] || die "from-file requires an existing file"
+
+    local payload
+    payload="$(render_payload_from_file "$path")"
+
+    local api_url
+    api_url="$(resolve_api_url)"
+    printf '%s' "$payload" |
+        curl_with_header -X POST \
+            -H 'content-type: application/json' \
+            --data-binary @- \
+            "$api_url/api/v1/announcements" |
+        pretty_json
+}
+
+# ---------- JSON builders ----------
+
+pretty_json() {
+    if command -v jq >/dev/null 2>&1; then
+        jq .
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 -m json.tool --no-ensure-ascii 2>/dev/null || python3 -m json.tool
+    else
+        cat
+    fi
+}
+
+build_payload_json() {
+    # Delegates to Python for safe JSON escaping without depending on jq.
+    python3 - "$@" <<'PY'
+import json
+import sys
+
+(_, id_, type_, severity, ends_at,
+ title_zh, title_en, body_zh, body_en,
+ starts_at, scheduled_update_at, dismissible) = sys.argv
+
+payload = {
+    "id": id_,
+    "type": type_,
+    "severity": severity,
+    "title": {
+        "zh": title_zh or None,
+        "en": title_en or None,
+    },
+    "body": {
+        "zh": body_zh or None,
+        "en": body_en or None,
+    },
+    "ends_at": ends_at,
+}
+if starts_at:
+    payload["starts_at"] = starts_at
+if scheduled_update_at:
+    payload["scheduled_update_at"] = scheduled_update_at
+if dismissible:
+    if dismissible.lower() in ("true", "1", "yes"):
+        payload["dismissible"] = True
+    elif dismissible.lower() in ("false", "0", "no"):
+        payload["dismissible"] = False
+    else:
+        sys.exit(f"invalid --dismissible: {dismissible}")
+
+print(json.dumps(payload, ensure_ascii=False))
+PY
+}
+
+render_payload_from_file() {
+    local path="$1"
+    python3 - "$path" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "rb") as fh:
+    raw = fh.read()
+
+data = None
+ext = path.lower().rsplit(".", 1)[-1] if "." in path else ""
+if ext in ("yaml", "yml"):
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        sys.exit(
+            "ERROR: PyYAML is required for YAML input — "
+            "install it with `pip install pyyaml` or convert to JSON."
+        )
+    data = yaml.safe_load(raw)
+else:
+    data = json.loads(raw)
+
+if not isinstance(data, dict):
+    sys.exit("ERROR: announcement payload must be a JSON/YAML object")
+
+# Normalize title/body helpers: accept flat title_zh / title_en too.
+def merge_lang(obj, key):
+    obj.setdefault(key, {})
+    zh = obj.pop(f"{key}_zh", None)
+    en = obj.pop(f"{key}_en", None)
+    if zh is not None:
+        obj[key]["zh"] = zh
+    if en is not None:
+        obj[key]["en"] = en
+
+merge_lang(data, "title")
+merge_lang(data, "body")
+
+print(json.dumps(data, ensure_ascii=False))
+PY
+}
+
+# ---------- Entry ----------
+
+main() {
+    require_cmd curl
+    require_cmd python3
+
+    local cmd="${1:-}"
+    case "$cmd" in
+        list)           shift; cmd_list "$@";;
+        create)         shift; cmd_create "$@";;
+        delete)         shift; cmd_delete "$@";;
+        from-file)      shift; cmd_from_file "$@";;
+        -h|--help|help) sub_usage;;
+        "")             sub_usage;;
+        *)              die "unknown command: $cmd (try --help)";;
+    esac
+}
+
+main "$@"

--- a/web/backend/CMakeLists.txt
+++ b/web/backend/CMakeLists.txt
@@ -64,8 +64,10 @@ set(CHROMAPRINT3D_BACKEND_LIBRARY_SOURCES
     src/application/matting_vectorize_service.cpp
     src/application/recipe_editor_service.cpp
     src/application/server_facade.cpp
+    src/application/announcement_service.cpp
     src/presentation/backend_runtime.cpp
     src/presentation/cors_advice.cpp
+    src/presentation/announcement_auth_advice.cpp
     src/presentation/api_v1_controller.cpp)
 
 if(TARGET Drogon::Drogon)

--- a/web/backend/server_main.cpp
+++ b/web/backend/server_main.cpp
@@ -1,5 +1,6 @@
 #include "application/server_facade.h"
 #include "config/server_config.h"
+#include "presentation/announcement_auth_advice.h"
 #include "presentation/backend_runtime.h"
 #include "presentation/cors_advice.h"
 
@@ -17,6 +18,7 @@ int main(int argc, char** argv) {
     using chromaprint3d::backend::BuildUsage;
     using chromaprint3d::backend::InitBackendRuntime;
     using chromaprint3d::backend::ParseConfig;
+    using chromaprint3d::backend::RegisterAnnouncementAuthAdvice;
     using chromaprint3d::backend::RegisterCorsAdvice;
     using chromaprint3d::backend::ServerFacade;
 
@@ -44,6 +46,13 @@ int main(int argc, char** argv) {
         auto facade = std::make_shared<ServerFacade>(cfg);
         InitBackendRuntime(facade);
         RegisterCorsAdvice(cfg);
+        RegisterAnnouncementAuthAdvice(cfg);
+        if (cfg.announcement_token.empty()) {
+            spdlog::info("Announcement write routes disabled (no --announcement-token configured)");
+        } else {
+            spdlog::info("Announcement write routes enabled; allow_http={}",
+                         cfg.announcement_allow_http ? "true" : "false");
+        }
 
         auto upload_dir = std::filesystem::temp_directory_path() / "chromaprint3d_uploads";
         std::filesystem::create_directories(upload_dir);

--- a/web/backend/src/application/announcement_service.cpp
+++ b/web/backend/src/application/announcement_service.cpp
@@ -1,0 +1,516 @@
+#include "application/announcement_service.h"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <mutex>
+#include <regex>
+#include <sstream>
+#include <system_error>
+
+namespace chromaprint3d::backend {
+namespace {
+
+using json       = nlohmann::json;
+using clock_type = std::chrono::system_clock;
+
+constexpr std::size_t kMaxFileBytes      = 1024 * 1024; // 1 MB
+constexpr std::size_t kMaxTextFieldBytes = 2000;
+constexpr const char* kAnnouncementsFile = "announcements.json";
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+bool IsAllowedType(const std::string& s) {
+    return s == "info" || s == "warning" || s == "maintenance";
+}
+
+bool IsAllowedSeverity(const std::string& s) {
+    return s == "info" || s == "warning" || s == "error";
+}
+
+int SeverityRank(const std::string& s) {
+    if (s == "error") return 3;
+    if (s == "warning") return 2;
+    return 1; // info
+}
+
+std::optional<std::string> OptionalString(const json& obj, const std::string& key) {
+    if (!obj.contains(key) || obj[key].is_null()) return std::nullopt;
+    if (!obj[key].is_string()) return std::nullopt;
+    auto value = obj[key].get<std::string>();
+    if (value.empty()) return std::nullopt;
+    return value;
+}
+
+bool StringLengthWithinLimit(const std::optional<std::string>& s, std::size_t limit) {
+    if (!s) return true;
+    return s->size() <= limit;
+}
+
+// ---------------------------------------------------------------------------
+// Content hash (FNV-1a 64, printed as 8-hex prefix)
+//
+// Choice rationale: the hash is a *change detector* used by health() so
+// the frontend can refetch. It does not need cryptographic strength. FNV-1a
+// is stable, dependency-free and cheap.
+// ---------------------------------------------------------------------------
+
+std::string Fnv1a64Hex(const std::string& data) {
+    constexpr std::uint64_t kOffset = 1469598103934665603ULL;
+    constexpr std::uint64_t kPrime  = 1099511628211ULL;
+
+    std::uint64_t h = kOffset;
+    for (char c : data) {
+        h ^= static_cast<std::uint64_t>(static_cast<unsigned char>(c));
+        h *= kPrime;
+    }
+
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::array<char, 8> out{};
+    // Take the top 32 bits of the 64-bit hash and render as 8 hex chars.
+    const std::uint32_t top = static_cast<std::uint32_t>(h >> 32);
+    for (int i = 0; i < 8; ++i) { out[7 - i] = kHex[(top >> (i * 4)) & 0x0F]; }
+    return std::string(out.data(), out.size());
+}
+
+// ---------------------------------------------------------------------------
+// Wire format helpers
+// ---------------------------------------------------------------------------
+
+void WriteOptional(json& out, const std::string& key, const std::optional<std::string>& value) {
+    if (value)
+        out[key] = *value;
+    else
+        out[key] = nullptr;
+}
+
+// Canonicalize ordering for hashing so hash only changes when content changes.
+// Sort by id, then emit each record with the same key order.
+std::string CanonicalJsonForHash(const std::vector<Announcement>& items) {
+    std::vector<Announcement> sorted = items;
+    std::sort(sorted.begin(), sorted.end(),
+              [](const Announcement& a, const Announcement& b) { return a.id < b.id; });
+
+    json arr = json::array();
+    for (const auto& a : sorted) arr.push_back(AnnouncementService::ToWireJson(a));
+    // nlohmann's dump keeps insertion order for objects; we pass the same
+    // ToWireJson helper used by the wire format to keep both paths in sync.
+    return arr.dump();
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O helpers
+// ---------------------------------------------------------------------------
+
+std::optional<json> ReadJsonFile(const std::filesystem::path& path, std::size_t max_bytes) {
+    std::error_code ec;
+    const auto size = std::filesystem::file_size(path, ec);
+    if (ec) return std::nullopt;
+    if (size > max_bytes) {
+        spdlog::warn("announcements: {} exceeds size limit ({} > {}); treating as empty",
+                     path.string(), size, max_bytes);
+        return std::nullopt;
+    }
+
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return std::nullopt;
+    std::ostringstream buf;
+    buf << in.rdbuf();
+    try {
+        return json::parse(buf.str());
+    } catch (const std::exception& e) {
+        spdlog::warn("announcements: parse failed for {}: {}", path.string(), e.what());
+        return std::nullopt;
+    }
+}
+
+bool WriteJsonFileAtomic(const std::filesystem::path& path, const json& value) {
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec) {
+        spdlog::error("announcements: cannot create parent dir for {}: {}", path.string(),
+                      ec.message());
+        return false;
+    }
+
+    auto tmp = path;
+    tmp += ".tmp";
+    {
+        std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            spdlog::error("announcements: failed to open {} for writing", tmp.string());
+            return false;
+        }
+        out << value.dump(2);
+        out.flush();
+    }
+    std::filesystem::rename(tmp, path, ec);
+    if (ec) {
+        spdlog::error("announcements: rename {} → {} failed: {}", tmp.string(), path.string(),
+                      ec.message());
+        std::filesystem::remove(tmp, ec);
+        return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Announcement <-> JSON (on disk mirrors the wire format)
+// ---------------------------------------------------------------------------
+
+std::optional<Announcement> AnnouncementFromJson(const json& j, std::string& error_out) {
+    if (!j.is_object()) {
+        error_out = "entry is not an object";
+        return std::nullopt;
+    }
+    Announcement a;
+    try {
+        a.id                  = j.value("id", std::string{});
+        a.type                = j.value("type", std::string{});
+        a.severity            = j.value("severity", std::string{});
+        a.title_zh            = OptionalString(j.value("title", json::object()), "zh");
+        a.title_en            = OptionalString(j.value("title", json::object()), "en");
+        a.body_zh             = OptionalString(j.value("body", json::object()), "zh");
+        a.body_en             = OptionalString(j.value("body", json::object()), "en");
+        a.starts_at           = OptionalString(j, "starts_at");
+        a.ends_at             = j.value("ends_at", std::string{});
+        a.scheduled_update_at = OptionalString(j, "scheduled_update_at");
+        a.dismissible         = j.value("dismissible", true);
+        a.created_at          = j.value("created_at", std::string{});
+        a.updated_at          = j.value("updated_at", std::string{});
+    } catch (const std::exception& e) {
+        error_out = std::string("bad entry: ") + e.what();
+        return std::nullopt;
+    }
+    return a;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Public statics
+// ---------------------------------------------------------------------------
+
+std::string AnnouncementService::FormatIso8601Utc(clock_type::time_point tp) {
+    const auto time = clock_type::to_time_t(tp);
+    std::tm tm{};
+#if defined(_WIN32)
+    gmtime_s(&tm, &time);
+#else
+    gmtime_r(&time, &tm);
+#endif
+    std::array<char, 32> buf{};
+    std::strftime(buf.data(), buf.size(), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return std::string(buf.data());
+}
+
+bool AnnouncementService::IsValidIso8601Utc(const std::string& s) {
+    static const std::regex kPattern(R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$)");
+    return std::regex_match(s, kPattern);
+}
+
+bool AnnouncementService::IsValidId(const std::string& id) {
+    static const std::regex kPattern(R"(^[a-zA-Z0-9_-]{1,64}$)");
+    return std::regex_match(id, kPattern);
+}
+
+json AnnouncementService::ToWireJson(const Announcement& a) {
+    json out;
+    out["id"]       = a.id;
+    out["type"]     = a.type;
+    out["severity"] = a.severity;
+
+    json title = json::object();
+    WriteOptional(title, "zh", a.title_zh);
+    WriteOptional(title, "en", a.title_en);
+    out["title"] = std::move(title);
+
+    json body = json::object();
+    WriteOptional(body, "zh", a.body_zh);
+    WriteOptional(body, "en", a.body_en);
+    out["body"] = std::move(body);
+
+    WriteOptional(out, "starts_at", a.starts_at);
+    out["ends_at"] = a.ends_at;
+    WriteOptional(out, "scheduled_update_at", a.scheduled_update_at);
+
+    out["dismissible"] = a.dismissible;
+    out["created_at"]  = a.created_at;
+    out["updated_at"]  = a.updated_at;
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Construction / state
+// ---------------------------------------------------------------------------
+
+AnnouncementService::AnnouncementService(std::filesystem::path data_dir)
+    : data_dir_(std::move(data_dir)), data_file_(data_dir_ / kAnnouncementsFile) {
+    std::unique_lock lk(mtx_);
+    LoadFromDiskLocked();
+    RefreshVersionHashLocked();
+    spdlog::info("announcements: loaded {} entries from {}", state_.items.size(),
+                 data_file_.string());
+}
+
+void AnnouncementService::LoadFromDiskLocked() {
+    state_.items.clear();
+    if (!std::filesystem::exists(data_file_)) return;
+
+    auto parsed = ReadJsonFile(data_file_, kMaxFileBytes);
+    if (!parsed) return;
+    if (!parsed->is_array()) {
+        spdlog::warn("announcements: {} is not a JSON array, ignoring", data_file_.string());
+        return;
+    }
+
+    for (const auto& entry : *parsed) {
+        std::string error;
+        auto parsed_entry = AnnouncementFromJson(entry, error);
+        if (!parsed_entry) {
+            spdlog::warn("announcements: skipping invalid entry: {}", error);
+            continue;
+        }
+        std::string validate_err;
+        if (!IsValidId(parsed_entry->id) || !IsAllowedType(parsed_entry->type) ||
+            !IsAllowedSeverity(parsed_entry->severity) ||
+            !IsValidIso8601Utc(parsed_entry->ends_at)) {
+            spdlog::warn("announcements: skipping entry '{}' failing schema",
+                         parsed_entry->id.empty() ? "<?>" : parsed_entry->id);
+            continue;
+        }
+        state_.items.push_back(std::move(*parsed_entry));
+    }
+}
+
+void AnnouncementService::PersistLocked() const {
+    json arr = json::array();
+    for (const auto& a : state_.items) arr.push_back(ToWireJson(a));
+    if (!WriteJsonFileAtomic(data_file_, arr)) {
+        spdlog::error("announcements: failed to persist {}", data_file_.string());
+    }
+}
+
+void AnnouncementService::RefreshVersionHashLocked() {
+    state_.version_hash = Fnv1a64Hex(CanonicalJsonForHash(state_.items));
+}
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+std::vector<Announcement> AnnouncementService::ListActive(clock_type::time_point now_utc) const {
+    const auto now = FormatIso8601Utc(now_utc);
+    std::shared_lock lk(mtx_);
+    std::vector<Announcement> out;
+    out.reserve(state_.items.size());
+    for (const auto& a : state_.items) {
+        if (a.starts_at && *a.starts_at > now) continue;
+        if (a.ends_at <= now) continue;
+        out.push_back(a);
+    }
+    std::sort(out.begin(), out.end(), [](const Announcement& a, const Announcement& b) {
+        const int ra = SeverityRank(a.severity);
+        const int rb = SeverityRank(b.severity);
+        if (ra != rb) return ra > rb;
+        return a.updated_at < b.updated_at;
+    });
+    return out;
+}
+
+std::vector<Announcement> AnnouncementService::ListActive() const {
+    return ListActive(clock_type::now());
+}
+
+std::size_t AnnouncementService::ActiveCount(clock_type::time_point now_utc) const {
+    return ListActive(now_utc).size();
+}
+
+std::size_t AnnouncementService::ActiveCount() const { return ActiveCount(clock_type::now()); }
+
+std::string AnnouncementService::VersionHash() const {
+    std::shared_lock lk(mtx_);
+    return state_.version_hash;
+}
+
+// ---------------------------------------------------------------------------
+// Upsert / Remove
+// ---------------------------------------------------------------------------
+
+std::optional<Announcement> AnnouncementService::ValidateAndBuild(const json& body,
+                                                                  std::string& error_out) const {
+    if (!body.is_object()) {
+        error_out = "body must be a JSON object";
+        return std::nullopt;
+    }
+
+    auto id = body.value("id", std::string{});
+    if (!IsValidId(id)) {
+        error_out = "id must match ^[a-zA-Z0-9_-]{1,64}$";
+        return std::nullopt;
+    }
+
+    auto type = body.value("type", std::string{});
+    if (!IsAllowedType(type)) {
+        error_out = "type must be one of: info, warning, maintenance";
+        return std::nullopt;
+    }
+
+    auto severity = body.value("severity", std::string{});
+    if (!IsAllowedSeverity(severity)) {
+        error_out = "severity must be one of: info, warning, error";
+        return std::nullopt;
+    }
+
+    auto title_zh = OptionalString(body.value("title", json::object()), "zh");
+    auto title_en = OptionalString(body.value("title", json::object()), "en");
+    if (!title_zh && !title_en) {
+        error_out = "title must be non-empty in at least one language";
+        return std::nullopt;
+    }
+    if (!StringLengthWithinLimit(title_zh, kMaxTextFieldBytes) ||
+        !StringLengthWithinLimit(title_en, kMaxTextFieldBytes)) {
+        error_out = "title exceeds 2000 characters";
+        return std::nullopt;
+    }
+
+    auto body_zh = OptionalString(body.value("body", json::object()), "zh");
+    auto body_en = OptionalString(body.value("body", json::object()), "en");
+    if (!body_zh && !body_en) {
+        error_out = "body must be non-empty in at least one language";
+        return std::nullopt;
+    }
+    if (!StringLengthWithinLimit(body_zh, kMaxTextFieldBytes) ||
+        !StringLengthWithinLimit(body_en, kMaxTextFieldBytes)) {
+        error_out = "body exceeds 2000 characters";
+        return std::nullopt;
+    }
+
+    auto starts_at = OptionalString(body, "starts_at");
+    if (starts_at && !IsValidIso8601Utc(*starts_at)) {
+        error_out = "starts_at must be an ISO8601 UTC string";
+        return std::nullopt;
+    }
+
+    auto ends_at = body.value("ends_at", std::string{});
+    if (ends_at.empty() || !IsValidIso8601Utc(ends_at)) {
+        error_out = "ends_at is required and must be an ISO8601 UTC string";
+        return std::nullopt;
+    }
+    const auto now_iso = FormatIso8601Utc(clock_type::now());
+    if (ends_at <= now_iso) {
+        error_out = "ends_at must be in the future";
+        return std::nullopt;
+    }
+    if (starts_at && *starts_at >= ends_at) {
+        error_out = "ends_at must be strictly later than starts_at";
+        return std::nullopt;
+    }
+
+    auto scheduled_update_at = OptionalString(body, "scheduled_update_at");
+    if (scheduled_update_at) {
+        if (!IsValidIso8601Utc(*scheduled_update_at)) {
+            error_out = "scheduled_update_at must be an ISO8601 UTC string";
+            return std::nullopt;
+        }
+        if (starts_at && *scheduled_update_at < *starts_at) {
+            error_out = "scheduled_update_at cannot be earlier than starts_at";
+            return std::nullopt;
+        }
+        if (*scheduled_update_at > ends_at) {
+            error_out = "scheduled_update_at cannot be later than ends_at";
+            return std::nullopt;
+        }
+    }
+
+    bool dismissible = true;
+    if (body.contains("dismissible")) {
+        if (!body["dismissible"].is_boolean()) {
+            error_out = "dismissible must be a boolean";
+            return std::nullopt;
+        }
+        dismissible = body["dismissible"].get<bool>();
+    }
+
+    Announcement a;
+    a.id                  = std::move(id);
+    a.type                = std::move(type);
+    a.severity            = std::move(severity);
+    a.title_zh            = std::move(title_zh);
+    a.title_en            = std::move(title_en);
+    a.body_zh             = std::move(body_zh);
+    a.body_en             = std::move(body_en);
+    a.starts_at           = std::move(starts_at);
+    a.ends_at             = std::move(ends_at);
+    a.scheduled_update_at = std::move(scheduled_update_at);
+    a.dismissible         = dismissible;
+    return a;
+}
+
+Announcement AnnouncementService::MergeForUpsert(const std::optional<Announcement>& existing,
+                                                 Announcement incoming,
+                                                 const std::string& now_iso) {
+    incoming.updated_at = now_iso;
+    if (existing && !existing->created_at.empty()) {
+        incoming.created_at = existing->created_at;
+    } else {
+        incoming.created_at = now_iso;
+    }
+    return incoming;
+}
+
+ServiceResult AnnouncementService::Upsert(const json& body) {
+    std::string error;
+    auto built = ValidateAndBuild(body, error);
+    if (!built) { return ServiceResult::Error(400, "invalid_announcement", error); }
+
+    const std::string target_id = built->id;
+    const auto now_iso          = FormatIso8601Utc(clock_type::now());
+
+    std::unique_lock lk(mtx_);
+    std::optional<Announcement> existing;
+    auto it = std::find_if(state_.items.begin(), state_.items.end(),
+                           [&](const Announcement& a) { return a.id == target_id; });
+    if (it != state_.items.end()) existing = *it;
+
+    auto merged = MergeForUpsert(existing, std::move(*built), now_iso);
+    if (it != state_.items.end()) {
+        *it = std::move(merged);
+    } else {
+        state_.items.push_back(std::move(merged));
+    }
+
+    RefreshVersionHashLocked();
+    PersistLocked();
+
+    const auto stored_it = std::find_if(state_.items.begin(), state_.items.end(),
+                                        [&](const Announcement& a) { return a.id == target_id; });
+    return ServiceResult::Success(200, {{"announcement", ToWireJson(*stored_it)},
+                                        {"announcements_version", state_.version_hash}});
+}
+
+ServiceResult AnnouncementService::Remove(const std::string& id) {
+    if (!IsValidId(id)) {
+        return ServiceResult::Error(400, "invalid_id", "id must match ^[a-zA-Z0-9_-]{1,64}$");
+    }
+
+    std::unique_lock lk(mtx_);
+    auto it = std::find_if(state_.items.begin(), state_.items.end(),
+                           [&](const Announcement& a) { return a.id == id; });
+    if (it == state_.items.end()) {
+        return ServiceResult::Error(404, "not_found", "announcement not found");
+    }
+    state_.items.erase(it);
+    RefreshVersionHashLocked();
+    PersistLocked();
+    return ServiceResult::Success(200, {{"announcements_version", state_.version_hash}});
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/announcement_service.h
+++ b/web/backend/src/application/announcement_service.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "application/service_result.h"
+
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <vector>
+
+namespace chromaprint3d::backend {
+
+// A user-facing announcement rendered by the frontend as a banner.
+//
+// Intentionally plain data + strings: every time field is the raw
+// ISO8601-UTC string supplied by the operator. All comparisons are done
+// as strings against a current-time string formatted by the service,
+// which gives total ordering without needing a UTC parser.
+struct Announcement {
+    std::string id;
+    std::string type;     // "info" | "warning" | "maintenance"
+    std::string severity; // "info" | "warning" | "error"
+
+    // Titles / bodies are bilingual. Both languages are optional; at
+    // least one of the two languages must be non-empty for title,
+    // and at least one for body.
+    std::optional<std::string> title_zh;
+    std::optional<std::string> title_en;
+    std::optional<std::string> body_zh;
+    std::optional<std::string> body_en;
+
+    std::optional<std::string> starts_at;
+    std::string ends_at;
+    std::optional<std::string> scheduled_update_at;
+    bool dismissible = true;
+
+    std::string created_at;
+    std::string updated_at;
+};
+
+// Thread-safe in-memory store backed by `${data_dir}/announcements.json`.
+// - Reads are lock-free-ish (shared mutex) and very fast.
+// - Writes are atomic: serialize → temp file → rename.
+// - Version hash is a stable 64-bit FNV-1a over the serialized JSON,
+//   surfaced as the first 8 hex chars; used by health to let the
+//   frontend detect changes.
+class AnnouncementService {
+public:
+    explicit AnnouncementService(std::filesystem::path data_dir);
+
+    AnnouncementService(const AnnouncementService&)            = delete;
+    AnnouncementService& operator=(const AnnouncementService&) = delete;
+
+    // Returns all announcements whose [starts_at, ends_at] window covers
+    // `now_utc`, sorted by severity (error > warning > info) then by
+    // updated_at ascending.
+    std::vector<Announcement> ListActive(std::chrono::system_clock::time_point now_utc) const;
+
+    // Convenience overload using the system clock.
+    std::vector<Announcement> ListActive() const;
+
+    // Insert (by id) or update (when an entry with the same id already
+    // exists). On update, created_at is preserved and updated_at is
+    // refreshed to "now". Returns 400 on schema validation errors.
+    ServiceResult Upsert(const nlohmann::json& body);
+
+    // Removes by id. Returns 404 when the id is not present.
+    ServiceResult Remove(const std::string& id);
+
+    // Stable 8-char hex content hash (FNV-1a over canonicalized JSON).
+    // Non-empty even when there are no announcements.
+    std::string VersionHash() const;
+
+    // Count of announcements active at the given time (used by Health()).
+    std::size_t ActiveCount(std::chrono::system_clock::time_point now_utc) const;
+    std::size_t ActiveCount() const;
+
+    // Returns the ISO8601-UTC string representation of `tp`.
+    static std::string FormatIso8601Utc(std::chrono::system_clock::time_point tp);
+
+    // Strict ISO8601-UTC validator: `YYYY-MM-DDTHH:MM:SS[.fraction]Z`.
+    static bool IsValidIso8601Utc(const std::string& s);
+
+    // `^[a-zA-Z0-9_-]{1,64}$`
+    static bool IsValidId(const std::string& id);
+
+    // Converts one announcement to the public JSON wire format.
+    static nlohmann::json ToWireJson(const Announcement& a);
+
+private:
+    struct State {
+        std::vector<Announcement> items;
+        std::string version_hash;
+    };
+
+    std::filesystem::path data_dir_;
+    std::filesystem::path data_file_;
+    mutable std::shared_mutex mtx_;
+    State state_;
+
+    // Re-serializes current items in canonical order and recomputes the
+    // FNV-1a hash. Caller must hold unique_lock.
+    void RefreshVersionHashLocked();
+
+    // Atomic disk persistence. Must be called under unique_lock.
+    void PersistLocked() const;
+
+    // Loads announcements from disk at construction time. Failures
+    // (missing file, parse errors, or per-entry validation errors) are
+    // logged and result in an empty list — the service must never
+    // prevent server startup.
+    void LoadFromDiskLocked();
+
+    // Validates `body` against the full schema. On success, returns a
+    // constructed Announcement with created_at/updated_at filled in. On
+    // failure, returns the error message in `error_out`.
+    std::optional<Announcement> ValidateAndBuild(const nlohmann::json& body,
+                                                 std::string& error_out) const;
+
+    // Merges created_at from an existing entry on upsert, so modifying
+    // the content preserves the original creation timestamp.
+    static Announcement MergeForUpsert(const std::optional<Announcement>& existing,
+                                       Announcement incoming, const std::string& now_iso);
+};
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -25,7 +25,8 @@ ServerFacade::ServerFacade(ServerConfig cfg)
               cfg_.board_geometry_cache_max),
       color_db_svc_(data_, sessions_), task_svc_(tasks_),
       convert_svc_(cfg_, data_, sessions_, tasks_), matting_svc_(cfg_, data_, tasks_),
-      recipe_svc_(data_, tasks_), calib_svc_(cfg_, data_, sessions_, boards_) {}
+      recipe_svc_(data_, tasks_), calib_svc_(cfg_, data_, sessions_, boards_),
+      announcement_svc_(cfg_.data_dir) {}
 
 std::string ServerFacade::EnsureSession(const std::optional<std::string>& existing_token,
                                         bool* created) {
@@ -56,13 +57,16 @@ ServiceResult ServerFacade::Health() const {
         {"allocator", ChromaPrint3D::AllocatorName()},
     };
 
-    return ServiceResult::Success(200, {
-                                           {"status", "ok"},
-                                           {"version", CHROMAPRINT3D_VERSION_STRING},
-                                           {"active_tasks", tasks_.ActiveTaskCount()},
-                                           {"total_tasks", tasks_.TotalTaskCount()},
-                                           {"memory", std::move(memory)},
-                                       });
+    return ServiceResult::Success(
+        200, {
+                 {"status", "ok"},
+                 {"version", CHROMAPRINT3D_VERSION_STRING},
+                 {"active_tasks", tasks_.ActiveTaskCount()},
+                 {"total_tasks", tasks_.TotalTaskCount()},
+                 {"memory", std::move(memory)},
+                 {"announcements_version", announcement_svc_.VersionHash()},
+                 {"active_announcement_count", announcement_svc_.ActiveCount()},
+             });
 }
 
 ServiceResult ServerFacade::ConvertDefaults() const {
@@ -339,6 +343,29 @@ ServiceResult ServerFacade::BuildColorDb(const std::string& owner,
                                          const std::string& meta_json, const std::string& db_name,
                                          const std::string& corners_json) {
     return calib_svc_.BuildColorDb(owner, image, meta_json, db_name, corners_json);
+}
+
+// ---------------------------------------------------------------------------
+// Announcements delegation
+// ---------------------------------------------------------------------------
+
+ServiceResult ServerFacade::ListAnnouncements() const {
+    const auto items = announcement_svc_.ListActive();
+    json arr         = json::array();
+    for (const auto& a : items) { arr.push_back(AnnouncementService::ToWireJson(a)); }
+    return ServiceResult::Success(200,
+                                  {
+                                      {"announcements", std::move(arr)},
+                                      {"announcements_version", announcement_svc_.VersionHash()},
+                                  });
+}
+
+ServiceResult ServerFacade::UpsertAnnouncement(const nlohmann::json& body) {
+    return announcement_svc_.Upsert(body);
+}
+
+ServiceResult ServerFacade::DeleteAnnouncement(const std::string& id) {
+    return announcement_svc_.Remove(id);
 }
 
 } // namespace chromaprint3d::backend

--- a/web/backend/src/application/server_facade.h
+++ b/web/backend/src/application/server_facade.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "application/announcement_service.h"
 #include "application/calibration_service.h"
 #include "application/color_db_service.h"
 #include "application/convert_service.h"
@@ -101,6 +102,11 @@ public:
                                const std::string& meta_json, const std::string& db_name,
                                const std::string& corners_json = "");
 
+    // Announcements (public read, token-guarded writes).
+    ServiceResult ListAnnouncements() const;
+    ServiceResult UpsertAnnouncement(const nlohmann::json& body);
+    ServiceResult DeleteAnnouncement(const std::string& id);
+
 private:
     ServerConfig cfg_;
     DataRepository data_;
@@ -114,6 +120,7 @@ private:
     MattingVectorizeService matting_svc_;
     RecipeEditorService recipe_svc_;
     CalibrationService calib_svc_;
+    AnnouncementService announcement_svc_;
 };
 
 } // namespace chromaprint3d::backend

--- a/web/backend/src/config/server_config.cpp
+++ b/web/backend/src/config/server_config.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -74,6 +75,11 @@ std::string BuildUsage(const char* exe_name) {
         << "  --board-cache-ttl N         Calibration board cache TTL seconds (default: 600)\n"
         << "  --board-geometry-cache-ttl N Board geometry cache TTL seconds (default: 600)\n"
         << "  --board-geometry-cache-max N Max cached board geometries (default: 16)\n"
+        << "  --announcement-token TOKEN  Secret for writing announcements (overrides env\n"
+        << "                              CHROMAPRINT3D_ANNOUNCEMENT_TOKEN); when empty, the\n"
+        << "                              write routes return 404 and the feature is disabled\n"
+        << "  --announcement-allow-http BOOL  Allow non-HTTPS announcement writes (default: 0,\n"
+        << "                                  local debugging only)\n"
         << "  -h, --help                  Show this help\n";
     return oss.str();
 }
@@ -81,6 +87,12 @@ std::string BuildUsage(const char* exe_name) {
 ConfigParseResult ParseConfig(int argc, char** argv) {
     ConfigParseResult result;
     ServerConfig cfg;
+
+    // Seed announcement token from environment first; CLI overrides it below.
+    if (const char* env_token = std::getenv("CHROMAPRINT3D_ANNOUNCEMENT_TOKEN");
+        env_token != nullptr) {
+        cfg.announcement_token = env_token;
+    }
 
     std::unordered_map<std::string, std::int64_t*> i64_flags = {
         {"--max-upload-mb", &cfg.max_upload_mb},
@@ -152,6 +164,20 @@ ConfigParseResult ParseConfig(int argc, char** argv) {
                 return result;
             }
             cfg.require_cors_origin = parsed;
+            continue;
+        }
+        if (arg == "--announcement-token") {
+            cfg.announcement_token = value;
+            continue;
+        }
+        if (arg == "--announcement-allow-http") {
+            bool parsed = false;
+            if (!ParseBool(value, parsed)) {
+                result.error_message =
+                    "Invalid boolean value for --announcement-allow-http: " + value;
+                return result;
+            }
+            cfg.announcement_allow_http = parsed;
             continue;
         }
 

--- a/web/backend/src/config/server_config.h
+++ b/web/backend/src/config/server_config.h
@@ -33,6 +33,15 @@ struct ServerConfig {
     std::int64_t board_geometry_cache_max = 16;
     bool require_cors_origin              = false;
     bool allow_open_cors                  = true;
+
+    // Announcement system: a shared secret that guards POST/DELETE on
+    // /api/v1/announcements. When empty, write routes return 404 (not 401) so
+    // that servers without the feature enabled do not leak route existence.
+    // Precedence: CLI --announcement-token > CHROMAPRINT3D_ANNOUNCEMENT_TOKEN env.
+    std::string announcement_token;
+    // When false (default) the auth advice rejects non-HTTPS announcement
+    // writes. Set via --announcement-allow-http for local debugging only.
+    bool announcement_allow_http = false;
 };
 
 struct ConfigParseResult {

--- a/web/backend/src/presentation/announcement_auth_advice.cpp
+++ b/web/backend/src/presentation/announcement_auth_advice.cpp
@@ -1,0 +1,135 @@
+#include "presentation/announcement_auth_advice.h"
+
+#include <drogon/drogon.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+namespace chromaprint3d::backend {
+namespace {
+
+constexpr const char* kAnnouncementTokenHeader      = "x-announcement-token";
+constexpr std::string_view kAnnouncementsPathPrefix = "/api/v1/announcements";
+
+bool IsAnnouncementsWritePath(std::string_view path) {
+    // Matches /api/v1/announcements and /api/v1/announcements/<id>
+    if (path != kAnnouncementsPathPrefix &&
+        path.rfind(std::string(kAnnouncementsPathPrefix) + "/", 0) != 0) {
+        return false;
+    }
+    return true;
+}
+
+bool IsWriteMethod(drogon::HttpMethod method) {
+    return method == drogon::Post || method == drogon::Delete;
+}
+
+bool ConstantTimeEquals(const std::string& a, const std::string& b) {
+    if (a.size() != b.size()) return false;
+    unsigned char diff = 0;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        diff |= static_cast<unsigned char>(a[i]) ^ static_cast<unsigned char>(b[i]);
+    }
+    return diff == 0;
+}
+
+bool IsSecureTransport(const drogon::HttpRequestPtr& req) {
+    if (req->isOnSecureConnection()) return true;
+    const auto& fwd = req->getHeader("x-forwarded-proto");
+    if (!fwd.empty()) {
+        // Lowercase compare — Nginx typically sends "https".
+        std::string lowered;
+        lowered.reserve(fwd.size());
+        std::transform(fwd.begin(), fwd.end(), std::back_inserter(lowered),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (lowered == "https") return true;
+    }
+    // Accept requests coming from loopback even over plain HTTP: deployment
+    // always terminates TLS at Nginx so 127.0.0.1 traffic is the only legit
+    // plain-HTTP source (e.g. the backend's own probes).
+    if (req->peerAddr().isLoopbackIp()) return true;
+    return false;
+}
+
+drogon::HttpResponsePtr BuildJsonResponse(drogon::HttpStatusCode status, const std::string& code,
+                                          const std::string& message) {
+    nlohmann::json body = {
+        {"ok", false},
+        {"error", {{"code", code}, {"message", message}}},
+    };
+    auto resp = drogon::HttpResponse::newHttpResponse();
+    resp->setStatusCode(status);
+    resp->setBody(body.dump());
+    resp->setContentTypeString("application/json; charset=utf-8");
+    return resp;
+}
+
+drogon::HttpResponsePtr BuildDisabledResponse() {
+    // When the feature is disabled we deliberately return 404 with a
+    // generic payload so that external probes cannot distinguish a server
+    // without the announcement feature from one with an unauthenticated
+    // request to an existing endpoint.
+    return BuildJsonResponse(drogon::k404NotFound, "not_found", "Not Found");
+}
+
+} // namespace
+
+void RegisterAnnouncementAuthAdvice(const ServerConfig& cfg) {
+    auto& app = drogon::app();
+
+    const std::string token_copy = cfg.announcement_token;
+    const bool allow_http        = cfg.announcement_allow_http;
+
+    app.registerPreRoutingAdvice([token_copy, allow_http](const drogon::HttpRequestPtr& req,
+                                                          drogon::AdviceCallback&& acb,
+                                                          drogon::AdviceChainCallback&& ccb) {
+        const auto& path = req->path();
+        if (!IsAnnouncementsWritePath(path)) {
+            ccb();
+            return;
+        }
+        if (!IsWriteMethod(req->method())) {
+            // GET / OPTIONS fall through to the controller (public read).
+            ccb();
+            return;
+        }
+
+        if (token_copy.empty()) {
+            acb(BuildDisabledResponse());
+            return;
+        }
+
+        if (!allow_http && !IsSecureTransport(req)) {
+            acb(BuildJsonResponse(drogon::k403Forbidden, "insecure_transport",
+                                  "Announcement writes require HTTPS"));
+            return;
+        }
+
+        if (req->method() == drogon::Post) {
+            const auto body = req->body();
+            if (body.size() > kAnnouncementMaxBodyBytes) {
+                acb(BuildJsonResponse(drogon::k413RequestEntityTooLarge, "payload_too_large",
+                                      "Announcement body exceeds 16KB"));
+                return;
+            }
+        }
+
+        const auto provided = std::string(req->getHeader(kAnnouncementTokenHeader));
+        if (provided.empty()) {
+            acb(BuildJsonResponse(drogon::k401Unauthorized, "unauthorized",
+                                  "Missing announcement token"));
+            return;
+        }
+        if (!ConstantTimeEquals(provided, token_copy)) {
+            acb(BuildJsonResponse(drogon::k401Unauthorized, "unauthorized",
+                                  "Invalid announcement token"));
+            return;
+        }
+
+        ccb();
+    });
+}
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/presentation/announcement_auth_advice.h
+++ b/web/backend/src/presentation/announcement_auth_advice.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "config/server_config.h"
+
+#include <cstddef>
+
+namespace chromaprint3d::backend {
+
+// Maximum accepted POST body for /api/v1/announcements (16 KB).
+// Chosen deliberately small — announcements are plain-text summaries,
+// not user artifacts. Larger bodies are rejected with 413 to prevent
+// abuse of the public announcement endpoint by an attacker who gained
+// access to the announcement token.
+inline constexpr std::size_t kAnnouncementMaxBodyBytes = 16 * 1024;
+
+// Registers a Drogon pre-routing advice that guards POST and DELETE on
+// /api/v1/announcements. Behavior summary:
+//   * GET  is always allowed (public read path).
+//   * POST/DELETE without a configured --announcement-token → 404
+//     (not 401) so servers without the feature enabled do not leak
+//     route existence.
+//   * POST/DELETE over plain HTTP (X-Forwarded-Proto != https) are
+//     rejected with 403 unless --announcement-allow-http is enabled
+//     for local debugging.
+//   * Token comparison is constant-time.
+//   * POST bodies larger than kAnnouncementMaxBodyBytes are rejected
+//     with 413.
+//
+// No dev/debug bypass exists on purpose. This repository is open source
+// and the security model assumes the auth flow is public; secrecy lives
+// in the token plus a mandatory Nginx IP allowlist in deployment.
+void RegisterAnnouncementAuthAdvice(const ServerConfig& cfg);
+
+} // namespace chromaprint3d::backend

--- a/web/backend/src/presentation/api_v1_controller.cpp
+++ b/web/backend/src/presentation/api_v1_controller.cpp
@@ -521,6 +521,31 @@ void ApiV1Controller::BuildColorDb(const drogon::HttpRequestPtr& req, Callback&&
     ReplyJson(std::move(cb), result, created ? std::optional<std::string>(token) : std::nullopt);
 }
 
+void ApiV1Controller::ListAnnouncements(const drogon::HttpRequestPtr& /*req*/, Callback&& cb) {
+    ReplyJson(std::move(cb), Facade().ListAnnouncements());
+}
+
+void ApiV1Controller::UpsertAnnouncement(const drogon::HttpRequestPtr& req, Callback&& cb) {
+    nlohmann::json body;
+    try {
+        body = nlohmann::json::parse(req->body());
+    } catch (...) {
+        ReplyJson(std::move(cb), ServiceResult::Error(400, "invalid_json", "Expected JSON body"));
+        return;
+    }
+    if (!body.is_object()) {
+        ReplyJson(std::move(cb),
+                  ServiceResult::Error(400, "invalid_json", "Expected JSON object body"));
+        return;
+    }
+    ReplyJson(std::move(cb), Facade().UpsertAnnouncement(body));
+}
+
+void ApiV1Controller::DeleteAnnouncement(const drogon::HttpRequestPtr& /*req*/, Callback&& cb,
+                                         const std::string& id) {
+    ReplyJson(std::move(cb), Facade().DeleteAnnouncement(id));
+}
+
 void ApiV1Controller::ApplySessionCookie(const drogon::HttpResponsePtr& resp,
                                          const std::string& token) const {
     drogon::Cookie cookie("session", token);

--- a/web/backend/src/presentation/api_v1_controller.h
+++ b/web/backend/src/presentation/api_v1_controller.h
@@ -82,6 +82,11 @@ public:
                   drogon::Options);
     ADD_METHOD_TO(ApiV1Controller::BuildColorDb, "/api/v1/calibration/colordb", drogon::Post,
                   drogon::Options);
+
+    ADD_METHOD_TO(ApiV1Controller::ListAnnouncements, "/api/v1/announcements", drogon::Get,
+                  drogon::Options);
+    ADD_METHOD_TO(ApiV1Controller::UpsertAnnouncement, "/api/v1/announcements", drogon::Post);
+    ADD_METHOD_TO(ApiV1Controller::DeleteAnnouncement, "/api/v1/announcements/{1}", drogon::Delete);
     METHOD_LIST_END
 
     using Callback = std::function<void(const drogon::HttpResponsePtr&)>;
@@ -135,6 +140,11 @@ public:
     void DownloadBoardMeta(const drogon::HttpRequestPtr& req, Callback&& cb, const std::string& id);
     void LocateBoard(const drogon::HttpRequestPtr& req, Callback&& cb);
     void BuildColorDb(const drogon::HttpRequestPtr& req, Callback&& cb);
+
+    void ListAnnouncements(const drogon::HttpRequestPtr& req, Callback&& cb);
+    void UpsertAnnouncement(const drogon::HttpRequestPtr& req, Callback&& cb);
+    void DeleteAnnouncement(const drogon::HttpRequestPtr& req, Callback&& cb,
+                            const std::string& id);
 
 private:
     ServerFacade& Facade() const;

--- a/web/backend/tests/CMakeLists.txt
+++ b/web/backend/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     test_server_facade.cpp
-    test_task_runtime.cpp)
+    test_task_runtime.cpp
+    test_announcement_service.cpp)
 
 add_executable(chromaprint3d_backend_tests ${TEST_SOURCES})
 

--- a/web/backend/tests/test_announcement_service.cpp
+++ b/web/backend/tests/test_announcement_service.cpp
@@ -1,0 +1,393 @@
+#include <gtest/gtest.h>
+
+#include "application/announcement_service.h"
+
+#include <nlohmann/json.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace chromaprint3d::backend {
+namespace {
+
+using json       = nlohmann::json;
+using clock_type = std::chrono::system_clock;
+
+// Use a fresh temporary directory per test instance so PersistLocked() never
+// pollutes either CHROMAPRINT3D_TEST_DATA_DIR or another test's state.
+class TempDataDir {
+public:
+    TempDataDir() {
+        const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ =
+            std::filesystem::temp_directory_path() /
+            ("chromaprint3d_announce_" + std::to_string(now) + "_" + std::to_string(counter_++));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~TempDataDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path_, ec);
+    }
+
+    TempDataDir(const TempDataDir&)            = delete;
+    TempDataDir& operator=(const TempDataDir&) = delete;
+
+    const std::filesystem::path& path() const { return path_; }
+
+private:
+    static inline std::atomic<int> counter_{0};
+    std::filesystem::path path_;
+};
+
+std::string IsoShift(clock_type::time_point base, std::chrono::seconds delta) {
+    return AnnouncementService::FormatIso8601Utc(base + delta);
+}
+
+json MakeBaseAnnouncement(const std::string& id, const std::string& ends_at) {
+    return json{
+        {"id", id},
+        {"type", "info"},
+        {"severity", "info"},
+        {"title", {{"zh", "中文标题"}, {"en", "English Title"}}},
+        {"body", {{"zh", "中文正文"}, {"en", "English body"}}},
+        {"ends_at", ends_at},
+    };
+}
+
+} // namespace
+
+TEST(AnnouncementServiceValidation, RejectsInvalidIdFormat) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+    auto body          = MakeBaseAnnouncement("bad id with space", ends_at);
+
+    const auto res = svc.Upsert(body);
+    EXPECT_FALSE(res.ok);
+    EXPECT_EQ(res.status_code, 400);
+    EXPECT_EQ(res.code, "invalid_announcement");
+}
+
+TEST(AnnouncementServiceValidation, RejectsUnknownType) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+    auto body          = MakeBaseAnnouncement("hello", ends_at);
+    body["type"]       = "promotion";
+
+    const auto res = svc.Upsert(body);
+    EXPECT_FALSE(res.ok);
+    EXPECT_EQ(res.status_code, 400);
+}
+
+TEST(AnnouncementServiceValidation, RejectsEmptyBilingualTitle) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+    auto body          = MakeBaseAnnouncement("t1", ends_at);
+    body["title"]      = {{"zh", nullptr}, {"en", ""}};
+
+    const auto res = svc.Upsert(body);
+    EXPECT_FALSE(res.ok);
+}
+
+TEST(AnnouncementServiceValidation, RejectsPastEndsAt) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto past = IsoShift(clock_type::now(), std::chrono::seconds(-10));
+    auto body       = MakeBaseAnnouncement("past", past);
+
+    const auto res = svc.Upsert(body);
+    EXPECT_FALSE(res.ok);
+}
+
+TEST(AnnouncementServiceValidation, RejectsStartsAtAfterEndsAt) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto now    = clock_type::now();
+    auto body         = MakeBaseAnnouncement("swap", IsoShift(now, std::chrono::hours(1)));
+    body["starts_at"] = IsoShift(now, std::chrono::hours(2));
+
+    const auto res = svc.Upsert(body);
+    EXPECT_FALSE(res.ok);
+}
+
+TEST(AnnouncementServiceValidation, RejectsScheduledUpdateOutsideWindow) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto now    = clock_type::now();
+    auto body         = MakeBaseAnnouncement("sched", IsoShift(now, std::chrono::hours(2)));
+    body["starts_at"] = IsoShift(now, std::chrono::minutes(10));
+    body["scheduled_update_at"] = IsoShift(now, std::chrono::minutes(5));
+
+    const auto res = svc.Upsert(body);
+    EXPECT_FALSE(res.ok);
+}
+
+TEST(AnnouncementServiceWindow, ListActiveRespectsStartsAndEnds) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto now = clock_type::now();
+    {
+        auto body         = MakeBaseAnnouncement("a", IsoShift(now, std::chrono::hours(1)));
+        body["starts_at"] = IsoShift(now, std::chrono::hours(-1));
+        const auto r      = svc.Upsert(body);
+        ASSERT_TRUE(r.ok) << r.message;
+    }
+    {
+        auto body         = MakeBaseAnnouncement("b", IsoShift(now, std::chrono::hours(3)));
+        body["starts_at"] = IsoShift(now, std::chrono::hours(2));
+        const auto r      = svc.Upsert(body);
+        ASSERT_TRUE(r.ok) << r.message;
+    }
+
+    const auto visible_now = svc.ListActive(now);
+    ASSERT_EQ(visible_now.size(), 1u);
+    EXPECT_EQ(visible_now.front().id, "a");
+
+    const auto later         = now + std::chrono::hours(2) + std::chrono::minutes(5);
+    const auto visible_later = svc.ListActive(later);
+    ASSERT_EQ(visible_later.size(), 1u);
+    EXPECT_EQ(visible_later.front().id, "b");
+
+    const auto past         = now + std::chrono::hours(4);
+    const auto visible_past = svc.ListActive(past);
+    EXPECT_TRUE(visible_past.empty());
+}
+
+TEST(AnnouncementServiceWindow, ListActiveSortsBySeverityThenUpdatedAt) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto now = clock_type::now();
+    for (const auto& [id, sev] : std::vector<std::pair<std::string, std::string>>{
+             {"i1", "info"}, {"w1", "warning"}, {"e1", "error"}}) {
+        auto body        = MakeBaseAnnouncement(id, IsoShift(now, std::chrono::hours(1)));
+        body["severity"] = sev;
+        ASSERT_TRUE(svc.Upsert(body).ok);
+    }
+
+    const auto list = svc.ListActive(now);
+    ASSERT_EQ(list.size(), 3u);
+    EXPECT_EQ(list[0].severity, "error");
+    EXPECT_EQ(list[1].severity, "warning");
+    EXPECT_EQ(list[2].severity, "info");
+}
+
+TEST(AnnouncementServicePersistence, UpsertWritesAtomicFileAndReloads) {
+    TempDataDir dir;
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(2));
+
+    {
+        AnnouncementService svc(dir.path());
+        const auto res = svc.Upsert(MakeBaseAnnouncement("persist", ends_at));
+        ASSERT_TRUE(res.ok) << res.message;
+    }
+
+    const auto file = dir.path() / "announcements.json";
+    ASSERT_TRUE(std::filesystem::exists(file));
+
+    std::ifstream in(file);
+    ASSERT_TRUE(in.is_open());
+    const std::string content((std::istreambuf_iterator<char>(in)),
+                              std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("\"persist\""), std::string::npos);
+
+    // Reload should find the same entry.
+    {
+        AnnouncementService svc(dir.path());
+        const auto list = svc.ListActive();
+        ASSERT_EQ(list.size(), 1u);
+        EXPECT_EQ(list.front().id, "persist");
+    }
+}
+
+TEST(AnnouncementServicePersistence, RemoveDeletesFromFile) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(2));
+    ASSERT_TRUE(svc.Upsert(MakeBaseAnnouncement("gone", ends_at)).ok);
+
+    const auto remove = svc.Remove("gone");
+    EXPECT_TRUE(remove.ok);
+
+    const auto after = svc.Remove("gone");
+    EXPECT_FALSE(after.ok);
+    EXPECT_EQ(after.status_code, 404);
+
+    EXPECT_TRUE(svc.ListActive().empty());
+}
+
+TEST(AnnouncementServicePersistence, IgnoresCorruptJsonOnLoad) {
+    TempDataDir dir;
+    const auto file = dir.path() / "announcements.json";
+
+    {
+        std::ofstream out(file);
+        out << "{ not valid json";
+    }
+
+    AnnouncementService svc(dir.path());
+    EXPECT_TRUE(svc.ListActive().empty());
+}
+
+TEST(AnnouncementServicePersistence, SkipsEntriesFailingSchemaOnLoad) {
+    TempDataDir dir;
+    const auto file = dir.path() / "announcements.json";
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+    json good          = MakeBaseAnnouncement("good", ends_at);
+    good["created_at"] = AnnouncementService::FormatIso8601Utc(clock_type::now());
+    good["updated_at"] = good["created_at"];
+
+    json bad = MakeBaseAnnouncement("bad space", ends_at);
+    json arr = json::array();
+    arr.push_back(good);
+    arr.push_back(bad);
+
+    {
+        std::ofstream out(file);
+        out << arr.dump(2);
+    }
+
+    AnnouncementService svc(dir.path());
+    const auto list = svc.ListActive();
+    ASSERT_EQ(list.size(), 1u);
+    EXPECT_EQ(list.front().id, "good");
+}
+
+TEST(AnnouncementServiceVersionHash, ChangesOnContentDiffAndResetsOnEmpty) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+
+    const auto initial_hash = svc.VersionHash();
+    EXPECT_EQ(initial_hash.size(), 8u);
+
+    ASSERT_TRUE(svc.Upsert(MakeBaseAnnouncement("h1", ends_at)).ok);
+    const auto hash_after_first = svc.VersionHash();
+    EXPECT_NE(hash_after_first, initial_hash);
+
+    // Upserting a *different* announcement must change the hash.
+    auto other        = MakeBaseAnnouncement("h1", ends_at);
+    other["severity"] = "warning";
+    ASSERT_TRUE(svc.Upsert(other).ok);
+    // Hash must change because severity differs even if updated_at landed
+    // in the same 1-second window.
+    const auto hash_after_edit = svc.VersionHash();
+    EXPECT_NE(hash_after_edit, hash_after_first);
+
+    ASSERT_TRUE(svc.Remove("h1").ok);
+    const auto hash_empty = svc.VersionHash();
+    EXPECT_EQ(hash_empty, initial_hash);
+}
+
+TEST(AnnouncementServiceVersionHash, IdempotentWithinSameSecond) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+
+    ASSERT_TRUE(svc.Upsert(MakeBaseAnnouncement("same", ends_at)).ok);
+    const auto h1 = svc.VersionHash();
+    ASSERT_TRUE(svc.Upsert(MakeBaseAnnouncement("same", ends_at)).ok);
+    const auto h2 = svc.VersionHash();
+    EXPECT_EQ(h1, h2);
+}
+
+TEST(AnnouncementServiceVersionHash, ChangesAcrossSecondBoundaryOnReupsert) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+    ASSERT_TRUE(svc.Upsert(MakeBaseAnnouncement("tick", ends_at)).ok);
+    const auto h1 = svc.VersionHash();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    ASSERT_TRUE(svc.Upsert(MakeBaseAnnouncement("tick", ends_at)).ok);
+    const auto h2 = svc.VersionHash();
+    EXPECT_NE(h1, h2);
+}
+
+TEST(AnnouncementServiceVersionHash, StableAcrossReload) {
+    TempDataDir dir;
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+    std::string h1;
+    {
+        AnnouncementService svc(dir.path());
+        ASSERT_TRUE(svc.Upsert(MakeBaseAnnouncement("stable", ends_at)).ok);
+        h1 = svc.VersionHash();
+    }
+    {
+        AnnouncementService svc(dir.path());
+        EXPECT_EQ(svc.VersionHash(), h1);
+    }
+}
+
+TEST(AnnouncementServiceUpsert, PreservesCreatedAtOnUpdate) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(2));
+    const auto first   = svc.Upsert(MakeBaseAnnouncement("keep", ends_at));
+    ASSERT_TRUE(first.ok);
+    const auto created_first = first.data.at("announcement").at("created_at").get<std::string>();
+
+    // Small sleep so updated_at differs from created_at
+    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+
+    auto body         = MakeBaseAnnouncement("keep", ends_at);
+    body["severity"]  = "warning";
+    const auto second = svc.Upsert(body);
+    ASSERT_TRUE(second.ok);
+    const auto created_second = second.data.at("announcement").at("created_at").get<std::string>();
+    const auto updated_second = second.data.at("announcement").at("updated_at").get<std::string>();
+
+    EXPECT_EQ(created_first, created_second);
+    EXPECT_NE(updated_second, created_second);
+}
+
+TEST(AnnouncementServiceRemove, RejectsInvalidId) {
+    TempDataDir dir;
+    AnnouncementService svc(dir.path());
+
+    const auto res = svc.Remove("bad id");
+    EXPECT_FALSE(res.ok);
+    EXPECT_EQ(res.status_code, 400);
+}
+
+TEST(AnnouncementServiceIdValidator, AcceptsAndRejectsExpectedForms) {
+    EXPECT_TRUE(AnnouncementService::IsValidId("maint-2026-04-18"));
+    EXPECT_TRUE(AnnouncementService::IsValidId("A_B_c_1"));
+    EXPECT_FALSE(AnnouncementService::IsValidId(""));
+    EXPECT_FALSE(AnnouncementService::IsValidId("has space"));
+    EXPECT_FALSE(AnnouncementService::IsValidId("with.dot"));
+    EXPECT_FALSE(AnnouncementService::IsValidId(std::string(65, 'a')));
+}
+
+TEST(AnnouncementServiceIsoValidator, AcceptsAndRejectsExpectedForms) {
+    EXPECT_TRUE(AnnouncementService::IsValidIso8601Utc("2026-04-17T03:30:00Z"));
+    EXPECT_TRUE(AnnouncementService::IsValidIso8601Utc("2026-04-17T03:30:00.123Z"));
+    EXPECT_FALSE(AnnouncementService::IsValidIso8601Utc("2026-04-17 03:30:00Z"));
+    EXPECT_FALSE(AnnouncementService::IsValidIso8601Utc("2026-04-17T03:30:00+08:00"));
+    EXPECT_FALSE(AnnouncementService::IsValidIso8601Utc(""));
+}
+
+} // namespace chromaprint3d::backend

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -36,6 +36,7 @@ import VectorizePanel from './components/VectorizePanel.vue'
 import ColorDBBuildSection from './components/calibration/ColorDBBuildSection.vue'
 import ColorDBUploadSection from './components/calibration/ColorDBUploadSection.vue'
 import UpdateBanner from './components/UpdateBanner.vue'
+import AnnouncementBanner from './components/AnnouncementBanner.vue'
 import WhatsNewModal from './components/WhatsNewModal.vue'
 import CheckUpdateLink from './components/CheckUpdateLink.vue'
 import { darkThemeOverrides, lightThemeOverrides } from './theme'
@@ -250,6 +251,7 @@ function toggleLocale() {
 
         <NLayoutContent class="app-shell__content">
           <div class="app-shell__content-inner">
+            <AnnouncementBanner />
             <UpdateBanner />
             <WhatsNewModal />
             <div class="app-shell__announce">

--- a/web/frontend/src/api/announcements.ts
+++ b/web/frontend/src/api/announcements.ts
@@ -1,0 +1,6 @@
+import type { AnnouncementsResponse } from '../types'
+import { request } from './base'
+
+export async function fetchAnnouncements(): Promise<AnnouncementsResponse> {
+  return request<AnnouncementsResponse>('/api/v1/announcements')
+}

--- a/web/frontend/src/components/AnnouncementBanner.vue
+++ b/web/frontend/src/components/AnnouncementBanner.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NAlert, NSpace, NText, NButton } from 'naive-ui'
+import type { Announcement, AnnouncementSeverity, AnnouncementType } from '../types'
+import { useAnnouncements } from '../composables/useAnnouncements'
+
+const { t, locale } = useI18n()
+const announcements = useAnnouncements()
+
+const now = ref(Date.now())
+let tickTimer: number | null = null
+
+onMounted(async () => {
+  await announcements.initialize()
+  tickTimer = window.setInterval(() => {
+    now.value = Date.now()
+  }, 1000)
+})
+
+onBeforeUnmount(() => {
+  if (tickTimer !== null) {
+    window.clearInterval(tickTimer)
+    tickTimer = null
+  }
+})
+
+function severityToAlertType(
+  severity: AnnouncementSeverity,
+): 'info' | 'warning' | 'error' | 'default' {
+  if (severity === 'error') return 'error'
+  if (severity === 'warning') return 'warning'
+  return 'info'
+}
+
+function pickLocalized(zh: string | null, en: string | null): string {
+  const zhText = zh ?? ''
+  const enText = en ?? ''
+  if (locale.value === 'zh-CN') {
+    return zhText || enText
+  }
+  return enText || zhText
+}
+
+function titleFor(a: Announcement): string {
+  const picked = pickLocalized(a.title.zh, a.title.en)
+  if (picked) return picked
+  return t(`app.announcements.typeLabels.${a.type}` as const)
+}
+
+function bodyFor(a: Announcement): string {
+  return pickLocalized(a.body.zh, a.body.en)
+}
+
+// Plain-text split on newlines so the banner body supports bullet-style
+// messages while NEVER invoking v-html. URLs are intentionally NOT
+// auto-linkified — anchor rendering from untrusted content would be a
+// policy violation.
+function bodyLines(a: Announcement): string[] {
+  const text = bodyFor(a)
+  if (!text) return []
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function formatLocalizedTime(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  try {
+    return new Intl.DateTimeFormat(locale.value === 'zh-CN' ? 'zh-CN' : 'en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    }).format(date)
+  } catch {
+    return iso
+  }
+}
+
+function relativeLabel(targetMs: number): string {
+  const deltaSec = Math.round((targetMs - now.value) / 1000)
+  if (deltaSec <= 0) return t('app.announcements.relative.now')
+  if (deltaSec < 60) return t('app.announcements.relative.seconds', { count: deltaSec })
+  const deltaMin = Math.round(deltaSec / 60)
+  if (deltaMin < 60) return t('app.announcements.relative.minutes', { count: deltaMin })
+  const deltaHours = Math.round(deltaMin / 60)
+  if (deltaHours < 24) return t('app.announcements.relative.hours', { count: deltaHours })
+  const deltaDays = Math.round(deltaHours / 24)
+  return t('app.announcements.relative.days', { count: deltaDays })
+}
+
+function scheduledLine(a: Announcement): string | null {
+  if (!a.scheduled_update_at) return null
+  const ms = new Date(a.scheduled_update_at).getTime()
+  if (Number.isNaN(ms)) return null
+  const formatted = formatLocalizedTime(a.scheduled_update_at)
+  if (ms <= now.value) {
+    return t('app.announcements.scheduledUpdatePast', { time: formatted })
+  }
+  return t('app.announcements.scheduledUpdate', {
+    time: formatted,
+    relative: relativeLabel(ms),
+  })
+}
+
+type BannerType = 'info' | 'warning' | 'error' | 'default'
+
+interface Item {
+  id: string
+  alertType: BannerType
+  title: string
+  lines: string[]
+  scheduled: string | null
+  dismissible: boolean
+  kind: AnnouncementType
+}
+
+const items = computed<Item[]>(() =>
+  announcements.visible.value.map((a) => ({
+    id: a.id,
+    alertType: severityToAlertType(a.severity),
+    title: titleFor(a),
+    lines: bodyLines(a),
+    scheduled: scheduledLine(a),
+    dismissible: a.dismissible,
+    kind: a.type,
+  })),
+)
+
+async function handleDismiss(id: string) {
+  await announcements.dismiss(id)
+}
+</script>
+
+<template>
+  <div v-if="items.length > 0" class="announcement-banner">
+    <div v-for="item in items" :key="item.id" class="announcement-banner__item">
+      <NAlert :type="item.alertType" :show-icon="true" :bordered="false">
+        <template #header>
+          <span class="announcement-banner__title">{{ item.title }}</span>
+        </template>
+        <NSpace vertical :size="6">
+          <ul v-if="item.lines.length > 1" class="announcement-banner__lines">
+            <li v-for="(line, idx) in item.lines" :key="idx">
+              <NText depth="2">{{ line }}</NText>
+            </li>
+          </ul>
+          <NText v-else-if="item.lines.length === 1" depth="2">{{ item.lines[0] }}</NText>
+          <NText v-if="item.scheduled" depth="1" class="announcement-banner__scheduled">
+            {{ item.scheduled }}
+          </NText>
+          <NSpace v-if="item.dismissible">
+            <NButton size="small" quaternary @click="handleDismiss(item.id)">
+              {{ t('app.announcements.dismiss') }}
+            </NButton>
+          </NSpace>
+        </NSpace>
+      </NAlert>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.announcement-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.announcement-banner__title {
+  font-weight: 600;
+}
+
+.announcement-banner__lines {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.announcement-banner__lines li {
+  margin: 2px 0;
+}
+
+.announcement-banner__scheduled {
+  font-size: 12px;
+}
+</style>

--- a/web/frontend/src/composables/useAnnouncements.ts
+++ b/web/frontend/src/composables/useAnnouncements.ts
@@ -1,0 +1,134 @@
+import { computed, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { fetchAnnouncements } from '../api/announcements'
+import { useAppStore } from '../stores/app'
+import { getStorageItem, setStorageItem } from '../runtime/storage'
+import type { Announcement } from '../types'
+
+const DISMISS_STORAGE_KEY = 'chromaprint3d-dismissed-announcements'
+
+// Persisted as a JSON object: { [id]: updated_at }. We compare both the
+// id AND the updated_at so that editing the announcement's content
+// re-surfaces it for a user that had dismissed the previous revision.
+type DismissMap = Record<string, string>
+
+async function readDismissed(): Promise<DismissMap> {
+  const raw = await getStorageItem(DISMISS_STORAGE_KEY)
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const out: DismissMap = {}
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === 'string') out[k] = v
+      }
+      return out
+    }
+  } catch {
+    // Corrupt or legacy storage — throw it away silently.
+  }
+  return {}
+}
+
+async function writeDismissed(value: DismissMap): Promise<void> {
+  await setStorageItem(DISMISS_STORAGE_KEY, JSON.stringify(value))
+}
+
+let sharedState: ReturnType<typeof createAnnouncementsState> | null = null
+
+function createAnnouncementsState() {
+  const app = useAppStore()
+  const { announcementsVersion } = storeToRefs(app)
+
+  const announcements = ref<Announcement[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const dismissed = ref<DismissMap>({})
+  const lastLoadedVersion = ref<string | null>(null)
+  let hydrated = false
+
+  async function hydrateDismissed() {
+    if (hydrated) return
+    dismissed.value = await readDismissed()
+    hydrated = true
+  }
+
+  function isDismissed(a: Announcement): boolean {
+    if (!a.dismissible) return false
+    const prev = dismissed.value[a.id]
+    if (!prev) return false
+    return prev === a.updated_at
+  }
+
+  async function dismiss(id: string) {
+    const match = announcements.value.find((a) => a.id === id)
+    if (!match || !match.dismissible) return
+    dismissed.value = { ...dismissed.value, [id]: match.updated_at }
+    await writeDismissed(dismissed.value)
+  }
+
+  async function reload() {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await fetchAnnouncements()
+      announcements.value = res.announcements ?? []
+      lastLoadedVersion.value = res.announcements_version ?? ''
+      // Opportunistic compaction: drop dismiss entries for ids that no
+      // longer exist on the server so storage does not grow forever.
+      const active = new Set(announcements.value.map((a) => a.id))
+      let changed = false
+      const next: DismissMap = {}
+      for (const [id, ts] of Object.entries(dismissed.value)) {
+        if (active.has(id)) {
+          next[id] = ts
+        } else {
+          changed = true
+        }
+      }
+      if (changed) {
+        dismissed.value = next
+        await writeDismissed(next)
+      }
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Failed to load announcements'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function initialize() {
+    await hydrateDismissed()
+    await reload()
+  }
+
+  // Refetch when the health-reported version stamp actually changes.
+  watch(announcementsVersion, async (next, prev) => {
+    if (!next || next === prev) return
+    if (next === lastLoadedVersion.value) return
+    await reload()
+  })
+
+  const visible = computed(() => announcements.value.filter((a) => !isDismissed(a)))
+
+  return {
+    announcements,
+    visible,
+    loading,
+    error,
+    initialize,
+    reload,
+    dismiss,
+    isDismissed,
+  }
+}
+
+export function useAnnouncements() {
+  if (!sharedState) sharedState = createAnnouncementsState()
+  return sharedState
+}
+
+// Exposed for tests only — resets the module-level singleton.
+export function __resetAnnouncementsStateForTests() {
+  sharedState = null
+}

--- a/web/frontend/src/locales/en.ts
+++ b/web/frontend/src/locales/en.ts
@@ -65,6 +65,23 @@ export default {
       makerWorldLink: 'MakerWorld',
       makerWorldSuffix: '',
     },
+    announcements: {
+      dismiss: "Don't show again for this revision",
+      scheduledUpdate: 'Scheduled upgrade: {time} ({relative})',
+      scheduledUpdatePast: 'Scheduled upgrade: {time} (window active)',
+      relative: {
+        days: 'in {count} days',
+        hours: 'in {count} hours',
+        minutes: 'in {count} minutes',
+        seconds: 'in a few seconds',
+        now: 'starting soon',
+      },
+      typeLabels: {
+        info: 'Announcement',
+        warning: 'Attention',
+        maintenance: 'Maintenance notice',
+      },
+    },
     update: {
       newVersionAvailable: 'New version {version} is available',
       changelog: 'Changelog',

--- a/web/frontend/src/locales/zh-CN.ts
+++ b/web/frontend/src/locales/zh-CN.ts
@@ -93,6 +93,23 @@ export default {
       makerWorldLink: 'MakerWorld',
       makerWorldSuffix: '上查看我的打印作品',
     },
+    announcements: {
+      dismiss: '不再提醒此版本',
+      scheduledUpdate: '计划升级时间：{time}（{relative}）',
+      scheduledUpdatePast: '计划升级时间：{time}（已到升级窗口）',
+      relative: {
+        days: '{count} 天后',
+        hours: '{count} 小时后',
+        minutes: '{count} 分钟后',
+        seconds: '{count} 秒内',
+        now: '即将开始',
+      },
+      typeLabels: {
+        info: '公告',
+        warning: '注意',
+        maintenance: '维护通知',
+      },
+    },
     update: {
       newVersionAvailable: '新版本 {version} 已发布',
       changelog: '更新内容',

--- a/web/frontend/src/stores/app.ts
+++ b/web/frontend/src/stores/app.ts
@@ -30,6 +30,8 @@ export const useAppStore = defineStore('app', () => {
   const activeTasks = ref(0)
   const totalTasks = ref(0)
   const serverMemory = ref<HealthMemory | null>(null)
+  const announcementsVersion = ref('')
+  const activeAnnouncementCount = ref(0)
 
   const isDark = ref(false)
   const recipeEditorTaskId = ref<string | null>(null)
@@ -89,12 +91,18 @@ export const useAppStore = defineStore('app', () => {
       activeTasks.value = h.active_tasks ?? 0
       totalTasks.value = h.total_tasks ?? 0
       serverMemory.value = h.memory ?? null
+      announcementsVersion.value = h.announcements_version ?? ''
+      activeAnnouncementCount.value = h.active_announcement_count ?? 0
     } catch {
       serverOnline.value = false
       serverVersion.value = ''
       activeTasks.value = 0
       totalTasks.value = 0
       serverMemory.value = null
+      // Intentionally keep announcementsVersion / activeAnnouncementCount
+      // as-is on transient health failures: the banner hides when the
+      // active list is empty anyway, and we don't want every network blip
+      // to re-trigger a full announcements refetch.
     }
   }
 
@@ -142,6 +150,8 @@ export const useAppStore = defineStore('app', () => {
     activeTasks,
     totalTasks,
     serverMemory,
+    announcementsVersion,
+    activeAnnouncementCount,
     isDark,
     recipeEditorTaskId,
     setSelectedFile,

--- a/web/frontend/src/types.ts
+++ b/web/frontend/src/types.ts
@@ -236,6 +236,37 @@ export interface HealthResponse {
   active_tasks: number
   total_tasks: number
   memory?: HealthMemory
+  announcements_version?: string
+  active_announcement_count?: number
+}
+
+// ---- Announcements ----
+
+export type AnnouncementType = 'info' | 'warning' | 'maintenance'
+export type AnnouncementSeverity = 'info' | 'warning' | 'error'
+
+export interface AnnouncementText {
+  zh: string | null
+  en: string | null
+}
+
+export interface Announcement {
+  id: string
+  type: AnnouncementType
+  severity: AnnouncementSeverity
+  title: AnnouncementText
+  body: AnnouncementText
+  starts_at: string | null
+  ends_at: string
+  scheduled_update_at: string | null
+  dismissible: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface AnnouncementsResponse {
+  announcements: Announcement[]
+  announcements_version: string
 }
 
 // ---- Matting ----


### PR DESCRIPTION
## 背景与动机

网站用户已经分布在海内外，几乎每时每刻都有用户在线。直接重启服务做版本更新会导致用户丢失数据。

本 PR 新增一条"用户公告"通道：在后端、前端与运维脚本上完整打通，用于在升级/维护前以 banner 方式提前宣告，不打扰在线用户的任务，并允许他们主动"不再提醒"。

定时自动升级方案暂不纳入本 PR，仅完善公告系统本身。

## 主要改动

### 后端
- 新增 `AnnouncementService`（`web/backend/src/application/announcement_service.*`）
  - Schema 校验：id 正则、双语至少一种、ISO8601 UTC 时间窗口合法性
  - 原子持久化：`${data_dir}/announcements.json`，tmp + rename
  - 版本戳：FNV-1a 64 位截断到 8 位 hex，对比 JSON 序列化字节流，变化代表内容改动
  - 线程安全：`std::shared_mutex` 区分读写
- 新增前置 advice `announcement_auth_advice.*`
  - 写入需带 `x-announcement-token` 头（常量时间比较）+ HTTPS
  - 未配置 token 时 `POST/DELETE` 一律返回 `404 not_found`，避免功能指纹化
  - `--announcement-allow-http` 临时放宽，loopback 来源视为安全（适配 Nginx 本地反代架构）
  - `POST` 请求体 > 16 KiB 返回 `413 payload_too_large`
- 路由：`GET /api/v1/announcements`（公开）、`POST` / `DELETE /api/v1/announcements/{id}`（鉴权）
- `GET /api/v1/health` 返回 `announcements_version` / `active_announcement_count`
- 新参数：`--announcement-token`（或 `CHROMAPRINT3D_ANNOUNCEMENT_TOKEN` env）、`--announcement-allow-http`

### 前端
- 新增 `AnnouncementBanner.vue` + `useAnnouncements` composable
- dismiss 策略：`localStorage` 键 `chromaprint3d-dismissed-announcements`，形如 `{id: updated_at}`，内容更新会重新唤起
- 严格纯文本渲染，禁用 `v-html`，不做 URL 自动链接化（XSS 硬门）
- i18n：`app.announcements.*`（zh-CN / en 双份）
- `stores/app.ts` 新增 `announcementsVersion` / `activeAnnouncementCount` ref，供 composable watch

### 运维
- `scripts/announce.sh`：`list` / `create` / `delete` / `from-file`
  - token 走 `CHROMAPRINT3D_ANNOUNCEMENT_TOKEN` 或 `*_TOKEN_FILE`，不进 shell 历史
  - JSON/YAML payload 构建走 Python，避免 shell 转义陷阱
- 新增 skill：`.cursor/skills/publish-announcement/SKILL.md`，Agent 可辅助运营发布
- 新增任务手册：`docs/agents/tasks/publish_announcement.md`

### 安全加固
- `.gitignore`：忽略 `announcement.env` / `.chromaprint3d-announcement-token` / 本地草稿
- `.cursor/hooks/protect-secrets.sh`：`beforeReadFile` 阻止读取上述敏感文件
- CI 新增 `gitleaks` 作业 + `.gitleaks.toml`（自定义 token 规则 + 路径/占位符 allowlist）

### 文档
- `README.md` / `docs/development.md` / `docs/deployment.md` 全面同步契约、部署步骤、威胁模型
- `docs/agents/web/{backend,frontend}/README.md` 增加公告系统落点
- `AGENTS.md` 新增"发布/撤回运维公告"导航入口

## 验证结果

### 后端
- `cmake --build build -j$(nproc)` ✅
- `ctest --test-dir build` **189/189** 通过，含 15 个新增 `AnnouncementService*` 单测（id 正则、时间窗口、schema、原子写、跨进程 reload、hash 幂等/跨秒变化、`created_at` 保留等）

### 端到端（本地 `./build/bin/chromaprint3d_server`）
| 场景 | 预期 | 实测 |
|---|---|---|
| 未配置 token 时 `POST` / `DELETE` | `404 not_found` | ✅ |
| 配置 token：`POST` 缺头 | `401` | ✅ |
| 配置 token：`POST` 错 token | `401` | ✅ |
| 配置 token：`POST` 正确 | `200` + announcement + version | ✅ |
| 同内容同秒重复 `POST` | version 不变（幂等） | ✅ |
| 修改 body 后 `POST` | version 变化 + `created_at` 保留 | ✅ |
| body > 16 KiB | `413 payload_too_large` | ✅ |
| id 不匹配 regex | `400 invalid_announcement` | ✅ |
| `DELETE` 未知 id | `404 not_found` | ✅ |
| `announcements.json` 原子落盘 | 文件存在、格式正确 | ✅ |
| `X-Forwarded-Proto: https` 明文 HTTP | 允许通过 | ✅ |
| `scripts/announce.sh list/create/delete/from-file` | 全部通过 | ✅ |
| token 从 `*_TOKEN_FILE` 读取 | 正常 | ✅ |

### 前端
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run build` ✅（有 chunk size warning，与本 PR 无关）
- `npm run test`：vitest 因 master 上已存在的 `html-encoding-sniffer` ESM require 问题无法启动 worker，**非本次引入**（已通过 `git stash` 回切到 origin/master 复现确认）

### 安全
- 本地 `gitleaks detect --no-git --config=.gitleaks.toml` → `no leaks found`
- `.cursor/hooks/protect-secrets.sh` 手工触发验证：`.env` / `announcement.env` / `.chromaprint3d-announcement-token` 一律 `deny`，普通文件 `allow`

## 回滚策略

改动全部收敛在新路由 + 新组件；默认不启用（后端不传 `--announcement-token` 即 404 屏蔽）：
- 运维侧：停掉 `--announcement-token` 参数即可，前端老 health 字段 optional，未返回时前端 composable 静默
- 若需要彻底回滚，直接 revert 本 commit

## 后续 TODO（非本 PR）

- 定时自动升级能力（用户已明确暂缓）
- Banner 支持自动链接化（需引入 DOMPurify + 白名单策略）
- 运营后台 UI（目前只有 CLI）

## AI 协作信息

- Plan：见 `/home/neroued/.cursor/plans/公告与定时更新系统_85527340.plan.md`（本机路径）
- Skill：`.cursor/skills/publish-announcement/SKILL.md`
- 任务手册：`docs/agents/tasks/publish_announcement.md`