### PR TITLE
fix(announcements): allow dedicated writable dir via --announcements-dir

### DIFF
--- a/.cursor/skills/publish-announcement/SKILL.md
+++ b/.cursor/skills/publish-announcement/SKILL.md
@@ -10,7 +10,7 @@ description: Help the operator publish, list, and remove user-visible announceme
 公告是用户打开 ChromaPrint3D 时顶部看到的 banner，**面向海内外用户同时展示**。
 发布流程由后端 `/api/v1/announcements` 和 `scripts/announce.sh` 驱动：
 
-1. 后端存储：`${data_dir}/announcements.json`（原子写，单文件）
+1. 后端存储：默认 `${data_dir}/announcements.json`，若启动带 `--announcements-dir <PATH>` 则落到 `<PATH>/announcements.json`（原子写，单文件）
 2. 鉴权：所有写操作需要 `x-announcement-token` 头，且只能通过 HTTPS
 3. 前端：启动时拉取一次；`/api/v1/health` 携带 `announcements_version`，
    该值变化时前端自动重新拉取

--- a/docs/agents/tasks/publish_announcement.md
+++ b/docs/agents/tasks/publish_announcement.md
@@ -13,7 +13,7 @@
 - `scripts/announce.sh` — CLI 工具（list / create / delete / from-file）
 - `.cursor/skills/publish-announcement/SKILL.md` — Agent 协作 SOP
 - `docs/deployment.md#公告系统announcements` — 部署契约与 token 管理
-- 运行时数据：`${data_dir}/announcements.json`（后端原子写入，无需手改）
+- 运行时数据：`${announcements_dir:-${data_dir}}/announcements.json`（后端原子写入，无需手改）。`read_only: true` 容器必须通过 `--announcements-dir` 指向独立可写 bind mount。
 
 ## 前置条件
 

--- a/docs/agents/web/backend/README.md
+++ b/docs/agents/web/backend/README.md
@@ -76,9 +76,13 @@
   - `POST /api/v1/announcements`（需 `x-announcement-token` 头 + HTTPS + body ≤ 16KB）
   - `DELETE /api/v1/announcements/{id}`（需 token）
 - 鉴权：`presentation/announcement_auth_advice.cpp` 前置 advice，未配置 token 时写入路由统一返回 `404 not_found`；非 HTTPS 返回 `403 insecure_transport`；token 用常量时间比较。
-- 领域：`application/announcement_service.{h,cpp}` 提供 schema 校验（id 正则、双语至少一种、时间窗口合法）、原子持久化（`${data_dir}/announcements.json` 写 tmp + rename）、FNV-1a 版本戳、按严重度排序的有效列表。
-- Facade：`ServerFacade::ListAnnouncements/UpsertAnnouncement/DeleteAnnouncement` 三个方法。
-- 单测：`web/backend/tests/test_announcement_service.cpp` 覆盖 schema、时间窗口、原子写、版本戳、幂等与跨进程 reload。
+- 领域：`application/announcement_service.{h,cpp}` 提供 schema 校验（id 正则、双语至少一种、时间窗口合法）、原子持久化、FNV-1a 版本戳、按严重度排序的有效列表。
+- 存储目录：
+  - 默认：`${data_dir}/announcements.json`（向后兼容）
+  - 独立目录：启动附加 `--announcements-dir <PATH>`，写 `<PATH>/announcements.json`，用于 `read_only: true` 容器的独立可写卷场景。
+  - 构造 `AnnouncementService` 时自动 `create_directories`，并做 tmp + rename 原子写。
+- Facade：`ServerFacade` 构造时根据 `cfg.announcements_dir` 选择目录，否则回退 `cfg.data_dir`；对外暴露 `ListAnnouncements/UpsertAnnouncement/DeleteAnnouncement`。
+- 单测：`web/backend/tests/test_announcement_service.cpp` 覆盖 schema、时间窗口、原子写、版本戳、幂等、跨进程 reload、缺目录自建、独立目录持久化。
 - 详细契约与部署：[docs/development.md#543-health](../../../development.md)、[docs/deployment.md#公告系统announcements](../../../deployment.md)。
 
 ## 配方编辑器

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1003,19 +1003,39 @@ docker compose pull && docker compose up -d
    # ~/chromaprint3d-deploy/.env
    CHROMAPRINT3D_ANNOUNCEMENT_TOKEN=<上一步的 token>
    ```
-3. 修改 `docker-compose.yml` 的 `chromaprint3d` 服务：
+3. 在宿主机准备公告数据目录（路径任意，建议和 `data_dir` 分离，便于单独备份与挂载权限控制）：
+   ```bash
+   mkdir -p ~/chromaprint3d-deploy/data/announcements
+   chmod 700 ~/chromaprint3d-deploy/data/announcements
+   ```
+4. 修改 `docker-compose.yml` 的 `chromaprint3d` 服务。当容器根是 `read_only: true`（推荐）时，必须显式 bind-mount 一个可写卷作为公告目录，并用 `--announcements-dir` 指向容器内挂载点：
    ```yaml
+   services:
+     chromaprint3d:
+       # ... 其他保持不变 ...
+       read_only: true
        environment:
          - CHROMAPRINT3D_ANNOUNCEMENT_TOKEN=${CHROMAPRINT3D_ANNOUNCEMENT_TOKEN}
+       volumes:
+         # 公告持久化目录：映射到宿主，保证镜像重启 / 升级后公告不丢
+         - ./data/announcements:/app/data/announcements
+       tmpfs:
+         - /tmp
+         - /app/data/tmp
        command:
-         # 其他参数保持不变
-         # --announcement-token 会被容器进程读取；也可改用上面的环境变量
+         - /app/chromaprint3d_server
+         - --data
+         - /app/data
+         - --announcements-dir
+         - /app/data/announcements
+         # 其他参数保持原样
    ```
-4. 滚动更新：
+   如果容器不是只读（`read_only: false` 或未设置），且 `data_dir` 本身是可写卷，可以省略 `--announcements-dir`，公告将落在 `${data_dir}/announcements.json`（向后兼容）。
+5. 滚动更新：
    ```bash
    docker compose up -d chromaprint3d
    ```
-5. 在 Nginx 的 `api.chromaprint3d.com` server block 中，对公告路由开启网段白名单（见本文档 2.4 章的 `location /api/v1/announcements` 块）。
+6. 在 Nginx 的 `api.chromaprint3d.com` server block 中，对公告路由开启网段白名单（见本文档 2.4 章的 `location /api/v1/announcements` 块）。
 
 > 未配置 token 时后端会把 POST/DELETE 一律返回 `404 not_found`，从外部观察不到"公告功能存在"。这是有意为之，降低指纹化探测的价值。
 
@@ -1041,9 +1061,13 @@ export CHROMAPRINT3D_API_URL=https://api.chromaprint3d.com:9443
 
 ### 存储与备份
 
-- 数据文件：`${data_dir}/announcements.json`
-- 写入：先写 `.tmp` 再 `rename`（原子）
-- 建议纳入现有备份计划（与 `data_dir` 其他状态一起备份即可）
+- 数据文件：`${announcements_dir:-${data_dir}}/announcements.json`
+  - 未设 `--announcements-dir` 时沿用 `${data_dir}/announcements.json`（旧部署行为）。
+  - 设了 `--announcements-dir <PATH>` 时落在该目录下的 `announcements.json`，推荐独立 bind mount。
+- 写入：先写 `.tmp` 再 `rename`（原子）。启动时若目录不存在会自动创建（仅限父目录可写的情况）。
+- 建议：
+  - 与 `data_dir` 分离的独立目录更容易单独备份、单独设权限（如 `chmod 700`）。
+  - 若镜像是 `read_only: true`，该目录必须是独立的可写卷，否则首次 POST 会因为无法建父目录而返回 `500`。
 
 ### Token 轮换建议
 
@@ -1061,4 +1085,6 @@ export CHROMAPRINT3D_API_URL=https://api.chromaprint3d.com:9443
 | `403 insecure_transport` | 请求走明文 HTTP | 检查 Nginx 是否透传 `X-Forwarded-Proto: https` |
 | `401 unauthorized` | token 错误 / 轮换后未同步 | 用 `openssl rand -hex 32` 重新生成并重启 |
 | `413 payload_too_large` | 公告 body > 16 KiB | 精简文案或拆条 |
+| `500 internal_error` + 日志含 `cannot create parent dir` / `rename ... failed` | 容器 `read_only: true` 但公告目录不是独立可写卷 | 按启用步骤 4 加 `--announcements-dir` 和对应 bind mount |
+| 重启镜像后公告全部消失 | 公告目录挂在 `tmpfs` 或容器内临时层（未持久化） | 改用宿主 bind mount（见启用步骤 3/4） |
 | 前端没看到新公告 | `announcements_version` 没变化 或被本地 dismiss | `./scripts/announce.sh list` 核对；编辑 `updated_at` 会重新唤起 |

--- a/docs/development.md
+++ b/docs/development.md
@@ -256,7 +256,7 @@ npm run dev
   - `starts_at`（可选）、`ends_at`（必填）、`scheduled_update_at`（可选）：全部 ISO8601 UTC，均与当前时间字符串比较，无需客户端解析时区。
   - `dismissible`：默认 `true`；`false` 时前端不展示"不再提醒"按钮。
 - 成功响应：POST / DELETE / GET 均返回 `announcements_version`（与 health 同步），便于前端局部更新。
-- 持久化：`${data_dir}/announcements.json`，原子写（临时文件 rename）。
+- 持久化：默认写 `${data_dir}/announcements.json`；启动时如指定 `--announcements-dir <PATH>`，则改写 `<PATH>/announcements.json`。原子写（临时文件 rename），启动时自动建父目录。
 - 有关部署与 token 分发策略，见 [docs/deployment.md#公告系统announcements](deployment.md#公告系统announcements)。
 
 ### 5.4 Bambu Studio 预设参数

--- a/web/backend/src/application/announcement_service.cpp
+++ b/web/backend/src/application/announcement_service.cpp
@@ -253,6 +253,16 @@ json AnnouncementService::ToWireJson(const Announcement& a) {
 
 AnnouncementService::AnnouncementService(std::filesystem::path data_dir)
     : data_dir_(std::move(data_dir)), data_file_(data_dir_ / kAnnouncementsFile) {
+    std::error_code ec;
+    std::filesystem::create_directories(data_dir_, ec);
+    if (ec) {
+        // Not fatal: the service still comes up with an empty in-memory
+        // state. The first Upsert() will retry creating the directory and
+        // fail with a clear error if the path is still unwritable.
+        spdlog::warn("announcements: failed to create data dir {}: {}", data_dir_.string(),
+                     ec.message());
+    }
+
     std::unique_lock lk(mtx_);
     LoadFromDiskLocked();
     RefreshVersionHashLocked();

--- a/web/backend/src/application/server_facade.cpp
+++ b/web/backend/src/application/server_facade.cpp
@@ -26,7 +26,7 @@ ServerFacade::ServerFacade(ServerConfig cfg)
       color_db_svc_(data_, sessions_), task_svc_(tasks_),
       convert_svc_(cfg_, data_, sessions_, tasks_), matting_svc_(cfg_, data_, tasks_),
       recipe_svc_(data_, tasks_), calib_svc_(cfg_, data_, sessions_, boards_),
-      announcement_svc_(cfg_.data_dir) {}
+      announcement_svc_(cfg_.announcements_dir.empty() ? cfg_.data_dir : cfg_.announcements_dir) {}
 
 std::string ServerFacade::EnsureSession(const std::optional<std::string>& existing_token,
                                         bool* created) {

--- a/web/backend/src/config/server_config.cpp
+++ b/web/backend/src/config/server_config.cpp
@@ -80,6 +80,9 @@ std::string BuildUsage(const char* exe_name) {
         << "                              write routes return 404 and the feature is disabled\n"
         << "  --announcement-allow-http BOOL  Allow non-HTTPS announcement writes (default: 0,\n"
         << "                                  local debugging only)\n"
+        << "  --announcements-dir DIR    Directory that stores announcements.json (default: same\n"
+        << "                              as --data). Point this at a writable bind mount when\n"
+        << "                              the container root is read-only.\n"
         << "  -h, --help                  Show this help\n";
     return oss.str();
 }
@@ -178,6 +181,10 @@ ConfigParseResult ParseConfig(int argc, char** argv) {
                 return result;
             }
             cfg.announcement_allow_http = parsed;
+            continue;
+        }
+        if (arg == "--announcements-dir") {
+            cfg.announcements_dir = value;
             continue;
         }
 

--- a/web/backend/src/config/server_config.h
+++ b/web/backend/src/config/server_config.h
@@ -42,6 +42,11 @@ struct ServerConfig {
     // When false (default) the auth advice rejects non-HTTPS announcement
     // writes. Set via --announcement-allow-http for local debugging only.
     bool announcement_allow_http = false;
+    // Directory that stores `announcements.json`. When empty, falls back to
+    // `data_dir`. Kept separate so deployments can bind-mount a writable
+    // volume at this path while the rest of `data_dir` (and the container
+    // root filesystem) stays read-only.
+    std::string announcements_dir;
 };
 
 struct ConfigParseResult {

--- a/web/backend/tests/test_announcement_service.cpp
+++ b/web/backend/tests/test_announcement_service.cpp
@@ -390,4 +390,42 @@ TEST(AnnouncementServiceIsoValidator, AcceptsAndRejectsExpectedForms) {
     EXPECT_FALSE(AnnouncementService::IsValidIso8601Utc(""));
 }
 
+// Mirrors the docker-compose + --announcements-dir layout where the
+// announcements directory is a separate writable volume mounted outside
+// the main data_dir. The service must auto-create the target directory
+// on startup and write announcements.json into it.
+TEST(AnnouncementServicePersistence, CreatesMissingDirectoryOnStartup) {
+    TempDataDir parent;
+    const auto target = parent.path() / "nested" / "announcements";
+    ASSERT_FALSE(std::filesystem::exists(target));
+
+    AnnouncementService svc(target);
+    EXPECT_TRUE(std::filesystem::is_directory(target));
+
+    const auto ends_at = IsoShift(clock_type::now(), std::chrono::hours(1));
+    const auto res     = svc.Upsert(MakeBaseAnnouncement("nested", ends_at));
+    ASSERT_TRUE(res.ok) << res.message;
+    EXPECT_TRUE(std::filesystem::exists(target / "announcements.json"));
+}
+
+// Simulates the production layout where announcements_dir is completely
+// independent of data_dir. Data persisted via one service instance must
+// reload from the same directory on a fresh instance.
+TEST(AnnouncementServicePersistence, StandaloneDirectoryReloadsAcrossInstances) {
+    TempDataDir dir;
+    const auto standalone = dir.path() / "announcements_only";
+    const auto ends_at    = IsoShift(clock_type::now(), std::chrono::hours(1));
+
+    {
+        AnnouncementService svc(standalone);
+        ASSERT_TRUE(svc.Upsert(MakeBaseAnnouncement("iso1", ends_at)).ok);
+    }
+    {
+        AnnouncementService svc(standalone);
+        const auto list = svc.ListActive();
+        ASSERT_EQ(list.size(), 1u);
+        EXPECT_EQ(list.front().id, "iso1");
+    }
+}
+
 } // namespace chromaprint3d::backend


### PR DESCRIPTION
## 背景

生产环境的 `docker-compose.yml` 用了 `read_only: true` 来加固容器根。公告服务默认把 `announcements.json` 写在 `${data_dir}/`，而 `${data_dir}` 是只读根的一部分，不是独立可写卷。结果：

- 第一次 POST 会因为 `create_directories` / `rename` 失败返回 `500`；
- 即便写入成功，`tmpfs` 只覆盖 `/tmp` 和 `/app/data/tmp`，重启镜像公告全丢。

## 方案

增加 `--announcements-dir <PATH>` 启动参数，让运维把公告目录作为独立的可写 bind mount，根文件系统仍可保持 `read_only: true`。未传参时沿用原行为（`${data_dir}/announcements.json`），老部署零影响。

## 变更

- `ServerConfig`
  - 新增 `announcements_dir` 字段
  - `--announcements-dir DIR` 解析 + usage 文本
- `ServerFacade`
  - 构造 `AnnouncementService` 时：`announcements_dir.empty() ? data_dir : announcements_dir`
- `AnnouncementService`
  - 构造时 `create_directories(data_dir_)`，日志友好、首次 Upsert 不会被目录缺失绊住
- 测试
  - `CreatesMissingDirectoryOnStartup`：嵌套不存在路径应自动创建
  - `StandaloneDirectoryReloadsAcrossInstances`：跨进程重载独立目录
- 文档
  - `docs/deployment.md` 公告部署给出只读容器的完整 compose 片段 + 故障排查
  - `docs/development.md`、`docs/agents/web/backend/README.md`、`docs/agents/tasks/publish_announcement.md`、`.cursor/skills/publish-announcement/SKILL.md` 同步新字段和持久化路径描述

## 验证

- 本地 `cmake --build build --target chromaprint3d_backend_tests` 通过
- `chromaprint3d_backend_tests --gtest_filter='AnnouncementService*'` 全 22 用例通过
- `chromaprint3d_server --help` 新增行：
  ```
  --announcements-dir DIR    Directory that stores announcements.json (default: same
                              as --data). Point this at a writable bind mount when
                              the container root is read-only.
  ```

## 部署计划

合并后预期发 `v1.3.2-rc.4` 预览镜像，再在家庭主机 / 云服务器修改 `docker-compose.yml`：

1. `mkdir -p ~/chromaprint3d-deploy/data/announcements && chmod 700 ...`
2. 给 `chromaprint3d` 服务加 volume `./data/announcements:/app/data/announcements`
3. `command` 里追加 `--announcements-dir /app/data/announcements`
4. `docker compose up -d` 滚动

## 风险

- 向后兼容：未设新参数 → 行为与 master 一致
- 目录不可写：初始化仅记录 `warn`，不阻止启动；首次写入仍会返回清晰的错误信息
- 权限：宿主目录建议 `chmod 700`；容器内以默认 uid 运行，若有 uid 偏移需结合 compose 的 `user` 设置（不在本 PR 范围）

## 回滚

revert 此 commit，重启容器即可；已落盘的 `${announcements_dir}/announcements.json` 需要运维手动复制回 `${data_dir}/` 才能继续可见。