### PR TITLE
docs(readme): 补全开源致谢、功能清单、徽章与中英对齐

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ChromaPrint3D
 
+[![License](https://img.shields.io/github/license/neroued/ChromaPrint3D)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/neroued/ChromaPrint3D?include_prereleases)](https://github.com/neroued/ChromaPrint3D/releases)
+[![Docker Pulls](https://img.shields.io/docker/pulls/neroued/chromaprint3d)](https://hub.docker.com/r/neroued/chromaprint3d)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fchromaprint3d.com)](https://chromaprint3d.com/)
+
 [English](#english) | [中文](#中文)
 
 ---
@@ -10,8 +15,18 @@
 
 ChromaPrint3D 可以把图片转换成多色 3D 打印可用的 3MF 模型。  
 支持 Bambu Studio 预设参数自动写入（0.2mm/0.4mm 喷嘴 × 观赏面朝上/朝下，共 4 种预设），并自动将模型颜色匹配到最接近的耗材丝槽位。  
-支持在转换时显式配置底板层数（`base_layers`）、双面生成（`double_sided`）以及透明镀层（`transparent_layer_mm`，仅观赏面朝下模式）。
 如果你只是想先体验效果，不需要先读一堆文档，直接从下面三种方式里选一种就行。
+
+## 核心功能
+
+- 图片 / SVG → 多色 3MF，4 种 Bambu Studio 预设自动注入
+- 模型颜色自动匹配到耗材丝槽位（RGB 欧氏距离）
+- 深度学习抠图（ONNX Runtime 推理）
+- 矢量化处理：抗锯齿检测、边缘感知 SLIC 分割、逐像素标签细化
+- 交互式配方编辑器：逐色重选、实时预览
+- 校准板生成 + 拍照构建 ColorDB（支持 4/8 色板工作流）
+- 高级几何控制：底板层数（`base_layers`）、双面打印（`double_sided`）、透明镀层（`transparent_layer_mm`，FaceDown 专属）
+- 运维公告系统：双语 banner、HTTPS 写入、token 鉴权
 
 ## 快速上手（3 选 1）
 
@@ -44,6 +59,8 @@ docker run -d -p 8080:8080 --name chromaprint3d neroued/chromaprint3d:latest
 | `gen_calibration_board` | 生成校准板 3MF |
 | `build_colordb` | 从校准板照片构建 ColorDB |
 
+> 完整可执行文件列表（含 `gen_stage`、`svg_to_3mf` 等）见 [docs/build.md](docs/build.md#23-构建-c-核心与应用)。
+
 > 矢量化 CLI 工具（raster_to_svg、evaluate_svg）已迁移至独立库 [neroued_vectorizer](https://github.com/neroued/neroued_vectorizer)。
 
 ## 开发者跳转
@@ -57,6 +74,25 @@ docker run -d -p 8080:8080 --name chromaprint3d neroued/chromaprint3d:latest
 - 模块索引：[docs/agents/README.md](docs/agents/README.md)
 - 任务手册：[docs/agents/tasks/README.md](docs/agents/tasks/README.md)
 
+## 致谢
+
+ChromaPrint3D 构建在众多优秀开源项目之上，特别感谢：
+
+- C++ 核心 / 算法：[OpenCV](https://opencv.org)、[spdlog](https://github.com/gabime/spdlog)、[Clipper2](https://github.com/AngusJohnson/Clipper2)、[lunasvg](https://github.com/sammycage/lunasvg)、[nlohmann/json](https://github.com/nlohmann/json)、[earcut.hpp](https://github.com/mapbox/earcut.hpp)、[ONNX Runtime](https://onnxruntime.ai)、[jemalloc](https://jemalloc.net)、[Little CMS](https://www.littlecms.com)
+- Web 后端：[Drogon](https://github.com/drogonframework/drogon)
+- Web 前端：[Vue](https://vuejs.org)、[Naive UI](https://www.naiveui.com)、[Pinia](https://pinia.vuejs.org)、[Vue I18n](https://vue-i18n.intlify.dev)、[Chart.js](https://www.chartjs.org)、[Vite](https://vitejs.dev)
+- 桌面壳：[Electron](https://www.electronjs.org)
+- Python 建模：[NumPy](https://numpy.org)、[SciPy](https://scipy.org)、[OpenCV](https://opencv.org)、[msgpack](https://msgpack.org)、[matplotlib](https://matplotlib.org)
+- 运行时系统依赖：[Potrace](https://potracer.com/)（通过 [neroued_vectorizer](https://github.com/neroued/neroued_vectorizer)）
+
+## 许可证
+
+本项目采用 Apache License 2.0，完整文本见 [LICENSE](LICENSE)。
+
+## 贡献
+
+欢迎通过 Issue / Pull Request 参与。提交前请阅读 [AGENTS.md](AGENTS.md) 与 [Git 分支与 PR 规范](.cursor/rules/git-branch-pr-policy.mdc)。
+
 ---
 
 <a id="english"></a>
@@ -67,8 +103,18 @@ docker run -d -p 8080:8080 --name chromaprint3d neroued/chromaprint3d:latest
 
 ChromaPrint3D turns images into multi-color 3MF models for 3D printing.  
 It supports automatic Bambu Studio preset injection (0.2mm/0.4mm nozzle × face-up/face-down, 4 presets) and auto-matches model colors to the closest filament slot.  
-You can also explicitly control base layers (`base_layers`), double-sided generation (`double_sided`), and transparent coating (`transparent_layer_mm`, FaceDown only) during conversion.
 If you only want a quick hands-on try, pick one of the options below.
+
+### Features
+
+- Image / SVG to multi-color 3MF with auto-injected Bambu Studio presets (4 variants)
+- Auto-match model colors to filament slots (RGB Euclidean distance)
+- Deep-learning matting (ONNX Runtime inference)
+- Vectorization: anti-aliasing detection, edge-aware SLIC, per-pixel label refinement
+- Interactive recipe editor: per-color replacement with live preview
+- Calibration board generation + photo-based ColorDB build (4/8-color workflows)
+- Advanced geometry controls: base layers (`base_layers`), double-sided printing (`double_sided`), transparent coating (`transparent_layer_mm`, FaceDown only)
+- Announcement system: bilingual banner, HTTPS-only writes, token-gated mutations
 
 ### Quick Start (Pick One)
 
@@ -101,6 +147,8 @@ Then open `http://localhost:8080`.
 | `gen_calibration_board` | Generate calibration board 3MF |
 | `build_colordb` | Build ColorDB from calibration photo |
 
+> Full list of executables (including `gen_stage`, `svg_to_3mf`, etc.) is in [docs/build.md](docs/build.md#23-构建-c-核心与应用).
+
 > Vectorization CLI tools (raster_to_svg, evaluate_svg) have been migrated to the standalone library [neroued_vectorizer](https://github.com/neroued/neroued_vectorizer).
 
 ### Developer Entry
@@ -109,6 +157,26 @@ Then open `http://localhost:8080`.
 - Local development and debugging: [docs/development.md](docs/development.md)
 - Release workflow: [docs/development.md#8-发布流程](docs/development.md#8-发布流程)
 - Deployment: [docs/deployment.md](docs/deployment.md)
+- Operations announcements (upgrade notices / maintenance banners): [docs/deployment.md#公告系统announcements](docs/deployment.md#公告系统announcements)
 - Collaboration guide: [AGENTS.md](AGENTS.md)
 - Module indexes: [docs/agents/README.md](docs/agents/README.md)
 - Task playbooks: [docs/agents/tasks/README.md](docs/agents/tasks/README.md)
+
+### Acknowledgments
+
+ChromaPrint3D builds on many excellent open-source projects. Special thanks to:
+
+- C++ core / algorithms: [OpenCV](https://opencv.org), [spdlog](https://github.com/gabime/spdlog), [Clipper2](https://github.com/AngusJohnson/Clipper2), [lunasvg](https://github.com/sammycage/lunasvg), [nlohmann/json](https://github.com/nlohmann/json), [earcut.hpp](https://github.com/mapbox/earcut.hpp), [ONNX Runtime](https://onnxruntime.ai), [jemalloc](https://jemalloc.net), [Little CMS](https://www.littlecms.com)
+- Web backend: [Drogon](https://github.com/drogonframework/drogon)
+- Web frontend: [Vue](https://vuejs.org), [Naive UI](https://www.naiveui.com), [Pinia](https://pinia.vuejs.org), [Vue I18n](https://vue-i18n.intlify.dev), [Chart.js](https://www.chartjs.org), [Vite](https://vitejs.dev)
+- Desktop shell: [Electron](https://www.electronjs.org)
+- Python modeling: [NumPy](https://numpy.org), [SciPy](https://scipy.org), [OpenCV](https://opencv.org), [msgpack](https://msgpack.org), [matplotlib](https://matplotlib.org)
+- Runtime system dependency: [Potrace](https://potracer.com/) (via [neroued_vectorizer](https://github.com/neroued/neroued_vectorizer))
+
+### License
+
+This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for the full text.
+
+### Contributing
+
+Issues and pull requests are welcome. Please read [AGENTS.md](AGENTS.md) and the [Git branch & PR policy](.cursor/rules/git-branch-pr-policy.mdc) before submitting.


### PR DESCRIPTION
## 变更类型

- [x] 文档 (docs)

## 变更说明

### 问题背景

当前 `README.md` 没有提及任何使用到的开源库，缺少最基本的上游致谢；同时首屏读者无法快速了解产品能力边界与技术栈，缺少 License / Contributing 段，且中英版存在条目漂移。

### 解决方案

保持现有"简洁"基调，只编辑 `README.md` 一个文件：

- 顶部新增 4 枚徽章：License / Release / Docker Pulls / Website
- 简介瘦身：把 `base_layers` / `double_sided` / `transparent_layer_mm` 从简介下沉到核心功能段
- 新增"核心功能 / Features"段（8 条 bullet），覆盖抠图、矢量化、配方编辑器、ColorDB、几何控制、公告系统等
- 新增 Acknowledgments 段：扁平列出 C++ / 后端 / 前端 / 桌面壳 / Python / 系统依赖 6 组上游开源库与链接，不含 License 标注
- 新增 License 与 Contributing 段，分别指向 LICENSE 与 AGENTS / git 分支规范
- CLI 工具表追加完整可执行文件清单的 \`docs/build.md\` 跳转
- 英文版同步全部新增段落，并补齐原本缺失的 "Operations announcements" 跳转条目

### 影响范围

- [x] \`docs/\` — 文档（仅 \`README.md\`）

## 验证记录

- [x] ReadLints 通过：README.md 无 Markdown lint 报错
- [x] 人工通读：中英两版结构 1:1 对齐（简介 / 核心功能 / 快速上手 / CLI / 开发者跳转 / 致谢 / 许可证 / 贡献）
- [x] 链接目标全部存在：\`LICENSE\`、\`AGENTS.md\`、\`.cursor/rules/git-branch-pr-policy.mdc\`、\`docs/build.md\`、\`docs/deployment.md\`、\`docs/development.md\` 均在仓库内

## 代码质量检查

- 不涉及 C++ 修改
- 不涉及工具函数与平台代码

## 文档与协作同步

- [x] 以上均不涉及

> 本次为 README 文案整理，未涉及 API / CLI / 构建 / 部署 / 前端行为变更，无需联动其它文档。

## 风险与回滚

**风险点：** 无。仅文档文案，不影响构建产物与运行时行为。徽章 URL 由 shields.io 动态渲染，若上游不可用会显示占位符，不影响 README 结构。

**回滚方案：** \`git revert <本次 commit>\` 即可。