### PR TITLE
feat(analytics): 重构 Umami 统计至集中化服务并补齐全模块埋点

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@
 | CLI 参数或默认值变化 | [README.md](README.md)、[docs/development.md](docs/development.md)、[docs/agents/apps/README.md](docs/agents/apps/README.md)、[docs/agents/tasks/extend_cli_flag.md](docs/agents/tasks/extend_cli_flag.md) |
 | 构建/部署流程变化 | [README.md](README.md)、[docs/development.md](docs/development.md)、[docs/deployment.md](docs/deployment.md)、[docs/agents/tasks/sync_docs_after_behavior_change.md](docs/agents/tasks/sync_docs_after_behavior_change.md) |
 | 用户可见前端行为变化 | [README.md](README.md)、[docs/development.md](docs/development.md)、[docs/agents/web/frontend/README.md](docs/agents/web/frontend/README.md) |
+| Umami 事件名 / 字段 schema 变化 | [web/frontend/src/services/analytics.ts](web/frontend/src/services/analytics.ts)（`EVENT_NAMES` / `EventPayloadMap`）、[docs/deployment.md](docs/deployment.md) §8.4 |
 | 模块入口或职责边界变化 | [docs/agents/README.md](docs/agents/README.md) 与对应模块索引 |
 
 ## PR 检查要求

--- a/docs/agents/web/frontend/README.md
+++ b/docs/agents/web/frontend/README.md
@@ -29,6 +29,7 @@
 | 调整多标签健康上报/leader 选举 | `src/composables/feature/useLeaderLease.ts` + `src/composables/feature/useAppLifecycle.ts` |
 | 调整 Browser/Electron 行为差异 | `src/runtime/*.ts` + `src/electron.d.ts` |
 | 调整公告 banner 展示 / dismiss 行为 | `src/components/AnnouncementBanner.vue` + `src/composables/useAnnouncements.ts` + `src/api/announcements.ts` + `src/locales/{zh-CN,en}.ts` |
+| 新增 / 修改 Umami 埋点事件 | `src/services/analytics.ts`（集中注册 `EVENT_NAMES` / `EventPayloadMap`）+ 调用点；不要直接写 `window.umami?.track(...)`。事件清单同步到 [docs/deployment.md](../../../deployment.md) §8.4 |
 
 ## 分层边界（强约束）
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -922,29 +922,142 @@ VITE_UMAMI_WEBSITE_ID=<预览版 website-id>
 
 ### 8.4 自定义事件清单
 
-前端通过 `window.umami.track()` 上报以下自定义事件，用于用户旅程分析和性能监控。
+> **重要**：所有埋点调用都必须通过 `web/frontend/src/services/analytics.ts` 提供的 `trackEvent` / `trackPageview` / `updateSessionProperties` API，禁止直接写 `window.umami?.track(...)`。事件名与字段结构在 `EVENT_NAMES` 与 `EventPayloadMap` 中集中维护，编辑器会对拼写、字段形状做编译期检查。新增或修改事件时请同步本节表格。
+>
+> **运行时隔离**：Electron 桌面端会跳过 Umami 脚本注入并丢弃所有 `trackEvent` 调用，因此表中所有事件仅在浏览器端（chromaprint3d.com / chromaprint3d-preview.chromaprint3d.com）上报。
 
-**用户旅程漏斗**：`image-select` → `convert-start` → `convert-complete` → `download-3mf`
+#### 会话身份
 
-**配方编辑漏斗**：`match-preview-start` → `match-preview-complete` / `recipe-editor-open` → `recipe-replace` → `generate-model-complete` → `download-3mf`
+前端在首次访问时通过 `crypto.randomUUID()` 生成匿名 ID，保存于 `localStorage['chromaprint3d-analytics-id']`，之后每次脚本加载完成会调用 `umami.identify(id, props)` 注入以下会话属性：
+
+| 字段 | 说明 |
+|---|---|
+| `runtime` | `browser` / `electron`（Electron 不会触达） |
+| `channel` | `stable`（`X.Y.Z`）/ `preview`（`X.Y.Z-rc.N`）/ `unknown` |
+| `version` | 构建时写入的 `__APP_VERSION__` |
+| `locale` | 当前 i18n locale，切换语言时会刷新 |
+
+#### 虚拟 pageview
+
+前端会对顶层 Tab 与子 Tab 切换上报**虚拟 pageview**，URL 形如 `/convert`、`/preprocess/vectorize`、`/calibration/4color`；每条 pageview 都会带上对应的 i18n 标题，便于在 Umami 后台区分各功能页面的访问量。初次挂载仅上报一次，避免重复计数。
+
+#### 用户旅程漏斗
+
+- **图生 3MF**：`image-select` → `convert-start` → `convert-complete` → `convert-download-3mf`
+- **配方编辑**：`match-preview-start` → `match-preview-complete` → `recipe-open` → `recipe-replace` → `recipe-generate-complete` → `recipe-download-3mf`
+- **矢量化**：`vectorize-start` → `vectorize-complete` → `vectorize-download-svg` 或 `vectorize-use-for-convert`
+- **抠图**：`matting-start` → `matting-complete` → `matting-postprocess-done` → `matting-download-foreground` 或 `matting-use-for-convert`
+- **校准板**：`calibration-generate-start` → `calibration-generate-complete` → `calibration-download-3mf`
+- **ColorDB 构建**：`colordb-locate-start` → `colordb-locate-complete` → `colordb-build-start` → `colordb-build-complete` → `colordb-download-json`
+
+#### 转换（Convert）
 
 | 事件名 | 触发点 | 关键字段 |
-|--------|--------|----------|
-| image-select | 选择文件 | type |
-| convert-start | 点击转换 | inputType, color_layers, model_enable |
-| convert-complete | 转换成功 | inputType, has3mf, elapsed_s, width, height, avg_de |
-| convert-fail | 转换失败 | inputType, error |
-| match-preview-start | 点击配方预览 | inputType, color_layers, model_enable |
-| match-preview-complete | 预览完成 | inputType, elapsed_s, width, height, avg_de |
-| match-preview-fail | 预览失败 | inputType, error |
-| recipe-editor-open | 进入编辑器 | （无） |
-| recipe-replace | 替换配方 | regionCount |
-| generate-model-complete | 模型生成完成 | （无） |
-| generate-model-fail | 模型生成失败 | error |
-| download-3mf | 下载成功 | filename |
-| memory-status | 每 5 分钟 / leader | rss_mb, heap_mb, artifact_pct, usage_pct, allocator |
+|---|---|---|
+| `image-select` | 选中输入文件 | `input_type`（raster/vector） |
+| `convert-start` | 点击转换 | `input_type`, `color_layers`, `model_enable`, `input_size_kb`, `colordb_count` |
+| `convert-complete` | 转换成功 | `input_type`, `has_3mf`, `duration_ms`, `width`, `height`, `avg_de`, `colordb_count` |
+| `convert-fail` | 转换失败 | `input_type`, `error`, `error_code` |
+| `match-preview-start` | 点击配方预览 | `input_type`, `color_layers`, `model_enable`, `input_size_kb`, `colordb_count` |
+| `match-preview-complete` | 预览完成 | `input_type`, `duration_ms`, `width`, `height`, `avg_de` |
+| `match-preview-fail` | 预览失败 | `input_type`, `error`, `error_code` |
+| `convert-download-3mf` | 下载成功 | `filename` |
 
-此外，前端会对主 Tab 和子 Tab 切换发送**虚拟 pageview**（如 `/convert`、`/preprocess/vectorize`），使 Umami 后台能区分各功能页面的访问量。
+#### 配方编辑器（Recipe）
+
+| 事件名 | 触发点 | 关键字段 |
+|---|---|---|
+| `recipe-open` | 进入编辑器（match-preview 完成后） | — |
+| `recipe-replace` | 替换配方 | `region_count` |
+| `recipe-undo` | 撤销 | — |
+| `recipe-global-mode-toggle` | 切换全局模式 | `enabled` |
+| `recipe-generate-complete` | 模型生成完成 | `duration_ms` |
+| `recipe-generate-fail` | 模型生成失败 | `error`, `error_code` |
+| `recipe-download-3mf` | 从编辑器下载 3MF | `filename` |
+
+#### 矢量化（Vectorize）
+
+| 事件名 | 触发点 | 关键字段 |
+|---|---|---|
+| `vectorize-start` | 点击矢量化 | `input_size_kb`, `num_colors` |
+| `vectorize-complete` | 矢量化成功 | `duration_ms`, `width`, `height`, `num_shapes`, `svg_size_kb`, `resolved_num_colors` |
+| `vectorize-fail` | 矢量化失败 | `error`, `error_code` |
+| `vectorize-download-svg` | 下载 SVG | `svg_size_kb` |
+| `vectorize-use-for-convert` | 将结果送入转换 | — |
+| `vectorize-clear-file` | 清除已选图片 | — |
+
+#### 抠图（Matting）
+
+| 事件名 | 触发点 | 关键字段 |
+|---|---|---|
+| `matting-start` | 点击开始抠图 | `method`, `input_size_kb` |
+| `matting-complete` | 抠图完成 | `method`, `duration_ms`, `has_alpha` |
+| `matting-fail` | 抠图失败 | `method`, `error`, `error_code` |
+| `matting-postprocess-done` | 后处理完成一次 | `duration_ms` |
+| `matting-download-mask` | 下载 mask | — |
+| `matting-download-foreground` | 下载前景图 | — |
+| `matting-use-for-convert` | 将前景送入转换 | — |
+| `matting-model-download-start` | 触发模型下载（仅 Electron，一般不可见） | `pending_count`, `total_count` |
+| `matting-model-download-complete` | 模型下载完成（仅 Electron） | `duration_ms`, `total_count` |
+| `matting-model-download-fail` | 模型下载失败（仅 Electron） | `error`, `error_code` |
+| `matting-model-download-cancel` | 取消模型下载（仅 Electron） | — |
+| `matting-connectivity-check` | 模型源连通性探测（仅 Electron） | `available_sources`, `total_sources`, `duration_ms` |
+
+> 表中带「仅 Electron」标注的事件因 Electron 运行时不加载 Umami 脚本而实际不会上报；保留这些埋点调用是为了与桌面端代码路径一致，也方便未来开启 Electron 遥测时零改动启用。
+
+#### 校准板（Calibration）
+
+| 事件名 | 触发点 | 关键字段 |
+|---|---|---|
+| `calibration-generate-start` | 点击生成 | `board_index`, `channel_count`, `nozzle_size`, `face_orientation` |
+| `calibration-generate-complete` | 生成成功 | `board_index`, `channel_count`, `nozzle_size`, `face_orientation`, `duration_ms` |
+| `calibration-generate-fail` | 生成失败 | `board_index`, `channel_count`, `error`, `error_code` |
+| `calibration-download-3mf` | 下载校准板 3MF | `board_index`, `channel_count` |
+| `calibration-download-meta` | 下载校准板 meta | `board_index`, `channel_count` |
+
+> 4 色流程的 `board_index` 固定为 1；8 色流程的 `board_index` 为 1 或 2，对应第一 / 第二块板。
+
+#### ColorDB
+
+| 事件名 | 触发点 | 关键字段 |
+|---|---|---|
+| `colordb-locate-start` | 点击识别 | — |
+| `colordb-locate-complete` | 识别成功 | `duration_ms` |
+| `colordb-locate-fail` | 识别失败 | `error`, `error_code` |
+| `colordb-build-start` | 点击构建 | — |
+| `colordb-build-complete` | 构建成功 | `num_channels`, `num_entries`, `duration_ms` |
+| `colordb-build-fail` | 构建失败 | `error`, `error_code` |
+| `colordb-download-json` | 下载构建结果 | — |
+| `colordb-upload` | 上传 ColorDB（单/多文件） | `mode`（single/batch）, `count`, `ok`, `fail` |
+| `colordb-delete` | 删除 ColorDB（单/批量） | `mode`, `ok`, `fail` |
+
+#### UI 交互
+
+| 事件名 | 触发点 | 关键字段 |
+|---|---|---|
+| `locale-toggle` | 切换语言 | `from`, `to` |
+| `theme-toggle` | 切换主题 | `theme`（dark/light） |
+| `tutorial-click` | 打开视频教程 | — |
+| `github-click` | 点击 GitHub 链接 | `target`（repo/issues） |
+| `makerworld-click` | 点击 MakerWorld 链接 | — |
+| `whats-new-open` | 打开「What's New」弹窗 | `trigger`（auto/manual） |
+| `announcement-dismiss` | 关闭公告 banner | `id` |
+| `update-banner-click` | 点击更新 banner 按钮 | `action`（download/dismiss） |
+| `check-update-click` | 手动检查更新 | `result`（has-update/no-update/fail） |
+
+#### 生命周期遥测
+
+| 事件名 | 触发点 | 关键字段 |
+|---|---|---|
+| `memory-status` | 每 5 分钟 / leader tab | `rss_mb`, `heap_mb`, `artifact_pct`, `usage_pct`, `allocator` |
+
+#### 字段与事件规范
+
+- **事件名**：全部使用 `{module}-{action}[-{qualifier}]` 的 kebab-case 小写形式；字段名统一 `snake_case`。
+- **耗时**：统一使用 `duration_ms`（整数毫秒，未知记为 `-1`）。
+- **错误**：失败事件同时带 `error`（已截断到 120 字符）与低基数的 `error_code`（如 `http_404` / `cancelled` / `timeout` / `parse_error` / `unknown`），便于按 code 聚合。
+- **下载**：所有下载事件遵循 `{module}-download-{format}` 命名（例如 `convert-download-3mf`、`recipe-download-3mf`、`vectorize-download-svg`、`colordb-download-json`）。
+- **一次性迁移**：2026-04 的字段重命名（`inputType`→`input_type`、`regionCount`→`region_count`、`has3mf`→`has_3mf`、`elapsed_s`→`duration_ms`、`recipe-editor-open`→`recipe-open`、`generate-model-*`→`recipe-generate-*`、`download-3mf`→`{module}-download-3mf`）会在 Umami 仪表盘中形成历史断点；新仪表盘请基于上表的新名称创建。
 
 ### 8.5 多标签 `memory-status` 去重
 

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import {
@@ -45,6 +45,7 @@ import { useAppLifecycle } from './composables/feature/useAppLifecycle'
 import { useUpdateChecker } from './composables/feature/useUpdateChecker'
 import { useWhatsNew } from './composables/feature/useWhatsNew'
 import { isElectronRuntime } from './runtime/platform'
+import { trackEvent, trackPageview, updateSessionProperties } from './services/analytics'
 import {
   getSiteIcpNumber,
   getSiteIcpUrl,
@@ -130,36 +131,75 @@ const SUB_TAB_VIRTUAL_URLS: Record<string, Record<string, string>> = {
   },
 }
 
-function trackVirtualPageview(url: string) {
-  window.umami?.track((props: Record<string, unknown>) => ({ ...props, url }))
+// Maps every virtual URL to the i18n key whose translation represents the
+// page title. Keeping the mapping explicit avoids accidentally reporting an
+// untranslated identifier if a sub-tab is ever renamed.
+const VIRTUAL_TITLE_KEY: Record<string, string> = {
+  '/convert': 'app.tabs.convert',
+  '/preprocess/vectorize': 'app.tabs.vectorize',
+  '/preprocess/matting': 'app.tabs.matting',
+  '/calibration-tools/calibration': 'app.tabs.calibration',
+  '/calibration-tools/calibration-8color': 'app.tabs.calibration8color',
+  '/calibration-tools/colordb-build': 'app.tabs.colordbBuild',
+  '/colordb-upload': 'app.tabs.colordbUpload',
 }
 
+const effectiveVirtualUrl = computed(() => {
+  const tab = activeTab.value
+  if (tab === 'preprocess') {
+    return (
+      SUB_TAB_VIRTUAL_URLS['preprocess']?.[activePreprocessTab.value] ?? TAB_VIRTUAL_URLS[tab] ?? ''
+    )
+  }
+  if (tab === 'calibration-tools') {
+    return (
+      SUB_TAB_VIRTUAL_URLS['calibration-tools']?.[activeCalibrationTab.value] ??
+      TAB_VIRTUAL_URLS[tab] ??
+      ''
+    )
+  }
+  return TAB_VIRTUAL_URLS[tab] ?? ''
+})
+
+const effectiveVirtualTitle = computed(() => {
+  const url = effectiveVirtualUrl.value
+  if (!url) return undefined
+  const key = VIRTUAL_TITLE_KEY[url]
+  return key ? t(key) : undefined
+})
+
+function reportCurrentPageview() {
+  const url = effectiveVirtualUrl.value
+  if (!url) return
+  trackPageview(url, effectiveVirtualTitle.value)
+}
+
+// Watch the derived URL so sub-tab switches also emit virtual pageviews.
+// `immediate: false` + an explicit `onMounted` call keeps boot to a single
+// pageview instead of the triple fire the old three-watcher setup produced.
+watch(effectiveVirtualUrl, (url, prev) => {
+  if (!url || url === prev) return
+  reportCurrentPageview()
+})
+
+onMounted(() => {
+  reportCurrentPageview()
+})
+
+// Keep Umami session properties in sync with runtime state. The first
+// identify is triggered on tracker load; these watchers refresh it whenever
+// the server version resolves or the user toggles the locale.
 watch(
-  activeTab,
-  (tab) => {
-    const url = TAB_VIRTUAL_URLS[tab]
-    if (url) trackVirtualPageview(url)
+  serverVersion,
+  (v) => {
+    if (v) updateSessionProperties({ version: v })
   },
   { immediate: true },
 )
 
-watch(
-  activePreprocessTab,
-  (sub) => {
-    const url = SUB_TAB_VIRTUAL_URLS['preprocess']?.[sub]
-    if (url) trackVirtualPageview(url)
-  },
-  { immediate: true },
-)
-
-watch(
-  activeCalibrationTab,
-  (sub) => {
-    const url = SUB_TAB_VIRTUAL_URLS['calibration-tools']?.[sub]
-    if (url) trackVirtualPageview(url)
-  },
-  { immediate: true },
-)
+watch(locale, (l) => {
+  updateSessionProperties({ locale: l })
+})
 
 useAppLifecycle()
 
@@ -186,7 +226,31 @@ function goToConvert() {
 }
 
 function toggleLocale() {
-  appStore.setLocale(locale.value === 'zh-CN' ? 'en' : 'zh-CN')
+  const from = locale.value
+  const to = from === 'zh-CN' ? 'en' : 'zh-CN'
+  trackEvent('locale-toggle', { from, to })
+  appStore.setLocale(to)
+}
+
+function onShowWhatsNewManual() {
+  trackEvent('whats-new-open', { trigger: 'manual' })
+  showWhatsNew()
+}
+
+function onTutorialClick() {
+  trackEvent('tutorial-click')
+}
+
+function onGithubRepoClick() {
+  trackEvent('github-click', { target: 'repo' })
+}
+
+function onGithubIssuesClick() {
+  trackEvent('github-click', { target: 'issues' })
+}
+
+function onMakerWorldClick() {
+  trackEvent('makerworld-click')
 }
 </script>
 
@@ -207,7 +271,7 @@ function toggleLocale() {
                 v-if="serverVersion"
                 depth="3"
                 class="app-shell__version app-shell__version--clickable"
-                @click="showWhatsNew"
+                @click="onShowWhatsNewManual"
               >
                 v{{ serverVersion }}
               </NText>
@@ -236,6 +300,7 @@ function toggleLocale() {
                 target="_blank"
                 size="small"
                 quaternary
+                @click="onTutorialClick"
               >
                 {{ t('common.videoTutorial') }}
               </NButton>
@@ -262,6 +327,7 @@ function toggleLocale() {
                     href="https://github.com/neroued/ChromaPrint3D"
                     target="_blank"
                     rel="noopener noreferrer"
+                    @click="onGithubRepoClick"
                     >{{ t('app.announcement.starLink') }}</a
                   >{{ t('app.announcement.starSuffix') }}
                   <span class="app-shell__announce-sep">&middot;</span>
@@ -270,13 +336,17 @@ function toggleLocale() {
                     href="https://github.com/neroued/ChromaPrint3D/issues"
                     target="_blank"
                     rel="noopener noreferrer"
+                    @click="onGithubIssuesClick"
                     >{{ t('app.announcement.issueLink') }}</a
                   >
                   <span class="app-shell__announce-sep">&middot;</span>
                   {{ t('app.announcement.makerWorldHint') }}
-                  <a :href="makerWorldUrl" target="_blank" rel="noopener noreferrer">{{
-                    t('app.announcement.makerWorldLink')
-                  }}</a
+                  <a
+                    :href="makerWorldUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    @click="onMakerWorldClick"
+                    >{{ t('app.announcement.makerWorldLink') }}</a
                   >{{ t('app.announcement.makerWorldSuffix') }}
                 </span>
               </div>
@@ -461,6 +531,7 @@ function toggleLocale() {
               target="_blank"
               rel="noopener noreferrer"
               class="app-shell__footer-link"
+              @click="onGithubRepoClick"
             >
               <NText depth="3" class="app-shell__meta-text">GitHub</NText>
             </a>

--- a/web/frontend/src/components/AnnouncementBanner.vue
+++ b/web/frontend/src/components/AnnouncementBanner.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { NAlert, NSpace, NText, NButton } from 'naive-ui'
 import type { Announcement, AnnouncementSeverity, AnnouncementType } from '../types'
 import { useAnnouncements } from '../composables/useAnnouncements'
+import { trackEvent } from '../services/analytics'
 
 const { t, locale } = useI18n()
 const announcements = useAnnouncements()
@@ -133,6 +134,7 @@ const items = computed<Item[]>(() =>
 )
 
 async function handleDismiss(id: string) {
+  trackEvent('announcement-dismiss', { id })
   await announcements.dismiss(id)
 }
 </script>

--- a/web/frontend/src/components/Calibration8ColorPanel.vue
+++ b/web/frontend/src/components/Calibration8ColorPanel.vue
@@ -21,6 +21,7 @@ import {
   getBoardMetaPath,
   getBoardModelPath,
 } from '../services/calibrationService'
+import { resolveErrorCode, shortenError, toDurationMs, trackEvent } from '../services/analytics'
 import type { FaceOrientation, NozzleSize, PaletteChannel } from '../types'
 
 type EditablePaletteChannel = PaletteChannel & {
@@ -98,6 +99,14 @@ async function handleGenerateBoard(boardIndex: number) {
   const generatingRef = isBoard1 ? generating1 : generating2
   const boardRef = isBoard1 ? board1Id : board2Id
 
+  const channelCount = palette.value.length
+  trackEvent('calibration-generate-start', {
+    board_index: boardIndex,
+    channel_count: channelCount,
+    nozzle_size: nozzleSize.value,
+    face_orientation: faceOrientation.value,
+  })
+  const startTs = performance.now()
   generatingRef.value = true
   boardRef.value = null
   try {
@@ -109,20 +118,43 @@ async function handleGenerateBoard(boardIndex: number) {
     })
     boardRef.value = response.board_id
     message.success(t('calibration.eightColor.boardGenerateSuccess', { index: boardIndex }))
+    trackEvent('calibration-generate-complete', {
+      board_index: boardIndex,
+      channel_count: channelCount,
+      nozzle_size: nozzleSize.value,
+      face_orientation: faceOrientation.value,
+      duration_ms: toDurationMs(performance.now() - startTs),
+    })
   } catch (error: unknown) {
     message.error(
       t('calibration.generateFailed', {
         error: error instanceof Error ? error.message : String(error),
       }),
     )
+    trackEvent('calibration-generate-fail', {
+      board_index: boardIndex,
+      channel_count: channelCount,
+      error: shortenError(error),
+      error_code: resolveErrorCode(error),
+    })
   } finally {
     generatingRef.value = false
   }
 }
 
+function resolveBoardIndex(boardId: string | null): number {
+  if (boardId && boardId === board1Id.value) return 1
+  if (boardId && boardId === board2Id.value) return 2
+  return 0
+}
+
 async function download3mf(boardId: string | null) {
   if (!boardId) return
   const ch = palette.value.length
+  trackEvent('calibration-download-3mf', {
+    board_index: resolveBoardIndex(boardId),
+    channel_count: ch,
+  })
   await downloadByUrl(
     getBoardModelPath(boardId),
     `calibration-board-${ch}ch-${boardId.slice(0, 8)}.3mf`,
@@ -132,6 +164,10 @@ async function download3mf(boardId: string | null) {
 async function downloadMeta(boardId: string | null) {
   if (!boardId) return
   const ch = palette.value.length
+  trackEvent('calibration-download-meta', {
+    board_index: resolveBoardIndex(boardId),
+    channel_count: ch,
+  })
   await downloadByUrl(
     getBoardMetaPath(boardId),
     `calibration-board-${ch}ch-${boardId.slice(0, 8)}-meta.json`,

--- a/web/frontend/src/components/CalibrationPanel.vue
+++ b/web/frontend/src/components/CalibrationPanel.vue
@@ -18,6 +18,7 @@ import {
 import { useI18n } from 'vue-i18n'
 import { useBlobDownload } from '../composables/useBlobDownload'
 import { generateBoard, getBoardMetaPath, getBoardModelPath } from '../services/calibrationService'
+import { resolveErrorCode, shortenError, toDurationMs, trackEvent } from '../services/analytics'
 import type { FaceOrientation, NozzleSize, PaletteChannel } from '../types'
 
 type EditablePaletteChannel = PaletteChannel & {
@@ -99,6 +100,14 @@ async function handleGenerate() {
     }
   }
 
+  const channelCount = palette.value.length
+  trackEvent('calibration-generate-start', {
+    board_index: 1,
+    channel_count: channelCount,
+    nozzle_size: nozzleSize.value,
+    face_orientation: faceOrientation.value,
+  })
+  const startTs = performance.now()
   generating.value = true
   boardId.value = null
   try {
@@ -109,12 +118,25 @@ async function handleGenerate() {
     })
     boardId.value = response.board_id
     message.success(t('calibration.generateSuccess'))
+    trackEvent('calibration-generate-complete', {
+      board_index: 1,
+      channel_count: channelCount,
+      nozzle_size: nozzleSize.value,
+      face_orientation: faceOrientation.value,
+      duration_ms: toDurationMs(performance.now() - startTs),
+    })
   } catch (error: unknown) {
     message.error(
       t('calibration.generateFailed', {
         error: error instanceof Error ? error.message : String(error),
       }),
     )
+    trackEvent('calibration-generate-fail', {
+      board_index: 1,
+      channel_count: channelCount,
+      error: shortenError(error),
+      error_code: resolveErrorCode(error),
+    })
   } finally {
     generating.value = false
   }
@@ -123,6 +145,10 @@ async function handleGenerate() {
 async function download3mf() {
   if (!boardId.value) return
   const ch = palette.value.length
+  trackEvent('calibration-download-3mf', {
+    board_index: 1,
+    channel_count: ch,
+  })
   await downloadByUrl(
     getBoardModelPath(boardId.value),
     `calibration-board-${ch}ch-${boardId.value.slice(0, 8)}.3mf`,
@@ -132,6 +158,10 @@ async function download3mf() {
 async function downloadMeta() {
   if (!boardId.value) return
   const ch = palette.value.length
+  trackEvent('calibration-download-meta', {
+    board_index: 1,
+    channel_count: ch,
+  })
   await downloadByUrl(
     getBoardMetaPath(boardId.value),
     `calibration-board-${ch}ch-${boardId.value.slice(0, 8)}-meta.json`,

--- a/web/frontend/src/components/CheckUpdateLink.vue
+++ b/web/frontend/src/components/CheckUpdateLink.vue
@@ -2,6 +2,7 @@
 import { useI18n } from 'vue-i18n'
 import { NText, useMessage } from 'naive-ui'
 import { useUpdateChecker } from '../composables/feature/useUpdateChecker'
+import { trackEvent } from '../services/analytics'
 
 const { t } = useI18n()
 const message = useMessage()
@@ -9,6 +10,12 @@ const { checking, checkForUpdate, hasUpdate, lastCheckFailed } = useUpdateChecke
 
 async function handleClick() {
   const found = await checkForUpdate()
+  const result: 'has-update' | 'no-update' | 'fail' = found
+    ? 'has-update'
+    : lastCheckFailed.value
+      ? 'fail'
+      : 'no-update'
+  trackEvent('check-update-click', { result })
   if (!found && !hasUpdate.value) {
     if (lastCheckFailed.value) {
       message.warning(t('app.update.checkFailed'))

--- a/web/frontend/src/components/ConvertPanel.vue
+++ b/web/frontend/src/components/ConvertPanel.vue
@@ -15,6 +15,13 @@ import { mapTaskError } from '../domain/error/taskErrorMapping'
 import { useAppStore } from '../stores/app'
 import ProgressActionGroup from './common/ProgressActionGroup.vue'
 import type { TaskStatus } from '../types'
+import {
+  trackEvent,
+  toDurationMs,
+  roundKb,
+  shortenError,
+  resolveErrorCode,
+} from '../services/analytics'
 
 const appStore = useAppStore()
 const { selectedFile, params, inputType, completedTask } = storeToRefs(appStore)
@@ -61,20 +68,23 @@ const {
 } = useAsyncTask<TaskStatus>(submitCurrentTask, fetchConvertTaskStatus, {
   onCompleted(s) {
     appStore.setCompletedTask(s)
-    window.umami?.track('convert-complete', {
-      inputType: inputType.value,
-      has3mf: Boolean(s.result?.has_3mf),
-      elapsed_s: s.elapsed_ms != null ? Math.round(s.elapsed_ms / 1000) : -1,
+    trackEvent('convert-complete', {
+      input_type: inputType.value,
+      has_3mf: Boolean(s.result?.has_3mf),
+      duration_ms: toDurationMs(s.elapsed_ms),
       width: s.result?.input_width ?? 0,
       height: s.result?.input_height ?? 0,
       avg_de: s.result?.stats?.avg_db_de ?? -1,
+      colordb_count: params.value.db_names?.length ?? 0,
     })
   },
   onFailed(s) {
     appStore.markTaskFailed()
-    window.umami?.track('convert-fail', {
-      inputType: inputType.value,
-      error: (s.error ?? 'unknown').slice(0, 120),
+    const err = s.error ?? 'unknown'
+    trackEvent('convert-fail', {
+      input_type: inputType.value,
+      error: shortenError(err),
+      error_code: resolveErrorCode(err),
     })
   },
 })
@@ -149,10 +159,12 @@ const download3mfFilename = computed(() => {
 
 async function handleConvert() {
   if (!selectedFile.value) return
-  window.umami?.track('convert-start', {
-    inputType: inputType.value,
+  trackEvent('convert-start', {
+    input_type: inputType.value,
     color_layers: params.value.color_layers ?? 0,
     model_enable: Boolean(params.value.model_enable),
+    input_size_kb: roundKb(selectedFile.value.size),
+    colordb_count: params.value.db_names?.length ?? 0,
   })
   appStore.markTaskStarted()
   await submitTask()
@@ -173,20 +185,22 @@ const {
   onCompleted(s) {
     appStore.setCompletedTask(s)
     appStore.setRecipeEditorTaskId(s.id)
-    window.umami?.track('match-preview-complete', {
-      inputType: inputType.value,
-      elapsed_s: s.elapsed_ms != null ? Math.round(s.elapsed_ms / 1000) : -1,
+    trackEvent('match-preview-complete', {
+      input_type: inputType.value,
+      duration_ms: toDurationMs(s.elapsed_ms),
       width: s.result?.input_width ?? 0,
       height: s.result?.input_height ?? 0,
       avg_de: s.result?.stats?.avg_db_de ?? -1,
     })
-    window.umami?.track('recipe-editor-open')
+    trackEvent('recipe-open')
   },
   onFailed(s) {
     appStore.markTaskFailed()
-    window.umami?.track('match-preview-fail', {
-      inputType: inputType.value,
-      error: (s.error ?? 'unknown').slice(0, 120),
+    const err = s.error ?? 'unknown'
+    trackEvent('match-preview-fail', {
+      input_type: inputType.value,
+      error: shortenError(err),
+      error_code: resolveErrorCode(err),
     })
   },
 })
@@ -216,10 +230,12 @@ const canMatchPreview = computed(() => {
 
 async function handleMatchPreview() {
   if (!selectedFile.value) return
-  window.umami?.track('match-preview-start', {
-    inputType: inputType.value,
+  trackEvent('match-preview-start', {
+    input_type: inputType.value,
     color_layers: params.value.color_layers ?? 0,
     model_enable: Boolean(params.value.model_enable),
+    input_size_kb: roundKb(selectedFile.value.size),
+    colordb_count: params.value.db_names?.length ?? 0,
   })
   appStore.markTaskStarted()
   await submitMatch()
@@ -231,7 +247,7 @@ async function handleDownload3MF() {
   const filename = download3mfFilename.value
   try {
     await downloadByUrl(getResultPath(completedTaskId.value), filename)
-    window.umami?.track('download-3mf', { filename })
+    trackEvent('convert-download-3mf', { filename })
   } catch {
     // error is already handled by runtime abstraction caller when needed
   } finally {

--- a/web/frontend/src/components/ImageUpload.vue
+++ b/web/frontend/src/components/ImageUpload.vue
@@ -16,6 +16,7 @@ import {
 } from '../domain/upload/imageUploadValidation'
 import { getUploadMaxMb, getUploadMaxPixels } from '../runtime/env'
 import { useI18n } from 'vue-i18n'
+import { trackEvent } from '../services/analytics'
 
 const { t } = useI18n()
 
@@ -76,7 +77,7 @@ async function handleChange(options: { fileList: UploadFileInfo[] }) {
     uploadError.value = null
     appStore.setSelectedFile(rawFile)
     const type: InputType = isSvgFile(rawFile) ? 'vector' : 'raster'
-    window.umami?.track('image-select', { type })
+    trackEvent('image-select', { input_type: type })
   }
 }
 

--- a/web/frontend/src/components/MattingPanel.vue
+++ b/web/frontend/src/components/MattingPanel.vue
@@ -46,6 +46,13 @@ import {
   postprocessMatting,
   submitMatting,
 } from '../services/mattingService'
+import {
+  resolveErrorCode,
+  roundKb,
+  shortenError,
+  toDurationMs,
+  trackEvent,
+} from '../services/analytics'
 
 const { t } = useI18n()
 
@@ -349,6 +356,11 @@ const {
   fetchMattingTaskStatus,
   {
     onCompleted(status) {
+      trackEvent('matting-complete', {
+        method: status.method,
+        duration_ms: toDurationMs(status.timing?.pipeline_ms ?? null),
+        has_alpha: status.has_alpha,
+      })
       fetchForegroundBlob(taskId.value!)
       if (status.has_alpha) {
         fetchAlphaBlob(taskId.value!)
@@ -357,6 +369,14 @@ const {
         clearBackendResults()
         schedulePostprocess()
       }
+    },
+    onFailed(status) {
+      const err = status.error ?? 'unknown'
+      trackEvent('matting-fail', {
+        method: status.method || selectedMethod.value || 'unknown',
+        error: shortenError(err),
+        error_code: resolveErrorCode(err),
+      })
     },
   },
 )
@@ -370,6 +390,10 @@ const canExecute = computed(
 
 async function handleMatting() {
   if (!file.value || !selectedMethod.value) return
+  trackEvent('matting-start', {
+    method: selectedMethod.value,
+    input_size_kb: roundKb(file.value.size),
+  })
   revokeBlobUrls()
   panZoomGroups.resetAll()
   await submitTask()
@@ -432,6 +456,7 @@ async function runPostprocess() {
   const id = taskId.value
   if (!id || !isCompleted.value) return
   postprocessing.value = true
+  const startTs = performance.now()
   try {
     const result = await postprocessMatting(id, {
       threshold: threshold.value,
@@ -480,6 +505,9 @@ async function runPostprocess() {
       revokeUrl(outlineBlobUrl.value)
       outlineBlobUrl.value = null
     }
+    trackEvent('matting-postprocess-done', {
+      duration_ms: toDurationMs(performance.now() - startTs),
+    })
   } catch (e: unknown) {
     if (taskId.value !== id) return
     error.value = e instanceof Error ? e.message : t('matting.postprocessFailed')
@@ -645,6 +673,7 @@ function handleDownloadMask() {
   const url = processedFgBlobUrl.value
     ? getMattingProcessedMaskPath(taskId.value)
     : getMattingMaskPath(taskId.value)
+  trackEvent('matting-download-mask')
   downloadBlob(url, `${fileBaseName.value}_mask.png`)
 }
 
@@ -653,6 +682,7 @@ async function handleDownloadForeground() {
   if (!url) return
   try {
     await downloadByObjectUrl(url, `${fileBaseName.value}_foreground.png`)
+    trackEvent('matting-download-foreground')
   } catch {
     // handled by useBlobDownload callback
   }
@@ -666,6 +696,7 @@ function handleUseForegroundForConvert() {
   })
   appStore.setSelectedFile(resultFile)
   appStore.activeTab = 'convert'
+  trackEvent('matting-use-for-convert')
 }
 
 // ── Computed helpers ─────────────────────────────────────────────────────

--- a/web/frontend/src/components/UpdateBanner.vue
+++ b/web/frontend/src/components/UpdateBanner.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { NAlert, NButton, NSpace, NText } from 'naive-ui'
 import { useUpdateChecker } from '../composables/feature/useUpdateChecker'
+import { trackEvent } from '../services/analytics'
 
 const { t } = useI18n()
 const { latestVersion, changelog, downloadUrl, showBanner, dismiss } = useUpdateChecker()
@@ -15,11 +16,20 @@ const changelogLines = computed(() => {
     .map((l) => l.trim())
     .filter(Boolean)
 })
+
+function onDismissClick() {
+  trackEvent('update-banner-click', { action: 'dismiss' })
+  dismiss()
+}
+
+function onDownloadClick() {
+  trackEvent('update-banner-click', { action: 'download' })
+}
 </script>
 
 <template>
   <div v-if="showBanner" class="update-banner">
-    <NAlert type="info" closable @close="dismiss">
+    <NAlert type="info" closable @close="onDismissClick">
       <template #header>
         {{ t('app.update.newVersionAvailable', { version: latestVersion }) }}
       </template>
@@ -38,6 +48,7 @@ const changelogLines = computed(() => {
             rel="noopener noreferrer"
             type="info"
             size="small"
+            @click="onDownloadClick"
           >
             {{ t('app.update.download') }}
           </NButton>

--- a/web/frontend/src/components/VectorizePanel.vue
+++ b/web/frontend/src/components/VectorizePanel.vue
@@ -44,6 +44,13 @@ import {
   getVectorizeSvgPath,
   submitVectorize,
 } from '../services/vectorizeService'
+import {
+  trackEvent,
+  toDurationMs,
+  roundKb,
+  shortenError,
+  resolveErrorCode,
+} from '../services/analytics'
 
 const { t } = useI18n()
 
@@ -75,7 +82,7 @@ const upload = useRasterToolUpload({
 
 const {
   backendMaxUploadMb,
-  clearFile,
+  clearFile: clearFileRaw,
   file,
   fileList,
   handleUploadChange,
@@ -85,6 +92,13 @@ const {
   rasterImageAccept,
   rasterImageFormatsText,
 } = upload
+
+function clearFile() {
+  if (file.value) {
+    trackEvent('vectorize-clear-file')
+  }
+  clearFileRaw()
+}
 
 const submitParams = computed<VectorizeParams>(() =>
   normalizeVectorizeParams(params.value, defaultVectorizeParams),
@@ -106,8 +120,23 @@ const {
   () => submitVectorize(file.value!, submitParams.value),
   fetchVectorizeTaskStatus,
   {
-    onCompleted() {
+    onCompleted(s) {
+      trackEvent('vectorize-complete', {
+        duration_ms: toDurationMs(s.timing?.pipeline_ms ?? null),
+        width: s.width,
+        height: s.height,
+        num_shapes: s.num_shapes,
+        svg_size_kb: roundKb(s.svg_size),
+        resolved_num_colors: s.resolved_num_colors,
+      })
       fetchSvgBlob(taskId.value!)
+    },
+    onFailed(s) {
+      const err = s.error ?? 'unknown'
+      trackEvent('vectorize-fail', {
+        error: shortenError(err),
+        error_code: resolveErrorCode(err),
+      })
     },
   },
 )
@@ -119,6 +148,10 @@ const canExecute = computed(() => file.value !== null && !loading.value)
 
 async function handleVectorize() {
   if (!file.value) return
+  trackEvent('vectorize-start', {
+    input_size_kb: roundKb(file.value.size),
+    num_colors: submitParams.value.num_colors ?? 0,
+  })
   revokeBlobUrls()
   svgContent.value = null
   panZoomGroups.resetAll()
@@ -170,6 +203,9 @@ async function handleDownloadSvg() {
   if (!svgBlobUrl.value) return
   try {
     await downloadByObjectUrl(svgBlobUrl.value, `${fileBaseName.value}.svg`)
+    trackEvent('vectorize-download-svg', {
+      svg_size_kb: roundKb(taskStatus.value?.svg_size ?? null),
+    })
   } catch {
     // handled by useBlobDownload callback
   }
@@ -182,6 +218,7 @@ function handleUseSvgForConvert() {
   })
   appStore.setSelectedFile(resultFile)
   appStore.activeTab = 'convert'
+  trackEvent('vectorize-use-for-convert')
 }
 
 // ── Computed helpers ─────────────────────────────────────────────────────

--- a/web/frontend/src/components/calibration/ColorDBBuildSection.vue
+++ b/web/frontend/src/components/calibration/ColorDBBuildSection.vue
@@ -16,6 +16,7 @@ import {
 import { useI18n } from 'vue-i18n'
 import { useBlobDownload } from '../../composables/useBlobDownload'
 import { useColorDBBuildFlow } from '../../composables/useColorDBBuildFlow'
+import { trackEvent } from '../../services/analytics'
 import { getSessionColorDBDownloadPath } from '../../services/sessionColorDBService'
 import CalibrationLocatePreview from './CalibrationLocatePreview.vue'
 import ColorDBResultOverview from './ColorDBResultOverview.vue'
@@ -87,6 +88,7 @@ async function handleBuildAndNotify() {
 
 async function downloadBuiltDB() {
   if (!builtDB.value) return
+  trackEvent('colordb-download-json')
   await downloadByUrl(
     getSessionColorDBDownloadPath(builtDB.value.name),
     `${builtDB.value.name}.json`,

--- a/web/frontend/src/components/calibration/ColorDBUploadSection.vue
+++ b/web/frontend/src/components/calibration/ColorDBUploadSection.vue
@@ -21,6 +21,7 @@ import { useI18n } from 'vue-i18n'
 import { useColorDBUploadFlow } from '../../composables/useColorDBUploadFlow'
 import { fetchSessionColorDBs, deleteSessionColorDB } from '../../api/session'
 import { roundTo } from '../../runtime/number'
+import { trackEvent } from '../../services/analytics'
 import type { ColorDBInfo } from '../../types'
 
 const { t } = useI18n()
@@ -88,18 +89,23 @@ async function loadSessionDbs() {
 
 async function handleDelete(name: string) {
   deletingName.value = name
+  let ok = 0
+  let fail = 0
   try {
     await deleteSessionColorDB(name)
+    ok = 1
     message.success(t('colordb.upload.messages.deleted', { name }))
     emit('colordb-updated')
     await loadSessionDbs()
   } catch (err: unknown) {
+    fail = 1
     message.error(
       t('colordb.upload.messages.deleteFailed', {
         error: err instanceof Error ? err.message : String(err),
       }),
     )
   } finally {
+    trackEvent('colordb-delete', { mode: 'single', ok, fail })
     deletingName.value = null
   }
 }
@@ -118,6 +124,7 @@ async function handleBatchDelete() {
       fail++
     }
   }
+  trackEvent('colordb-delete', { mode: 'batch', ok, fail })
   if (ok > 0) emit('colordb-updated')
   if (fail === 0) {
     message.success(t('colordb.upload.messages.batchDeleted', { count: ok }))

--- a/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
+++ b/web/frontend/src/components/recipeEditor/RecipeEditorPanel.vue
@@ -33,6 +33,7 @@ import RegionOverlayCanvas from './RegionOverlayCanvas.vue'
 import ZoomableImageViewport from '../common/ZoomableImageViewport.vue'
 import { useBlobDownload } from '../../composables/useBlobDownload'
 import { getResultPath } from '../../services/resultService'
+import { trackEvent, toDurationMs, shortenError, resolveErrorCode } from '../../services/analytics'
 
 const props = defineProps<{
   taskId: string
@@ -332,7 +333,7 @@ async function handleCandidateSelect(candidate: RecipeCandidate) {
     }
 
     if (generateDone.value) editedAfterGenerate.value = true
-    window.umami?.track('recipe-replace', { regionCount: regionIds.length })
+    trackEvent('recipe-replace', { region_count: regionIds.length })
     message.success(t('recipeEditor.replaceSuccess'))
   } catch (e) {
     message.error(e instanceof Error ? e.message : String(e))
@@ -346,6 +347,7 @@ async function handleUndo() {
   if (undoStack.value.length === 0 || !summary.value) return
   const entry = undoStack.value.pop()!
   replacing.value = true
+  trackEvent('recipe-undo')
   try {
     const newSummary = await replaceRecipe(
       props.taskId,
@@ -444,6 +446,7 @@ async function handleGenerate() {
   generateDone.value = false
   editedAfterGenerate.value = false
   appStore.clearCompletedTask()
+  const startedAt = performance.now()
   try {
     await submitGenerateModel(props.taskId)
     const status = await waitForRecipeGeneration(props.taskId, {
@@ -452,11 +455,16 @@ async function handleGenerate() {
     })
     appStore.setCompletedTask(status)
     generateDone.value = true
-    window.umami?.track('generate-model-complete')
+    trackEvent('recipe-generate-complete', {
+      duration_ms: toDurationMs(performance.now() - startedAt),
+    })
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
     generateError.value = msg
-    window.umami?.track('generate-model-fail', { error: msg.slice(0, 120) })
+    trackEvent('recipe-generate-fail', {
+      error: shortenError(e),
+      error_code: resolveErrorCode(e),
+    })
   } finally {
     generating.value = false
   }
@@ -465,9 +473,11 @@ async function handleGenerate() {
 async function handleDownload3MF() {
   if (downloading3mf.value) return
   downloading3mf.value = true
+  const baseName = appStore.selectedFile?.name?.replace(/\.[^.]+$/, '') ?? 'result'
+  const filename = `${baseName}.3mf`
   try {
-    const baseName = appStore.selectedFile?.name?.replace(/\.[^.]+$/, '') ?? 'result'
-    await downloadByUrl(getResultPath(props.taskId), `${baseName}.3mf`)
+    await downloadByUrl(getResultPath(props.taskId), filename)
+    trackEvent('recipe-download-3mf', { filename })
   } catch {
     /* handled by runtime */
   } finally {
@@ -518,6 +528,10 @@ watch(
   },
   { immediate: true },
 )
+
+watch(globalMode, (enabled) => {
+  trackEvent('recipe-global-mode-toggle', { enabled })
+})
 
 onUnmounted(() => {
   stopKeepalive()

--- a/web/frontend/src/composables/feature/useAppLifecycle.ts
+++ b/web/frontend/src/composables/feature/useAppLifecycle.ts
@@ -1,6 +1,7 @@
 import { onMounted, onUnmounted, watch } from 'vue'
 import { useAppStore } from '../../stores/app'
 import type { HealthMemory } from '../../types'
+import { trackEvent } from '../../services/analytics'
 import { useLeaderLease } from './useLeaderLease'
 
 let themeSwitchCleanupTimer: ReturnType<typeof setTimeout> | null = null
@@ -31,8 +32,8 @@ const MB = 1048576
 let memoryReportTimer: ReturnType<typeof setInterval> | null = null
 
 function reportMemoryToUmami(memory: HealthMemory, isLeader: boolean) {
-  if (!isLeader || !window.umami) return
-  window.umami.track('memory-status', {
+  if (!isLeader) return
+  trackEvent('memory-status', {
     rss_mb: Math.round(memory.rss_bytes / MB),
     heap_mb: Math.round(memory.heap_resident_bytes / MB),
     artifact_pct:
@@ -93,6 +94,7 @@ export function useAppLifecycle() {
     () => appStore.isDark,
     (dark) => {
       void syncTheme(dark, appStore)
+      trackEvent('theme-toggle', { theme: dark ? 'dark' : 'light' })
     },
   )
 }

--- a/web/frontend/src/composables/feature/useWhatsNew.ts
+++ b/web/frontend/src/composables/feature/useWhatsNew.ts
@@ -3,6 +3,7 @@ import { useI18n } from 'vue-i18n'
 import { fetchManifestFromUrl } from './versionManifest'
 import type { VersionManifest } from './versionManifest'
 import { getStorageItem, setStorageItem } from '../../runtime/storage'
+import { trackEvent } from '../../services/analytics'
 
 const SEEN_KEY = 'chromaprint3d-whats-new-seen'
 const LOCAL_MANIFEST_PATH = `${import.meta.env.BASE_URL}version-manifest.json`
@@ -60,6 +61,7 @@ export function useWhatsNew() {
     const seen = await getStorageItem(SEEN_KEY)
     if (seen !== data.version) {
       visible.value = true
+      trackEvent('whats-new-open', { trigger: 'auto' })
     }
   }
 

--- a/web/frontend/src/composables/useColorDBBuildFlow.ts
+++ b/web/frontend/src/composables/useColorDBBuildFlow.ts
@@ -2,6 +2,7 @@ import { computed, ref, shallowRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { UploadFileInfo } from 'naive-ui'
 import { buildColorDB, locateCalibrationBoard } from '../api/calibration'
+import { resolveErrorCode, shortenError, toDurationMs, trackEvent } from '../services/analytics'
 import type { ColorDBBuildResult, CalibrationLocateResult } from '../types'
 import { isValidColorDBName } from './colordbName'
 
@@ -156,6 +157,8 @@ export function useColorDBBuildFlow(options: UseColorDBBuildFlowOptions = {}) {
     locateError.value = null
     buildError.value = null
 
+    trackEvent('colordb-locate-start')
+    const startTs = performance.now()
     try {
       if (!boardGeometry.value && metaJsonCache.value) {
         boardGeometry.value = parseMetaGeometry(metaJsonCache.value)
@@ -165,10 +168,17 @@ export function useColorDBBuildFlow(options: UseColorDBBuildFlowOptions = {}) {
       locateResult.value = result
       corners.value = result.corners.map((c) => [c[0], c[1]] as [number, number])
       phase.value = 'preview'
+      trackEvent('colordb-locate-complete', {
+        duration_ms: toDurationMs(performance.now() - startTs),
+      })
       return true
     } catch (error: unknown) {
       locateError.value = error instanceof Error ? error.message : String(error)
       phase.value = 'upload'
+      trackEvent('colordb-locate-fail', {
+        error: shortenError(error),
+        error_code: resolveErrorCode(error),
+      })
       return false
     }
   }
@@ -180,6 +190,8 @@ export function useColorDBBuildFlow(options: UseColorDBBuildFlowOptions = {}) {
     building.value = true
     builtDB.value = null
     buildError.value = null
+    trackEvent('colordb-build-start')
+    const startTs = performance.now()
     try {
       const result = await buildColorDB(
         calibImage.value,
@@ -189,6 +201,11 @@ export function useColorDBBuildFlow(options: UseColorDBBuildFlowOptions = {}) {
       )
       builtDB.value = result
       phase.value = 'result'
+      trackEvent('colordb-build-complete', {
+        num_channels: result.num_channels,
+        num_entries: result.num_entries,
+        duration_ms: toDurationMs(performance.now() - startTs),
+      })
       if (options.onBuilt) {
         await options.onBuilt(result)
       }
@@ -196,6 +213,10 @@ export function useColorDBBuildFlow(options: UseColorDBBuildFlowOptions = {}) {
     } catch (error: unknown) {
       buildError.value = error instanceof Error ? error.message : String(error)
       phase.value = 'preview'
+      trackEvent('colordb-build-fail', {
+        error: shortenError(error),
+        error_code: resolveErrorCode(error),
+      })
       return null
     } finally {
       building.value = false

--- a/web/frontend/src/composables/useColorDBUploadFlow.ts
+++ b/web/frontend/src/composables/useColorDBUploadFlow.ts
@@ -2,6 +2,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { UploadFileInfo } from 'naive-ui'
 import { uploadColorDB } from '../api/session'
+import { trackEvent } from '../services/analytics'
 import type { ColorDBInfo } from '../types'
 
 export interface UploadResultItem {
@@ -75,6 +76,14 @@ export function useColorDBUploadFlow(options: UseColorDBUploadFlowOptions = {}) 
           ? (results[0]?.error ?? t('colordb.upload.messages.singleUploadFailed'))
           : t('colordb.upload.messages.allUploadFailed')
     }
+
+    const failCount = results.length - uploaded.length
+    trackEvent('colordb-upload', {
+      mode: files.length > 1 ? 'batch' : 'single',
+      count: files.length,
+      ok: uploaded.length,
+      fail: failCount,
+    })
 
     if (options.onBatchDone) {
       await options.onBatchDone(results)

--- a/web/frontend/src/composables/useElectronMattingModels.ts
+++ b/web/frontend/src/composables/useElectronMattingModels.ts
@@ -2,6 +2,7 @@ import { computed, ref, type ComputedRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toErrorMessage } from '../runtime/error'
 import { isElectronRuntime } from '../runtime/platform'
+import { resolveErrorCode, shortenError, toDurationMs, trackEvent } from '../services/analytics'
 
 const CONNECTIVITY_CACHE_TTL_MS = 60_000
 
@@ -111,6 +112,7 @@ export function useElectronMattingModels(hasOnlyOpenCvMethod: ComputedRef<boolea
     const checkConnectivity = window.electron?.models?.checkConnectivity
     if (!checkConnectivity) return null
     modelConnectivityLoading.value = true
+    const startTs = performance.now()
     try {
       const report = await checkConnectivity()
       modelConnectivity.value = report
@@ -119,6 +121,11 @@ export function useElectronMattingModels(hasOnlyOpenCvMethod: ComputedRef<boolea
       } else if (modelError.value?.includes(t('matting.connectivity.checkLabel'))) {
         modelError.value = null
       }
+      trackEvent('matting-connectivity-check', {
+        available_sources: report.availableSources,
+        total_sources: report.totalSources,
+        duration_ms: toDurationMs(performance.now() - startTs),
+      })
       return report
     } catch (error: unknown) {
       modelError.value = toErrorMessage(error, t('matting.connectivity.checkFailed'))
@@ -145,6 +152,9 @@ export function useElectronMattingModels(hasOnlyOpenCvMethod: ComputedRef<boolea
     }
   }
 
+  let downloadStartTs: number | null = null
+  let downloadInitialTotalCount = 0
+
   function bindModelProgressListener() {
     if (!isElectron) return
     const modelsApi = window.electron?.models
@@ -157,8 +167,20 @@ export function useElectronMattingModels(hasOnlyOpenCvMethod: ComputedRef<boolea
         downloadSessionBaseBytes.value = payload.downloadedBytes
         downloadSessionTotalBytes.value = Math.max(0, payload.totalBytes - payload.downloadedBytes)
       }
+      if (payload.type === 'completed' && downloadStartTs !== null) {
+        trackEvent('matting-model-download-complete', {
+          duration_ms: toDurationMs(performance.now() - downloadStartTs),
+          total_count: downloadInitialTotalCount,
+        })
+        downloadStartTs = null
+      }
       if (payload.type === 'error') {
         modelError.value = payload.message
+        trackEvent('matting-model-download-fail', {
+          error: shortenError(payload.message),
+          error_code: resolveErrorCode(payload.message),
+        })
+        downloadStartTs = null
       }
       if (
         payload.type === 'completed' ||
@@ -178,6 +200,14 @@ export function useElectronMattingModels(hasOnlyOpenCvMethod: ComputedRef<boolea
     modelProgress.value = null
     downloadSessionBaseBytes.value = 0
     downloadSessionTotalBytes.value = requiredDownloadBytes.value
+    const pendingCount = pendingModelCount.value
+    const totalCount = modelStatus.value?.totalModels ?? 0
+    downloadStartTs = performance.now()
+    downloadInitialTotalCount = totalCount
+    trackEvent('matting-model-download-start', {
+      pending_count: pendingCount,
+      total_count: totalCount,
+    })
     try {
       const connectivity = await checkModelConnectivity()
       if (!connectivity || connectivity.availableSources <= 0) {
@@ -187,6 +217,17 @@ export function useElectronMattingModels(hasOnlyOpenCvMethod: ComputedRef<boolea
       modelStatus.value = await startDownload()
     } catch (error: unknown) {
       modelError.value = toErrorMessage(error, t('matting.model.downloadFailed'))
+      // Pre-download or synchronous failures never reach the progress listener,
+      // so we emit the fail event here to guarantee every "start" has a paired
+      // terminal event. The progress listener only fires if the IPC task was
+      // actually scheduled by the main process.
+      if (downloadStartTs !== null) {
+        trackEvent('matting-model-download-fail', {
+          error: shortenError(error),
+          error_code: resolveErrorCode(error),
+        })
+        downloadStartTs = null
+      }
     } finally {
       modelActionLoading.value = false
       await refreshModelStatus()
@@ -196,6 +237,8 @@ export function useElectronMattingModels(hasOnlyOpenCvMethod: ComputedRef<boolea
   async function handleCancelModelDownload() {
     const cancelDownload = window.electron?.models?.cancelDownload
     if (!cancelDownload) return
+    trackEvent('matting-model-download-cancel')
+    downloadStartTs = null
     try {
       await cancelDownload()
     } catch (error: unknown) {

--- a/web/frontend/src/electron.d.ts
+++ b/web/frontend/src/electron.d.ts
@@ -122,12 +122,10 @@ declare global {
 
   interface Window {
     electron?: ElectronRendererApi
-    umami?: {
-      track(): void
-      track(event: string, data?: Record<string, unknown>): void
-      track(callback: () => { name: string; data?: Record<string, unknown> }): void
-      track(callback: (props: Record<string, unknown>) => Record<string, unknown>): void
-    }
+    // Intentionally omitted: `window.umami` is an implementation detail of
+    // `src/services/analytics.ts`. All call sites must route through
+    // `trackEvent` / `trackPageview` so event names and payload shapes stay
+    // type-checked and testable.
   }
 
   interface ImportMetaEnv {

--- a/web/frontend/src/main.ts
+++ b/web/frontend/src/main.ts
@@ -2,21 +2,12 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import i18n from './locales'
+import { initAnalytics } from './services/analytics'
 import './styles/base.css'
 import './styles/app-shell.css'
 import './styles/calibration.css'
 
-const umamiHost = import.meta.env.VITE_UMAMI_HOST
-const umamiWebsiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID
-if (umamiHost && umamiWebsiteId) {
-  const script = document.createElement('script')
-  script.defer = true
-  script.src = `${umamiHost}/script.js`
-  script.dataset.websiteId = umamiWebsiteId
-  script.dataset.domains = window.location.hostname
-  script.dataset.performance = 'true'
-  document.head.appendChild(script)
-}
+initAnalytics()
 
 const app = createApp(App)
 app.use(createPinia())

--- a/web/frontend/src/services/analytics.ts
+++ b/web/frontend/src/services/analytics.ts
@@ -1,0 +1,552 @@
+import i18n from '../locales'
+import { getRuntimeKind, isElectronRuntime } from '../runtime/platform'
+
+// ---------------------------------------------------------------------------
+// Event catalog
+//
+// All custom events MUST be registered here so that:
+//   - `EventName` is a closed union, preventing typos / drift at call sites.
+//   - `EventPayloadMap` provides compile-time shape checking for each event.
+// ---------------------------------------------------------------------------
+
+export const EVENT_NAMES = [
+  // Convert (raster / vector → 3MF)
+  'image-select',
+  'convert-start',
+  'convert-complete',
+  'convert-fail',
+  'match-preview-start',
+  'match-preview-complete',
+  'match-preview-fail',
+  'convert-download-3mf',
+  // Recipe editor / model regeneration
+  'recipe-open',
+  'recipe-replace',
+  'recipe-undo',
+  'recipe-global-mode-toggle',
+  'recipe-generate-complete',
+  'recipe-generate-fail',
+  'recipe-download-3mf',
+  // Vectorize
+  'vectorize-start',
+  'vectorize-complete',
+  'vectorize-fail',
+  'vectorize-download-svg',
+  'vectorize-use-for-convert',
+  'vectorize-clear-file',
+  // Matting (background removal)
+  'matting-model-download-start',
+  'matting-model-download-complete',
+  'matting-model-download-fail',
+  'matting-model-download-cancel',
+  'matting-connectivity-check',
+  'matting-start',
+  'matting-complete',
+  'matting-fail',
+  'matting-postprocess-done',
+  'matting-download-mask',
+  'matting-download-foreground',
+  'matting-use-for-convert',
+  // Calibration (board generation)
+  'calibration-generate-start',
+  'calibration-generate-complete',
+  'calibration-generate-fail',
+  'calibration-download-3mf',
+  'calibration-download-meta',
+  // ColorDB build / upload / delete
+  'colordb-locate-start',
+  'colordb-locate-complete',
+  'colordb-locate-fail',
+  'colordb-build-start',
+  'colordb-build-complete',
+  'colordb-build-fail',
+  'colordb-download-json',
+  'colordb-upload',
+  'colordb-delete',
+  // UI interactions
+  'locale-toggle',
+  'theme-toggle',
+  'tutorial-click',
+  'github-click',
+  'makerworld-click',
+  'whats-new-open',
+  'announcement-dismiss',
+  'update-banner-click',
+  'check-update-click',
+  // Lifecycle telemetry
+  'memory-status',
+] as const
+
+export type EventName = (typeof EVENT_NAMES)[number]
+
+type InputKind = 'raster' | 'vector'
+
+type BulkMode = 'single' | 'batch'
+
+type EmptyPayload = Record<string, never>
+
+export interface EventPayloadMap {
+  // ---- Convert ----
+  'image-select': { input_type: InputKind }
+  'convert-start': {
+    input_type: InputKind
+    color_layers: number
+    model_enable: boolean
+    input_size_kb: number
+    colordb_count: number
+  }
+  'convert-complete': {
+    input_type: InputKind
+    has_3mf: boolean
+    duration_ms: number
+    width: number
+    height: number
+    avg_de: number
+    colordb_count: number
+  }
+  'convert-fail': {
+    input_type: InputKind
+    error: string
+    error_code: string
+  }
+  'match-preview-start': {
+    input_type: InputKind
+    color_layers: number
+    model_enable: boolean
+    input_size_kb: number
+    colordb_count: number
+  }
+  'match-preview-complete': {
+    input_type: InputKind
+    duration_ms: number
+    width: number
+    height: number
+    avg_de: number
+  }
+  'match-preview-fail': {
+    input_type: InputKind
+    error: string
+    error_code: string
+  }
+  'convert-download-3mf': { filename: string }
+
+  // ---- Recipe ----
+  'recipe-open': EmptyPayload
+  'recipe-replace': { region_count: number }
+  'recipe-undo': EmptyPayload
+  'recipe-global-mode-toggle': { enabled: boolean }
+  'recipe-generate-complete': { duration_ms: number }
+  'recipe-generate-fail': { error: string; error_code: string }
+  'recipe-download-3mf': { filename: string }
+
+  // ---- Vectorize ----
+  'vectorize-start': { input_size_kb: number; num_colors: number }
+  'vectorize-complete': {
+    duration_ms: number
+    width: number
+    height: number
+    num_shapes: number
+    svg_size_kb: number
+    resolved_num_colors: number
+  }
+  'vectorize-fail': { error: string; error_code: string }
+  'vectorize-download-svg': { svg_size_kb: number }
+  'vectorize-use-for-convert': EmptyPayload
+  'vectorize-clear-file': EmptyPayload
+
+  // ---- Matting ----
+  'matting-model-download-start': { pending_count: number; total_count: number }
+  'matting-model-download-complete': { duration_ms: number; total_count: number }
+  'matting-model-download-fail': { error: string; error_code: string }
+  'matting-model-download-cancel': EmptyPayload
+  'matting-connectivity-check': {
+    available_sources: number
+    total_sources: number
+    duration_ms: number
+  }
+  'matting-start': { method: string; input_size_kb: number }
+  'matting-complete': {
+    method: string
+    duration_ms: number
+    has_alpha: boolean
+  }
+  'matting-fail': { method: string; error: string; error_code: string }
+  'matting-postprocess-done': { duration_ms: number }
+  'matting-download-mask': EmptyPayload
+  'matting-download-foreground': EmptyPayload
+  'matting-use-for-convert': EmptyPayload
+
+  // ---- Calibration ----
+  'calibration-generate-start': {
+    board_index: number
+    channel_count: number
+    nozzle_size: string
+    face_orientation: string
+  }
+  'calibration-generate-complete': {
+    board_index: number
+    channel_count: number
+    nozzle_size: string
+    face_orientation: string
+    duration_ms: number
+  }
+  'calibration-generate-fail': {
+    board_index: number
+    channel_count: number
+    error: string
+    error_code: string
+  }
+  'calibration-download-3mf': {
+    board_index: number
+    channel_count: number
+  }
+  'calibration-download-meta': {
+    board_index: number
+    channel_count: number
+  }
+
+  // ---- ColorDB ----
+  'colordb-locate-start': EmptyPayload
+  'colordb-locate-complete': { duration_ms: number }
+  'colordb-locate-fail': { error: string; error_code: string }
+  'colordb-build-start': EmptyPayload
+  'colordb-build-complete': {
+    num_channels: number
+    num_entries: number
+    duration_ms: number
+  }
+  'colordb-build-fail': { error: string; error_code: string }
+  'colordb-download-json': EmptyPayload
+  'colordb-upload': {
+    mode: BulkMode
+    count: number
+    ok: number
+    fail: number
+  }
+  'colordb-delete': {
+    mode: BulkMode
+    ok: number
+    fail: number
+  }
+
+  // ---- UI ----
+  'locale-toggle': { from: string; to: string }
+  'theme-toggle': { theme: 'dark' | 'light' }
+  'tutorial-click': EmptyPayload
+  'github-click': { target: 'repo' | 'issues' }
+  'makerworld-click': EmptyPayload
+  'whats-new-open': { trigger: 'auto' | 'manual' }
+  'announcement-dismiss': { id: string }
+  'update-banner-click': { action: 'download' | 'dismiss' }
+  'check-update-click': { result: 'has-update' | 'no-update' | 'fail' }
+
+  // ---- Lifecycle ----
+  'memory-status': {
+    rss_mb: number
+    heap_mb: number
+    artifact_pct: number
+    usage_pct: number
+    allocator: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal Umami binding (intentionally not declared on `Window`)
+// ---------------------------------------------------------------------------
+
+type UmamiTracker = {
+  track: {
+    (): void
+    (event: string, data?: Record<string, unknown>): void
+    (callback: (props: Record<string, unknown>) => Record<string, unknown>): void
+  }
+  identify: {
+    (data: Record<string, unknown>): void
+    (id: string, data?: Record<string, unknown>): void
+  }
+}
+
+function getUmami(): UmamiTracker | undefined {
+  if (typeof window === 'undefined') return undefined
+  return (window as unknown as { umami?: UmamiTracker }).umami
+}
+
+// ---------------------------------------------------------------------------
+// Session identity
+//
+// A stable, fully anonymous per-install UUID stored in localStorage. No PII.
+// On Electron we do not load the tracker at all, so this key is unused there.
+// ---------------------------------------------------------------------------
+
+const DISTINCT_ID_KEY = 'chromaprint3d-analytics-id'
+
+export interface SessionProperties {
+  runtime: 'electron' | 'browser'
+  channel: 'stable' | 'preview' | 'unknown'
+  version: string
+  locale: string
+}
+
+function readCurrentLocale(): string {
+  const raw = i18n.global.locale as unknown
+  if (raw && typeof raw === 'object' && 'value' in (raw as { value?: unknown })) {
+    const v = (raw as { value?: unknown }).value
+    return typeof v === 'string' ? v : String(v ?? 'unknown')
+  }
+  return typeof raw === 'string' ? raw : 'unknown'
+}
+
+function detectChannel(version: string | undefined | null): SessionProperties['channel'] {
+  if (!version) return 'unknown'
+  if (/-rc\.\d+/i.test(version)) return 'preview'
+  if (/^\d+\.\d+\.\d+$/.test(version)) return 'stable'
+  return 'unknown'
+}
+
+const bootVersion =
+  typeof __APP_VERSION__ === 'string' && __APP_VERSION__ ? __APP_VERSION__ : 'unknown'
+
+let currentSessionProps: SessionProperties = {
+  runtime: getRuntimeKind(),
+  channel: detectChannel(bootVersion),
+  version: bootVersion,
+  locale: readCurrentLocale(),
+}
+
+function getOrCreateDistinctId(): string | null {
+  if (typeof localStorage === 'undefined') return null
+  try {
+    const existing = localStorage.getItem(DISTINCT_ID_KEY)
+    if (existing) return existing
+    const id =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`
+    localStorage.setItem(DISTINCT_ID_KEY, id)
+    return id
+  } catch {
+    return null
+  }
+}
+
+// The Umami snippet is loaded via `<script defer>` so it typically becomes
+// available before Vue's `onMounted` hooks fire, but there is still a window
+// in which early calls could race the script. To avoid losing the very first
+// pageview (triggered on mount) or the `identify` payload, we buffer calls
+// and flush them once `window.umami` is detected. The buffer has a bounded
+// retry window so failures are forgotten rather than leaking memory.
+
+const PENDING_MAX_QUEUE = 64
+const PENDING_MAX_ATTEMPTS = 40 // ~10s total at 250ms
+const pendingCalls: Array<(u: UmamiTracker) => void> = []
+let pendingTimer: ReturnType<typeof setTimeout> | null = null
+let pendingAttempts = 0
+let identifyNeeded = false
+
+function flushPending(): boolean {
+  const umami = getUmami()
+  if (!umami) return false
+  if (identifyNeeded && typeof umami.identify === 'function') {
+    identifyNeeded = false
+    const id = getOrCreateDistinctId()
+    try {
+      if (id) {
+        umami.identify(id, { ...currentSessionProps })
+      } else {
+        umami.identify({ ...currentSessionProps })
+      }
+    } catch {
+      // swallow: analytics must never break the app
+    }
+  }
+  while (pendingCalls.length > 0) {
+    const call = pendingCalls.shift()
+    if (!call) break
+    try {
+      call(umami)
+    } catch {
+      // ignore
+    }
+  }
+  return true
+}
+
+function schedulePendingFlush() {
+  if (flushPending()) return
+  if (pendingTimer != null) return
+  pendingAttempts = 0
+  const retry = () => {
+    pendingTimer = null
+    pendingAttempts += 1
+    if (flushPending()) return
+    if (pendingAttempts >= PENDING_MAX_ATTEMPTS) {
+      // Give up without re-queueing; further calls will restart the loop.
+      pendingCalls.length = 0
+      identifyNeeded = false
+      return
+    }
+    pendingTimer = setTimeout(retry, 250)
+  }
+  pendingTimer = setTimeout(retry, 250)
+}
+
+function enqueuePending(fn: (u: UmamiTracker) => void) {
+  if (pendingCalls.length >= PENDING_MAX_QUEUE) return
+  pendingCalls.push(fn)
+  schedulePendingFlush()
+}
+
+function scheduleIdentify() {
+  identifyNeeded = true
+  schedulePendingFlush()
+}
+
+export function identifyAnonymousUser() {
+  scheduleIdentify()
+}
+
+export function updateSessionProperties(partial: Partial<SessionProperties>) {
+  currentSessionProps = { ...currentSessionProps, ...partial }
+  if (partial.version && (!partial.channel || partial.channel === 'unknown')) {
+    currentSessionProps.channel = detectChannel(partial.version)
+  }
+  scheduleIdentify()
+}
+
+// ---------------------------------------------------------------------------
+// Script injection
+// ---------------------------------------------------------------------------
+
+let initialized = false
+
+export function initAnalytics() {
+  if (initialized) return
+  initialized = true
+  if (typeof document === 'undefined') return
+  // Desktop app is a private single-user environment; tracking browser-only
+  // keeps the Electron binary free of third-party network calls.
+  if (isElectronRuntime()) return
+
+  const host = import.meta.env.VITE_UMAMI_HOST
+  const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID
+  if (!host || !websiteId) return
+
+  const script = document.createElement('script')
+  script.defer = true
+  script.src = `${host}/script.js`
+  script.dataset.websiteId = websiteId
+  script.dataset.hostUrl = host
+  script.dataset.domains = window.location.hostname
+  script.dataset.performance = 'true'
+  script.dataset.doNotTrack = 'true'
+  script.dataset.excludeSearch = 'true'
+  script.dataset.excludeHash = 'true'
+  script.addEventListener('load', () => scheduleIdentify(), { once: true })
+  document.head.appendChild(script)
+}
+
+// ---------------------------------------------------------------------------
+// Normalization utilities
+// ---------------------------------------------------------------------------
+
+/** Round byte count to an integer kilobyte value. Returns 0 for invalid input. */
+export function roundKb(bytes: number | null | undefined): number {
+  if (typeof bytes !== 'number' || !Number.isFinite(bytes) || bytes <= 0) return 0
+  return Math.round(bytes / 1024)
+}
+
+/** Normalize a millisecond elapsed time to a non-negative integer. Returns -1 if unknown. */
+export function toDurationMs(ms: number | null | undefined): number {
+  if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return -1
+  return Math.round(ms)
+}
+
+/** Umami caps strings at 500 chars; we keep messages short so payloads stay readable. */
+export function shortenError(e: unknown): string {
+  const raw = e instanceof Error ? e.message : typeof e === 'string' ? e : String(e ?? '')
+  const trimmed = raw.trim()
+  if (!trimmed) return 'unknown'
+  return trimmed.length > 120 ? trimmed.slice(0, 120) : trimmed
+}
+
+/**
+ * Reduce an arbitrary error into a low-cardinality bucket suitable for
+ * aggregation in Umami. Prefer narrow error codes for dashboarding over the
+ * raw `error` string.
+ */
+export function resolveErrorCode(e: unknown): string {
+  const raw = e instanceof Error ? e.message : typeof e === 'string' ? e : String(e ?? '')
+  if (!raw) return 'unknown'
+  const status = /\b(?:http[\s:]*|status[\s:=]*)(\d{3})\b/i.exec(raw)
+  if (status) return `http_${status[1]}`
+  const bareStatus = /\b([45]\d{2})\b/.exec(raw)
+  if (bareStatus) return `http_${bareStatus[1]}`
+  const lowered = raw.toLowerCase()
+  if (lowered.includes('aborted') || lowered.includes('cancel')) return 'cancelled'
+  if (lowered.includes('timeout')) return 'timeout'
+  if (lowered.includes('network') || lowered.includes('failed to fetch')) return 'network'
+  if (lowered.includes('not found')) return 'not_found'
+  if (lowered.includes('unauthorized')) return 'unauthorized'
+  if (lowered.includes('forbidden')) return 'forbidden'
+  if (lowered.includes('parse') || lowered.includes('json') || lowered.includes('syntax')) {
+    return 'parse_error'
+  }
+  if (lowered.includes('payload') || lowered.includes('too large')) return 'payload_too_large'
+  if (lowered.includes('unsupported') || lowered.includes('invalid')) return 'invalid_input'
+  return 'unknown'
+}
+
+// ---------------------------------------------------------------------------
+// Public tracking API
+// ---------------------------------------------------------------------------
+
+type EmptyEventName = {
+  [K in EventName]: EventPayloadMap[K] extends EmptyPayload ? K : never
+}[EventName]
+
+type PayloadEventName = Exclude<EventName, EmptyEventName>
+
+export function trackEvent<K extends EmptyEventName>(name: K): void
+export function trackEvent<K extends PayloadEventName>(name: K, data: EventPayloadMap[K]): void
+export function trackEvent<K extends EventName>(name: K, data?: EventPayloadMap[K]): void {
+  if (isElectronRuntime()) return
+  const payload = data as Record<string, unknown> | undefined
+  const send = (u: UmamiTracker) => {
+    if (payload && Object.keys(payload).length > 0) {
+      u.track(name, payload)
+    } else {
+      u.track(name)
+    }
+  }
+  const umami = getUmami()
+  if (umami) {
+    try {
+      send(umami)
+    } catch {
+      // never let analytics break the app
+    }
+    return
+  }
+  enqueuePending(send)
+}
+
+export function trackPageview(url: string, title?: string) {
+  if (isElectronRuntime()) return
+  const send = (u: UmamiTracker) => {
+    u.track((props) => ({
+      ...props,
+      url,
+      ...(title ? { title } : {}),
+    }))
+  }
+  const umami = getUmami()
+  if (umami) {
+    try {
+      send(umami)
+    } catch {
+      // noop
+    }
+    return
+  }
+  enqueuePending(send)
+}


### PR DESCRIPTION
## Summary

- 将所有 Umami 调用集中到新增的 `web/frontend/src/services/analytics.ts`：提供类型安全的事件目录 (`EventName` / `EventPayloadMap`)、`distinctId` + 会话属性 (runtime/channel/version/locale) 经 `umami.identify` 注入、异步加载队列 + 有界重试、`duration_ms`/`*_kb`/`error_code` 归一化工具；Electron 运行时整链路静默丢弃，桌面端不发起任何三方请求。
- 修复 `App.vue` 首屏重复虚拟 pageview：三个 `watch` 合并为单一 `computed` + `watch(immediate: false)`，`onMounted` 仅触发一次初始 pageview，每条 pageview 带 i18n 标题；监听 `locale` / `serverVersion` 刷新会话属性。
- 统一事件/字段命名（已记录到 `docs/deployment.md §8.4`）：
  - 字段：`inputType` → `input_type`、`regionCount` → `region_count`、`has3mf` → `has_3mf`、`elapsed_s`(秒整数) → `duration_ms`(毫秒整数)。
  - 事件：`recipe-editor-open` → `recipe-open`、`generate-model-*` → `recipe-generate-*`；下载类统一为 `{module}-download-{format}`（`download-3mf` 拆为 `convert-download-3mf` / `recipe-download-3mf`）。
  - 所有 `*-fail` 事件新增低基数 `error_code`。
- 补齐 Vectorize / Matting (含 `matting-connectivity-check` 与模型下载全生命周期) / Calibration (4 色 + 8 色) / ColorDB (locate / build / upload / delete) 四大模块的 `start` / `complete` / `fail` / `download` 漏斗；补齐 UI 交互事件：locale-change、theme-toggle、tutorial-click、github-click、makerworld-click、whats-new-open、announcement-dismiss、update-banner-click、check-update-click。
- `main.ts` / `electron.d.ts`：改走 `initAnalytics()`，补齐 script dataset (`data-host-url` / `data-do-not-track` / `data-exclude-search` / `data-exclude-hash`)；删除公开的 `window.umami` 类型声明，强制通过 service 调用。
- 文档同步：`docs/deployment.md §8.4` 按模块分组重写事件清单并注明一次性迁移断点；`AGENTS.md` 文档更新触发矩阵新增 Umami schema 变更行；`docs/agents/web/frontend/README.md` 新增 "新增 / 修改 Umami 埋点事件" 落点指引。

## 风险与影响

- **一次性历史断点**：字段/事件重命名会导致 Umami 仪表盘旧报表失效；已在文档与评审中明确接受，历史原始数据保留可回溯。
- **Electron 静默**：桌面端所有埋点不上报（包括 pageview），与现网策略一致，无新增外发流量。
- **异步加载**：Umami 脚本加载失败时，队列在有界重试后丢弃调用，不会造成内存泄漏，也不影响前端主流程。

## 回滚方案

- revert 本 PR 即可恢复旧命名与直接的 `window.umami?.track` 调用；Umami 站点侧无破坏性改动。

## Test plan

- [x] `cd web/frontend && npm run typecheck`
- [x] `cd web/frontend && npm run lint:eslint`
- [x] 审阅 `docs/deployment.md §8.4` 与代码内 `EVENT_NAMES` / `EventPayloadMap` 保持一致
- [ ] 浏览器端验证 Umami 实时看板能收到：首屏 pageview、切 Tab 的虚拟 pageview、locale-change、convert-start/complete、vectorize-start/complete、matting-start/complete、calibration-generate-*、colordb-* 等代表性事件
- [ ] Electron 运行时验证无任何指向 `VITE_UMAMI_HOST` 的网络请求
- [ ] 观察一周 Umami 仪表盘确认各 `*-fail` 事件的 `error_code` 分布合理，`duration_ms` 分位正常