### PR TITLE
refactor(core): zero-copy 3MF mesh export via Vec3u layout bridge

### DIFF
--- a/core/README.en.md
+++ b/core/README.en.md
@@ -138,7 +138,7 @@ All public functions throw subclasses of `ChromaPrint3D::Error` instead of bare 
 
 **Headers:** `vec3.h`, `color.h`
 
-- `Vec3i`: Integer 3-component vector (voxel coordinates, mesh indices)
+- `Vec3<T>`: Integer 3-component vector template, with `Vec3i = Vec3<int32_t>` (voxel coordinates, signed offsets) and `Vec3u = Vec3<uint32_t>` (mesh triangle indices, layout-compatible with `neroued_3mf::IndexTriangle` for zero-copy 3MF export)
 - `Vec3f`: Float 3-component vector (normalization, distance, interpolation, clamping)
 - `Rgb`: Linear sRGB color (components in [0, 1]), with Lab interconversion and gamma encode/decode
 - `Lab`: CIE L\*a\*b\* color, provides `DeltaE76` color difference computation

--- a/core/README.md
+++ b/core/README.md
@@ -138,7 +138,7 @@ core/
 
 **头文件：** `vec3.h`、`color.h`
 
-- `Vec3i`：整型三分量向量（用于体素坐标、网格索引）
+- `Vec3<T>`：整型三分量向量模板，提供 `Vec3i = Vec3<int32_t>`（体素坐标、有符号偏移）与 `Vec3u = Vec3<uint32_t>`（网格三角面索引，与 `neroued_3mf::IndexTriangle` 布局兼容，3MF 导出走零拷贝路径）
 - `Vec3f`：浮点三分量向量（支持归一化、距离、插值、钳位等操作）
 - `Rgb`：线性 sRGB 颜色（各分量 [0, 1]），支持与 Lab 互转、gamma 编解码
 - `Lab`：CIE L\*a\*b\* 颜色，提供 `DeltaE76` 色差计算

--- a/core/include/chromaprint3d/mesh.h
+++ b/core/include/chromaprint3d/mesh.h
@@ -32,7 +32,7 @@ struct BuildMeshConfig {
 /// A simple indexed triangle mesh.
 struct Mesh {
     std::vector<Vec3f> vertices;
-    std::vector<Vec3i> indices;
+    std::vector<Vec3u> indices;
 
     /// Generate a mesh from a VoxelGrid using greedy meshing.
     static Mesh Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg = BuildMeshConfig{});

--- a/core/include/chromaprint3d/vec3.h
+++ b/core/include/chromaprint3d/vec3.h
@@ -5,37 +5,38 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 namespace ChromaPrint3D {
 
-/// 3-component integer vector.
-struct Vec3i {
-    int x = 0; ///< X component.
-    int y = 0; ///< Y component.
-    int z = 0; ///< Z component.
+template <typename T>
+struct Vec3 {
+    T x = 0; ///< X component.
+    T y = 0; ///< Y component.
+    T z = 0; ///< Z component.
 
-    constexpr Vec3i() = default;
+    constexpr Vec3() = default;
 
     /// Constructs a vector with the given components.
     /// \param x_ X component
     /// \param y_ Y component
     /// \param z_ Z component
-    constexpr Vec3i(int x_, int y_, int z_) : x(x_), y(y_), z(z_) {}
+    constexpr Vec3(T x_, T y_, T z_) : x(x_), y(y_), z(z_) {}
 
     /// Vector addition.
-    Vec3i operator+(const Vec3i& o) const { return {x + o.x, y + o.y, z + o.z}; }
+    Vec3 operator+(const Vec3& o) const { return {x + o.x, y + o.y, z + o.z}; }
 
     /// Vector subtraction.
-    Vec3i operator-(const Vec3i& o) const { return {x - o.x, y - o.y, z - o.z}; }
+    Vec3 operator-(const Vec3& o) const { return {x - o.x, y - o.y, z - o.z}; }
 
     /// Scalar multiplication.
-    Vec3i operator*(int s) const { return {x * s, y * s, z * s}; }
+    Vec3 operator*(T s) const { return {x * s, y * s, z * s}; }
 
     /// Scalar division.
-    Vec3i operator/(int s) const { return {x / s, y / s, z / s}; }
+    Vec3 operator/(T s) const { return {x / s, y / s, z / s}; }
 
     /// In-place vector addition.
-    Vec3i& operator+=(const Vec3i& o) {
+    Vec3& operator+=(const Vec3& o) {
         x += o.x;
         y += o.y;
         z += o.z;
@@ -43,7 +44,7 @@ struct Vec3i {
     }
 
     /// In-place vector subtraction.
-    Vec3i& operator-=(const Vec3i& o) {
+    Vec3& operator-=(const Vec3& o) {
         x -= o.x;
         y -= o.y;
         z -= o.z;
@@ -51,7 +52,7 @@ struct Vec3i {
     }
 
     /// In-place scalar multiplication.
-    Vec3i& operator*=(int s) {
+    Vec3& operator*=(T s) {
         x *= s;
         y *= s;
         z *= s;
@@ -59,7 +60,7 @@ struct Vec3i {
     }
 
     /// In-place scalar division.
-    Vec3i& operator/=(int s) {
+    Vec3& operator/=(T s) {
         x /= s;
         y /= s;
         z /= s;
@@ -67,22 +68,30 @@ struct Vec3i {
     }
 
     /// Component access by index (0=x, 1=y, 2=z).
-    int& operator[](int i) { return i == 0 ? x : (i == 1 ? y : z); }
+    T& operator[](int i) { return i == 0 ? x : (i == 1 ? y : z); }
 
     /// Component access by index (0=x, 1=y, 2=z).
-    const int& operator[](int i) const { return i == 0 ? x : (i == 1 ? y : z); }
+    const T& operator[](int i) const { return i == 0 ? x : (i == 1 ? y : z); }
 
     /// Computes the dot product with another vector.
     /// \param o The other vector
     /// \return Dot product result
-    int Dot(const Vec3i& o) const { return x * o.x + y * o.y + z * o.z; }
+    T Dot(const Vec3& o) const { return x * o.x + y * o.y + z * o.z; }
 
     /// Computes the squared length of the vector.
     /// \return Squared length (x² + y² + z²)
-    int LengthSquared() const { return Dot(*this); }
+    T LengthSquared() const { return Dot(*this); }
 };
 
-inline Vec3i operator*(int s, const Vec3i& v) { return v * s; }
+template <typename S, typename T>
+inline Vec3<T> operator*(S s, const Vec3<T>& v) {
+    return v * static_cast<T>(s);
+}
+
+using Vec3i = Vec3<int32_t>;
+using Vec3u = Vec3<uint32_t>;
+
+static_assert(sizeof(Vec3u) == 12, "Vec3u must be 12 bytes for layout compatibility with IndexTriangle");
 
 /// 3-component float vector.
 struct Vec3f {

--- a/core/include/chromaprint3d/vec3.h
+++ b/core/include/chromaprint3d/vec3.h
@@ -102,7 +102,8 @@ using Vec3i = Vec3<int32_t>;
 /// `neroued_3mf::IndexTriangle` layout for zero-copy 3MF export.
 using Vec3u = Vec3<uint32_t>;
 
-static_assert(sizeof(Vec3u) == 12, "Vec3u must be 12 bytes for layout compatibility with IndexTriangle");
+static_assert(sizeof(Vec3u) == 12,
+              "Vec3u must be 12 bytes for layout compatibility with IndexTriangle");
 
 /// 3-component float vector.
 struct Vec3f {

--- a/core/include/chromaprint3d/vec3.h
+++ b/core/include/chromaprint3d/vec3.h
@@ -1,7 +1,9 @@
 #pragma once
 
 /// \file vec3.h
-/// \brief 3-component integer and float vector types.
+/// \brief 3-component vector types: generic `Vec3<T>` (with `Vec3i`/`Vec3u`
+/// aliases) for integer coordinates / mesh indices, and a dedicated `Vec3f`
+/// for floating-point geometry.
 
 #include <algorithm>
 #include <cmath>
@@ -9,6 +11,8 @@
 
 namespace ChromaPrint3D {
 
+/// 3-component generic vector. Used with integer instantiations for voxel
+/// coordinates and mesh indices; see the `Vec3i`/`Vec3u` aliases below.
 template <typename T>
 struct Vec3 {
     T x = 0; ///< X component.
@@ -81,6 +85,9 @@ struct Vec3 {
     /// Computes the squared length of the vector.
     /// \return Squared length (x² + y² + z²)
     T LengthSquared() const { return Dot(*this); }
+
+    /// Componentwise equality (auto-generated `!=` via C++20).
+    bool operator==(const Vec3&) const = default;
 };
 
 template <typename S, typename T>
@@ -88,7 +95,11 @@ inline Vec3<T> operator*(S s, const Vec3<T>& v) {
     return v * static_cast<T>(s);
 }
 
+/// Signed 32-bit integer vector. Used for voxel coordinates and signed offsets.
 using Vec3i = Vec3<int32_t>;
+
+/// Unsigned 32-bit integer vector. Used for mesh triangle indices; matches
+/// `neroued_3mf::IndexTriangle` layout for zero-copy 3MF export.
 using Vec3u = Vec3<uint32_t>;
 
 static_assert(sizeof(Vec3u) == 12, "Vec3u must be 12 bytes for layout compatibility with IndexTriangle");

--- a/core/src/geo/export_3mf.cpp
+++ b/core/src/geo/export_3mf.cpp
@@ -226,13 +226,9 @@ neroued_3mf::Document BuildStandardDocument(const std::vector<InputObject>& obje
     }
     uint32_t bmg_id = builder.AddBaseMaterialGroup(std::move(materials));
 
+    // BuildInputObjects already filters empty meshes; the views here are non-empty.
     for (std::size_t i = 0; i < objects.size(); ++i) {
-        auto view = detail::MakeMeshView(*objects[i].mesh);
-        if (view.triangles.empty()) {
-            spdlog::warn("BuildStandardDocument: object '{}' dropped (empty mesh)",
-                         objects[i].name);
-            continue;
-        }
+        auto view    = detail::MakeMeshView(*objects[i].mesh);
         uint32_t oid = builder.AddMeshObject(objects[i].name, view, bmg_id,
                                              static_cast<uint32_t>(i));
         builder.AddBuildItem(oid);
@@ -284,14 +280,10 @@ neroued_3mf::Document BuildBambuDocument(const std::vector<InputObject>& objects
 
     std::vector<uint32_t> object_ids;
     int part_id = 1;
+    // BuildInputObjects already filters empty meshes; the views here are non-empty.
     for (std::size_t i = 0; i < objects.size(); ++i) {
-        auto view      = detail::MakeMeshView(*objects[i].mesh);
-        int face_count = static_cast<int>(view.triangles.size());
-        if (view.triangles.empty()) {
-            spdlog::warn("BuildBambuDocument: object '{}' dropped (empty mesh)",
-                         objects[i].name);
-            continue;
-        }
+        auto view            = detail::MakeMeshView(*objects[i].mesh);
+        const int face_count = static_cast<int>(view.triangles.size());
 
         uint32_t oid = builder.AddMeshObject(objects[i].name, view);
         builder.AddBuildItem(oid);

--- a/core/src/geo/export_3mf.cpp
+++ b/core/src/geo/export_3mf.cpp
@@ -228,9 +228,9 @@ neroued_3mf::Document BuildStandardDocument(const std::vector<InputObject>& obje
 
     // BuildInputObjects already filters empty meshes; the views here are non-empty.
     for (std::size_t i = 0; i < objects.size(); ++i) {
-        auto view    = detail::MakeMeshView(*objects[i].mesh);
-        uint32_t oid = builder.AddMeshObject(objects[i].name, view, bmg_id,
-                                             static_cast<uint32_t>(i));
+        auto view = detail::MakeMeshView(*objects[i].mesh);
+        uint32_t oid =
+            builder.AddMeshObject(objects[i].name, view, bmg_id, static_cast<uint32_t>(i));
         builder.AddBuildItem(oid);
     }
 

--- a/core/src/geo/export_3mf.cpp
+++ b/core/src/geo/export_3mf.cpp
@@ -4,6 +4,7 @@
 #include "chromaprint3d/version.h"
 #include "chromaprint3d/voxel.h"
 #include "bambu_metadata.h"
+#include "export_bridge.h"
 
 #include <neroued/3mf/neroued_3mf.h>
 
@@ -25,49 +26,6 @@
 
 namespace ChromaPrint3D {
 namespace {
-
-// ── Mesh type conversion ────────────────────────────────────────────────────
-
-bool IsDegenerateTriangle(const Vec3f& a, const Vec3f& b, const Vec3f& c) {
-    Vec3f ab = b - a;
-    Vec3f ac = c - a;
-    float cx = ab.y * ac.z - ab.z * ac.y;
-    float cy = ab.z * ac.x - ab.x * ac.z;
-    float cz = ab.x * ac.y - ab.y * ac.x;
-    return (cx * cx + cy * cy + cz * cz) <= 1e-12f;
-}
-
-neroued_3mf::Mesh ConvertMesh(const Mesh& src) {
-    neroued_3mf::Mesh dst;
-    const std::size_t vc = src.vertices.size();
-
-    dst.vertices.reserve(vc);
-    for (const Vec3f& v : src.vertices) { dst.vertices.push_back({v.x, v.y, v.z}); }
-
-    dst.triangles.reserve(src.indices.size());
-    std::size_t dropped = 0;
-    for (const Vec3i& tri : src.indices) {
-        if (tri.x < 0 || tri.y < 0 || tri.z < 0 || static_cast<std::size_t>(tri.x) >= vc ||
-            static_cast<std::size_t>(tri.y) >= vc || static_cast<std::size_t>(tri.z) >= vc) {
-            throw InputError("Mesh index out of range");
-        }
-        if (tri.x == tri.y || tri.y == tri.z || tri.x == tri.z) {
-            ++dropped;
-            continue;
-        }
-        const Vec3f& v0 = src.vertices[static_cast<std::size_t>(tri.x)];
-        const Vec3f& v1 = src.vertices[static_cast<std::size_t>(tri.y)];
-        const Vec3f& v2 = src.vertices[static_cast<std::size_t>(tri.z)];
-        if (IsDegenerateTriangle(v0, v1, v2)) {
-            ++dropped;
-            continue;
-        }
-        dst.triangles.push_back({static_cast<uint32_t>(tri.x), static_cast<uint32_t>(tri.y),
-                                 static_cast<uint32_t>(tri.z)});
-    }
-    if (dropped > 0) { spdlog::debug("ConvertMesh: filtered {} degenerate triangle(s)", dropped); }
-    return dst;
-}
 
 // ── Hex color normalization ─────────────────────────────────────────────────
 
@@ -269,13 +227,13 @@ neroued_3mf::Document BuildStandardDocument(const std::vector<InputObject>& obje
     uint32_t bmg_id = builder.AddBaseMaterialGroup(std::move(materials));
 
     for (std::size_t i = 0; i < objects.size(); ++i) {
-        neroued_3mf::Mesh converted = ConvertMesh(*objects[i].mesh);
-        if (converted.triangles.empty()) {
-            spdlog::warn("BuildStandardDocument: object '{}' dropped (all triangles degenerate)",
+        auto view = detail::MakeMeshView(*objects[i].mesh);
+        if (view.triangles.empty()) {
+            spdlog::warn("BuildStandardDocument: object '{}' dropped (empty mesh)",
                          objects[i].name);
             continue;
         }
-        uint32_t oid = builder.AddMeshObject(objects[i].name, std::move(converted), bmg_id,
+        uint32_t oid = builder.AddMeshObject(objects[i].name, view, bmg_id,
                                              static_cast<uint32_t>(i));
         builder.AddBuildItem(oid);
     }
@@ -327,15 +285,15 @@ neroued_3mf::Document BuildBambuDocument(const std::vector<InputObject>& objects
     std::vector<uint32_t> object_ids;
     int part_id = 1;
     for (std::size_t i = 0; i < objects.size(); ++i) {
-        neroued_3mf::Mesh converted = ConvertMesh(*objects[i].mesh);
-        int face_count              = static_cast<int>(converted.triangles.size());
-        if (converted.triangles.empty()) {
-            spdlog::warn("BuildBambuDocument: object '{}' dropped (all triangles degenerate)",
+        auto view      = detail::MakeMeshView(*objects[i].mesh);
+        int face_count = static_cast<int>(view.triangles.size());
+        if (view.triangles.empty()) {
+            spdlog::warn("BuildBambuDocument: object '{}' dropped (empty mesh)",
                          objects[i].name);
             continue;
         }
 
-        uint32_t oid = builder.AddMeshObject(objects[i].name, std::move(converted));
+        uint32_t oid = builder.AddMeshObject(objects[i].name, view);
         builder.AddBuildItem(oid);
         object_ids.push_back(oid);
 

--- a/core/src/geo/export_bridge.h
+++ b/core/src/geo/export_bridge.h
@@ -1,0 +1,67 @@
+#pragma once
+
+/// \file export_bridge.h
+/// \brief Zero-copy type bridge between ChromaPrint3D and neroued_3mf types.
+///
+/// Verifies layout compatibility at compile time and provides MakeMeshView()
+/// to construct a neroued_3mf::MeshView directly from ChromaPrint3D::Mesh
+/// without copying vertex or index data.
+
+#include "chromaprint3d/mesh.h"
+#include "chromaprint3d/vec3.h"
+
+#include <neroued/3mf/types.h>
+
+#include <cstddef>
+#include <span>
+#include <type_traits>
+
+namespace ChromaPrint3D {
+namespace detail {
+
+// ── ChromaPrint3D::Vec3f ↔ neroued_3mf::Vec3f ────────────────────────────
+
+static_assert(sizeof(ChromaPrint3D::Vec3f) == sizeof(neroued_3mf::Vec3f),
+              "Vec3f types must have the same size");
+static_assert(alignof(ChromaPrint3D::Vec3f) == alignof(neroued_3mf::Vec3f),
+              "Vec3f types must have the same alignment");
+static_assert(offsetof(ChromaPrint3D::Vec3f, x) == offsetof(neroued_3mf::Vec3f, x),
+              "Vec3f::x offset mismatch");
+static_assert(offsetof(ChromaPrint3D::Vec3f, y) == offsetof(neroued_3mf::Vec3f, y),
+              "Vec3f::y offset mismatch");
+static_assert(offsetof(ChromaPrint3D::Vec3f, z) == offsetof(neroued_3mf::Vec3f, z),
+              "Vec3f::z offset mismatch");
+static_assert(std::is_trivially_copyable_v<ChromaPrint3D::Vec3f>);
+static_assert(std::is_trivially_copyable_v<neroued_3mf::Vec3f>);
+
+// ── ChromaPrint3D::Vec3u ↔ neroued_3mf::IndexTriangle ────────────────────
+
+static_assert(sizeof(Vec3u) == sizeof(neroued_3mf::IndexTriangle),
+              "Vec3u and IndexTriangle must have the same size");
+static_assert(alignof(Vec3u) == alignof(neroued_3mf::IndexTriangle),
+              "Vec3u and IndexTriangle must have the same alignment");
+static_assert(offsetof(Vec3u, x) == offsetof(neroued_3mf::IndexTriangle, v1),
+              "Vec3u::x ↔ IndexTriangle::v1 offset mismatch");
+static_assert(offsetof(Vec3u, y) == offsetof(neroued_3mf::IndexTriangle, v2),
+              "Vec3u::y ↔ IndexTriangle::v2 offset mismatch");
+static_assert(offsetof(Vec3u, z) == offsetof(neroued_3mf::IndexTriangle, v3),
+              "Vec3u::z ↔ IndexTriangle::v3 offset mismatch");
+static_assert(std::is_trivially_copyable_v<Vec3u>);
+static_assert(std::is_trivially_copyable_v<neroued_3mf::IndexTriangle>);
+
+/// Construct a zero-copy MeshView from a ChromaPrint3D Mesh.
+/// The caller must keep \p mesh alive until the MeshView is consumed
+/// (i.e., until WriteToBuffer / WriteToFile returns).
+inline neroued_3mf::MeshView MakeMeshView(const Mesh& mesh) {
+    return {
+        .vertices = std::span<const neroued_3mf::Vec3f>(
+            reinterpret_cast<const neroued_3mf::Vec3f*>(mesh.vertices.data()),
+            mesh.vertices.size()),
+        .triangles = std::span<const neroued_3mf::IndexTriangle>(
+            reinterpret_cast<const neroued_3mf::IndexTriangle*>(mesh.indices.data()),
+            mesh.indices.size()),
+    };
+}
+
+} // namespace detail
+} // namespace ChromaPrint3D

--- a/core/src/geo/geo.cpp
+++ b/core/src/geo/geo.cpp
@@ -334,13 +334,13 @@ Mesh Mesh::Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg) {
                     x3[v] += h;
 
                     const Vec3u v0{CheckedU32Coord(x0[0]), CheckedU32Coord(x0[1]),
-                                    CheckedU32Coord(x0[2])};
+                                   CheckedU32Coord(x0[2])};
                     const Vec3u v1{CheckedU32Coord(x1[0]), CheckedU32Coord(x1[1]),
-                                    CheckedU32Coord(x1[2])};
+                                   CheckedU32Coord(x1[2])};
                     const Vec3u v2{CheckedU32Coord(x2[0]), CheckedU32Coord(x2[1]),
-                                    CheckedU32Coord(x2[2])};
+                                   CheckedU32Coord(x2[2])};
                     const Vec3u v3{CheckedU32Coord(x3[0]), CheckedU32Coord(x3[1]),
-                                    CheckedU32Coord(x3[2])};
+                                   CheckedU32Coord(x3[2])};
                     if (c > 0) {
                         add_quad(v0, v1, v3, v2);
                     } else {

--- a/core/src/geo/geo.cpp
+++ b/core/src/geo/geo.cpp
@@ -4,6 +4,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include <cstdint>
+#include <limits>
 #include <unordered_map>
 
 namespace ChromaPrint3D {
@@ -12,6 +14,18 @@ inline size_t GridIndex(int w, int h, int l, int width, int height, int layers) 
     return (static_cast<size_t>(h) * static_cast<size_t>(width) + static_cast<size_t>(w)) *
                static_cast<size_t>(layers) +
            static_cast<size_t>(l);
+}
+
+uint32_t CheckedU32Index(std::size_t value) {
+    if (value > static_cast<std::size_t>(std::numeric_limits<uint32_t>::max())) {
+        throw InputError("Mesh vertex index exceeds uint32_t range");
+    }
+    return static_cast<uint32_t>(value);
+}
+
+uint32_t CheckedU32Coord(int value) {
+    if (value < 0) { throw InputError("Mesh coordinate is negative"); }
+    return static_cast<uint32_t>(value);
 }
 } // namespace
 
@@ -198,17 +212,17 @@ Mesh Mesh::Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg) {
         static_cast<size_t>(width) * static_cast<size_t>(height) * static_cast<size_t>(layers);
     if (voxel_grid.ooc.size() < expected) { throw InputError("VoxelGrid ooc size mismatch"); }
 
-    struct Vec3iHash {
-        size_t operator()(const Vec3i& v) const {
-            size_t h = std::hash<int>{}(v.x);
-            h ^= std::hash<int>{}(v.y) + 0x9e3779b9 + (h << 6) + (h >> 2);
-            h ^= std::hash<int>{}(v.z) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    struct Vec3uHash {
+        size_t operator()(const Vec3u& v) const {
+            size_t h = std::hash<uint32_t>{}(v.x);
+            h ^= std::hash<uint32_t>{}(v.y) + 0x9e3779b9 + (h << 6) + (h >> 2);
+            h ^= std::hash<uint32_t>{}(v.z) + 0x9e3779b9 + (h << 6) + (h >> 2);
             return h;
         }
     };
 
-    struct Vec3iEq {
-        bool operator()(const Vec3i& a, const Vec3i& b) const {
+    struct Vec3uEq {
+        bool operator()(const Vec3u& a, const Vec3u& b) const {
             return a.x == b.x && a.y == b.y && a.z == b.z;
         }
     };
@@ -220,33 +234,33 @@ Mesh Mesh::Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg) {
     mesh.vertices.reserve(estimated_surface);
     mesh.indices.reserve(estimated_surface * 2);
 
-    std::unordered_map<Vec3i, int, Vec3iHash, Vec3iEq> vertex_map;
+    std::unordered_map<Vec3u, uint32_t, Vec3uHash, Vec3uEq> vertex_map;
     vertex_map.reserve(estimated_surface);
 
     const float px = cfg.pixel_mm;
     const float pz = cfg.layer_height_mm;
 
-    auto add_vertex = [&](const Vec3i& v) {
+    auto add_vertex = [&](const Vec3u& v) {
         auto it = vertex_map.find(v);
         if (it != vertex_map.end()) { return it->second; }
         float z = static_cast<float>(v.z) * pz;
         for (const auto& gap : cfg.interface_offsets) {
-            if (gap.z_index >= 0 && v.z == gap.z_index) {
+            if (gap.z_index >= 0 && v.z == static_cast<uint32_t>(gap.z_index)) {
                 z += gap.offset_mm;
                 break;
             }
         }
-        const int idx = static_cast<int>(mesh.vertices.size());
+        const uint32_t idx = CheckedU32Index(mesh.vertices.size());
         mesh.vertices.emplace_back(static_cast<float>(v.x) * px, static_cast<float>(v.y) * px, z);
         vertex_map.emplace(v, idx);
         return idx;
     };
 
-    auto add_quad = [&](const Vec3i& v0, const Vec3i& v1, const Vec3i& v2, const Vec3i& v3) {
-        const int i0 = add_vertex(v0);
-        const int i1 = add_vertex(v1);
-        const int i2 = add_vertex(v2);
-        const int i3 = add_vertex(v3);
+    auto add_quad = [&](const Vec3u& v0, const Vec3u& v1, const Vec3u& v2, const Vec3u& v3) {
+        const uint32_t i0 = add_vertex(v0);
+        const uint32_t i1 = add_vertex(v1);
+        const uint32_t i2 = add_vertex(v2);
+        const uint32_t i3 = add_vertex(v3);
         mesh.indices.emplace_back(i0, i1, i2);
         mesh.indices.emplace_back(i0, i2, i3);
     };
@@ -325,10 +339,14 @@ Mesh Mesh::Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg) {
                     x3[u] += w;
                     x3[v] += h;
 
-                    const Vec3i v0{x0[0], x0[1], x0[2]};
-                    const Vec3i v1{x1[0], x1[1], x1[2]};
-                    const Vec3i v2{x2[0], x2[1], x2[2]};
-                    const Vec3i v3{x3[0], x3[1], x3[2]};
+                    const Vec3u v0{CheckedU32Coord(x0[0]), CheckedU32Coord(x0[1]),
+                                    CheckedU32Coord(x0[2])};
+                    const Vec3u v1{CheckedU32Coord(x1[0]), CheckedU32Coord(x1[1]),
+                                    CheckedU32Coord(x1[2])};
+                    const Vec3u v2{CheckedU32Coord(x2[0]), CheckedU32Coord(x2[1]),
+                                    CheckedU32Coord(x2[2])};
+                    const Vec3u v3{CheckedU32Coord(x3[0]), CheckedU32Coord(x3[1]),
+                                    CheckedU32Coord(x3[2])};
                     if (c > 0) {
                         add_quad(v0, v1, v3, v2);
                     } else {

--- a/core/src/geo/geo.cpp
+++ b/core/src/geo/geo.cpp
@@ -221,12 +221,6 @@ Mesh Mesh::Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg) {
         }
     };
 
-    struct Vec3uEq {
-        bool operator()(const Vec3u& a, const Vec3u& b) const {
-            return a.x == b.x && a.y == b.y && a.z == b.z;
-        }
-    };
-
     const std::size_t estimated_surface =
         static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 2 +
         static_cast<std::size_t>(width) * static_cast<std::size_t>(layers) * 2 +
@@ -234,7 +228,7 @@ Mesh Mesh::Build(const VoxelGrid& voxel_grid, const BuildMeshConfig& cfg) {
     mesh.vertices.reserve(estimated_surface);
     mesh.indices.reserve(estimated_surface * 2);
 
-    std::unordered_map<Vec3u, uint32_t, Vec3uHash, Vec3uEq> vertex_map;
+    std::unordered_map<Vec3u, uint32_t, Vec3uHash> vertex_map;
     vertex_map.reserve(estimated_surface);
 
     const float px = cfg.pixel_mm;

--- a/core/src/vecgeo/triangulate.cpp
+++ b/core/src/vecgeo/triangulate.cpp
@@ -1,5 +1,7 @@
 #include "triangulate.h"
 
+#include "chromaprint3d/error.h"
+
 #include <earcut/earcut.hpp>
 
 #include <algorithm>
@@ -28,6 +30,13 @@ namespace ChromaPrint3D::detail {
 namespace {
 
 constexpr double kClipperScale = 100000.0;
+
+uint32_t CheckedU32Index(std::size_t value) {
+    if (value > static_cast<std::size_t>(std::numeric_limits<uint32_t>::max())) {
+        throw InputError("Triangulated vertex index exceeds uint32_t range");
+    }
+    return static_cast<uint32_t>(value);
+}
 
 Contour Path64ToContour(const Clipper2Lib::Path64& path) {
     Contour c;
@@ -170,8 +179,9 @@ TriangulatedRegion TriangulateMergedPaths(const Clipper2Lib::Paths64& paths) {
             const auto& v1 = result.vertices[base + i1];
             const auto& v2 = result.vertices[base + i2];
             if (IsDegenerateTriangle2D(v0, v1, v2)) continue;
-            result.triangles.emplace_back(static_cast<int>(base + i0), static_cast<int>(base + i1),
-                                          static_cast<int>(base + i2));
+            result.triangles.emplace_back(CheckedU32Index(base + i0),
+                                          CheckedU32Index(base + i1),
+                                          CheckedU32Index(base + i2));
         }
     }
 

--- a/core/src/vecgeo/triangulate.cpp
+++ b/core/src/vecgeo/triangulate.cpp
@@ -179,8 +179,7 @@ TriangulatedRegion TriangulateMergedPaths(const Clipper2Lib::Paths64& paths) {
             const auto& v1 = result.vertices[base + i1];
             const auto& v2 = result.vertices[base + i2];
             if (IsDegenerateTriangle2D(v0, v1, v2)) continue;
-            result.triangles.emplace_back(CheckedU32Index(base + i0),
-                                          CheckedU32Index(base + i1),
+            result.triangles.emplace_back(CheckedU32Index(base + i0), CheckedU32Index(base + i1),
                                           CheckedU32Index(base + i2));
         }
     }

--- a/core/src/vecgeo/triangulate.h
+++ b/core/src/vecgeo/triangulate.h
@@ -26,7 +26,7 @@ struct TriangulatedRegion {
     std::vector<Vec2f> vertices;
 
     /// Triangle indices into `vertices`.
-    std::vector<Vec3i> triangles;
+    std::vector<Vec3u> triangles;
 
     bool Empty() const { return polygon_groups.empty(); }
 };

--- a/core/src/vecgeo/vector_mesh_builder.cpp
+++ b/core/src/vecgeo/vector_mesh_builder.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -18,6 +19,13 @@ namespace ChromaPrint3D {
 namespace {
 
 constexpr double kClipperScale = 100000.0;
+
+uint32_t CheckedU32Index(std::size_t value) {
+    if (value > static_cast<std::size_t>(std::numeric_limits<uint32_t>::max())) {
+        throw InputError("Mesh vertex index exceeds uint32_t range");
+    }
+    return static_cast<uint32_t>(value);
+}
 
 // ---------------------------------------------------------------------------
 // Coordinate conversion
@@ -191,11 +199,11 @@ ZRange ComputeBaseZ(int color_layers, int base_layers, float lh, float half_gap,
 // ---------------------------------------------------------------------------
 
 void ExtrudeSlab(const detail::TriangulatedRegion& region, float z_bot, float z_top,
-                 std::vector<Vec3f>& out_verts, std::vector<Vec3i>& out_faces) {
+                 std::vector<Vec3f>& out_verts, std::vector<Vec3u>& out_faces) {
     if (region.Empty()) return;
 
-    const int N    = static_cast<int>(region.vertices.size());
-    const int base = static_cast<int>(out_verts.size());
+    const size_t N    = region.vertices.size();
+    const size_t base = out_verts.size();
 
     out_verts.reserve(out_verts.size() + static_cast<size_t>(2 * N));
     for (const Vec2f& v : region.vertices) { out_verts.push_back({v.x, v.y, z_top}); }
@@ -205,29 +213,31 @@ void ExtrudeSlab(const detail::TriangulatedRegion& region, float z_bot, float z_
     const size_t num_wall_edges = region.vertices.size();
     out_faces.reserve(out_faces.size() + 2 * num_tris + 2 * num_wall_edges);
 
-    for (const Vec3i& t : region.triangles) {
-        out_faces.push_back({base + t.x, base + t.y, base + t.z});
+    for (const Vec3u& t : region.triangles) {
+        out_faces.push_back({CheckedU32Index(base + t.x), CheckedU32Index(base + t.y),
+                             CheckedU32Index(base + t.z)});
     }
-    for (const Vec3i& t : region.triangles) {
-        out_faces.push_back({base + N + t.x, base + N + t.z, base + N + t.y});
+    for (const Vec3u& t : region.triangles) {
+        out_faces.push_back({CheckedU32Index(base + N + t.x), CheckedU32Index(base + N + t.z),
+                             CheckedU32Index(base + N + t.y)});
     }
 
     constexpr float kMinEdgeLenSq = 1e-12f;
 
-    int offset = 0;
+    size_t offset = 0;
     for (const auto& group : region.polygon_groups) {
         for (const auto& ring : group) {
-            const int n = static_cast<int>(ring.size());
-            for (int i = 0; i < n; ++i) {
-                int j    = (i + 1) % n;
-                float dx = ring[static_cast<size_t>(j)].x - ring[static_cast<size_t>(i)].x;
-                float dy = ring[static_cast<size_t>(j)].y - ring[static_cast<size_t>(i)].y;
+            const size_t n = ring.size();
+            for (size_t i = 0; i < n; ++i) {
+                size_t j = (i + 1) % n;
+                float dx   = ring[static_cast<size_t>(j)].x - ring[static_cast<size_t>(i)].x;
+                float dy   = ring[static_cast<size_t>(j)].y - ring[static_cast<size_t>(i)].y;
                 if (dx * dx + dy * dy < kMinEdgeLenSq) continue;
 
-                int ti = base + offset + i;
-                int tj = base + offset + j;
-                int bi = base + N + offset + i;
-                int bj = base + N + offset + j;
+                uint32_t ti = CheckedU32Index(base + offset + i);
+                uint32_t tj = CheckedU32Index(base + offset + j);
+                uint32_t bi = CheckedU32Index(base + N + offset + i);
+                uint32_t bj = CheckedU32Index(base + N + offset + j);
                 out_faces.push_back({bi, bj, tj});
                 out_faces.push_back({bi, tj, ti});
             }
@@ -362,7 +372,7 @@ std::vector<Mesh> BuildVectorMeshes(const std::vector<VectorShape>& shapes,
 #endif
     for (int C = 0; C < num_channels; ++C) {
         std::vector<Vec3f> verts;
-        std::vector<Vec3i> faces;
+        std::vector<Vec3u> faces;
 
         for (const auto& run : runs_per_channel[static_cast<size_t>(C)]) {
             const auto& region = regions[run.group_idx];
@@ -412,7 +422,7 @@ std::vector<Mesh> BuildVectorMeshes(const std::vector<VectorShape>& shapes,
 
     if (has_base) {
         std::vector<Vec3f> verts;
-        std::vector<Vec3i> faces;
+        std::vector<Vec3u> faces;
         ZRange bz = ComputeBaseZ(color_layers, base_layers, lh, half_gap, cfg.double_sided);
         ExtrudeSlab(shared_region, bz.bot, bz.top, verts, faces);
 
@@ -427,7 +437,7 @@ std::vector<Mesh> BuildVectorMeshes(const std::vector<VectorShape>& shapes,
         float z_top = total_z + cfg.transparent_layer_mm;
 
         std::vector<Vec3f> verts;
-        std::vector<Vec3i> faces;
+        std::vector<Vec3u> faces;
         ExtrudeSlab(shared_region, z_bot, z_top, verts, faces);
 
         int transparent_idx                          = num_channels + (has_base ? 1 : 0);

--- a/core/src/vecgeo/vector_mesh_builder.cpp
+++ b/core/src/vecgeo/vector_mesh_builder.cpp
@@ -230,8 +230,8 @@ void ExtrudeSlab(const detail::TriangulatedRegion& region, float z_bot, float z_
             const size_t n = ring.size();
             for (size_t i = 0; i < n; ++i) {
                 size_t j = (i + 1) % n;
-                float dx   = ring[static_cast<size_t>(j)].x - ring[static_cast<size_t>(i)].x;
-                float dy   = ring[static_cast<size_t>(j)].y - ring[static_cast<size_t>(i)].y;
+                float dx = ring[static_cast<size_t>(j)].x - ring[static_cast<size_t>(i)].x;
+                float dy = ring[static_cast<size_t>(j)].y - ring[static_cast<size_t>(i)].y;
                 if (dx * dx + dy * dy < kMinEdgeLenSq) continue;
 
                 uint32_t ti = CheckedU32Index(base + offset + i);

--- a/core/tests/test_3mf_writer.cpp
+++ b/core/tests/test_3mf_writer.cpp
@@ -186,7 +186,7 @@ Mesh MakeHighTriCountMesh(int num_triangles) {
     mesh.vertices.reserve(static_cast<std::size_t>(num_triangles) * 3);
     mesh.indices.reserve(static_cast<std::size_t>(num_triangles));
     for (int i = 0; i < num_triangles; ++i) {
-        float x  = static_cast<float>(i) * 2.0f;
+        float x       = static_cast<float>(i) * 2.0f;
         uint32_t base = static_cast<uint32_t>(mesh.vertices.size());
         mesh.vertices.push_back({x, 0.0f, 0.0f});
         mesh.vertices.push_back({x + 1.0f, 0.0f, 0.0f});
@@ -210,10 +210,7 @@ TEST(ThreeMfWriter, WritesRequiredOpcParts) {
     n3mf_mesh.vertices.reserve(box.vertices.size());
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
     n3mf_mesh.triangles.reserve(box.indices.size());
-    for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({idx.x, idx.y,
-                                       idx.z});
-    }
+    for (const auto& idx : box.indices) { n3mf_mesh.triangles.push_back({idx.x, idx.y, idx.z}); }
 
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);
@@ -233,10 +230,7 @@ TEST(ThreeMfWriter, DefaultPackageKeepsMinimalOpcLayout) {
     Mesh box = MakeBoxMesh();
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
-    for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({idx.x, idx.y,
-                                       idx.z});
-    }
+    for (const auto& idx : box.indices) { n3mf_mesh.triangles.push_back({idx.x, idx.y, idx.z}); }
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);
 
@@ -254,10 +248,7 @@ TEST(ThreeMfWriter, MergesDynamicOpcContributionIntoPackage) {
     Mesh box = MakeBoxMesh();
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
-    for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({idx.x, idx.y,
-                                       idx.z});
-    }
+    for (const auto& idx : box.indices) { n3mf_mesh.triangles.push_back({idx.x, idx.y, idx.z}); }
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);
 
@@ -298,10 +289,7 @@ TEST(ThreeMfWriter, SerializesUnitAndMetadata) {
     Mesh box = MakeBoxMesh();
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
-    for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({idx.x, idx.y,
-                                       idx.z});
-    }
+    for (const auto& idx : box.indices) { n3mf_mesh.triangles.push_back({idx.x, idx.y, idx.z}); }
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);
 
@@ -323,10 +311,7 @@ TEST(ThreeMfWriter, SerializesBuildItemTransform) {
     Mesh box = MakeBoxMesh();
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
-    for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({idx.x, idx.y,
-                                       idx.z});
-    }
+    for (const auto& idx : box.indices) { n3mf_mesh.triangles.push_back({idx.x, idx.y, idx.z}); }
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
 
     neroued_3mf::Transform t = neroued_3mf::Transform::Translation(10.0f, 20.0f, 30.0f);
@@ -351,10 +336,7 @@ TEST(ThreeMfWriter, WriteToFileMatchesWriteToBuffer) {
     Mesh box = MakeDenseMesh(10, 2);
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
-    for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({idx.x, idx.y,
-                                       idx.z});
-    }
+    for (const auto& idx : box.indices) { n3mf_mesh.triangles.push_back({idx.x, idx.y, idx.z}); }
     uint32_t oid = builder.AddMeshObject("FileTest", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);
 

--- a/core/tests/test_3mf_writer.cpp
+++ b/core/tests/test_3mf_writer.cpp
@@ -187,7 +187,7 @@ Mesh MakeHighTriCountMesh(int num_triangles) {
     mesh.indices.reserve(static_cast<std::size_t>(num_triangles));
     for (int i = 0; i < num_triangles; ++i) {
         float x  = static_cast<float>(i) * 2.0f;
-        int base = static_cast<int>(mesh.vertices.size());
+        uint32_t base = static_cast<uint32_t>(mesh.vertices.size());
         mesh.vertices.push_back({x, 0.0f, 0.0f});
         mesh.vertices.push_back({x + 1.0f, 0.0f, 0.0f});
         mesh.vertices.push_back({x + 0.5f, 1.0f, 0.0f});
@@ -211,8 +211,8 @@ TEST(ThreeMfWriter, WritesRequiredOpcParts) {
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
     n3mf_mesh.triangles.reserve(box.indices.size());
     for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({static_cast<uint32_t>(idx.x), static_cast<uint32_t>(idx.y),
-                                       static_cast<uint32_t>(idx.z)});
+        n3mf_mesh.triangles.push_back({idx.x, idx.y,
+                                       idx.z});
     }
 
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
@@ -234,8 +234,8 @@ TEST(ThreeMfWriter, DefaultPackageKeepsMinimalOpcLayout) {
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
     for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({static_cast<uint32_t>(idx.x), static_cast<uint32_t>(idx.y),
-                                       static_cast<uint32_t>(idx.z)});
+        n3mf_mesh.triangles.push_back({idx.x, idx.y,
+                                       idx.z});
     }
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);
@@ -255,8 +255,8 @@ TEST(ThreeMfWriter, MergesDynamicOpcContributionIntoPackage) {
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
     for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({static_cast<uint32_t>(idx.x), static_cast<uint32_t>(idx.y),
-                                       static_cast<uint32_t>(idx.z)});
+        n3mf_mesh.triangles.push_back({idx.x, idx.y,
+                                       idx.z});
     }
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);
@@ -299,8 +299,8 @@ TEST(ThreeMfWriter, SerializesUnitAndMetadata) {
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
     for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({static_cast<uint32_t>(idx.x), static_cast<uint32_t>(idx.y),
-                                       static_cast<uint32_t>(idx.z)});
+        n3mf_mesh.triangles.push_back({idx.x, idx.y,
+                                       idx.z});
     }
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);
@@ -324,8 +324,8 @@ TEST(ThreeMfWriter, SerializesBuildItemTransform) {
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
     for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({static_cast<uint32_t>(idx.x), static_cast<uint32_t>(idx.y),
-                                       static_cast<uint32_t>(idx.z)});
+        n3mf_mesh.triangles.push_back({idx.x, idx.y,
+                                       idx.z});
     }
     uint32_t oid = builder.AddMeshObject("Object A", std::move(n3mf_mesh));
 
@@ -352,8 +352,8 @@ TEST(ThreeMfWriter, WriteToFileMatchesWriteToBuffer) {
     neroued_3mf::Mesh n3mf_mesh;
     for (const auto& v : box.vertices) { n3mf_mesh.vertices.push_back({v.x, v.y, v.z}); }
     for (const auto& idx : box.indices) {
-        n3mf_mesh.triangles.push_back({static_cast<uint32_t>(idx.x), static_cast<uint32_t>(idx.y),
-                                       static_cast<uint32_t>(idx.z)});
+        n3mf_mesh.triangles.push_back({idx.x, idx.y,
+                                       idx.z});
     }
     uint32_t oid = builder.AddMeshObject("FileTest", std::move(n3mf_mesh));
     builder.AddBuildItem(oid);

--- a/core/tests/test_mesh.cpp
+++ b/core/tests/test_mesh.cpp
@@ -47,14 +47,11 @@ TEST(Mesh, TriangleIndicesAreValid) {
     grid.Set(0, 0, 0, true);
     grid.Set(1, 0, 0, true);
 
-    Mesh mesh      = Mesh::Build(grid);
-    int max_vertex = static_cast<int>(mesh.vertices.size());
-    for (const Vec3i& tri : mesh.indices) {
-        EXPECT_GE(tri.x, 0);
+    Mesh mesh           = Mesh::Build(grid);
+    uint32_t max_vertex = static_cast<uint32_t>(mesh.vertices.size());
+    for (const Vec3u& tri : mesh.indices) {
         EXPECT_LT(tri.x, max_vertex);
-        EXPECT_GE(tri.y, 0);
         EXPECT_LT(tri.y, max_vertex);
-        EXPECT_GE(tri.z, 0);
         EXPECT_LT(tri.z, max_vertex);
     }
 }

--- a/core/tests/test_slicer_preset.cpp
+++ b/core/tests/test_slicer_preset.cpp
@@ -257,19 +257,6 @@ Mesh MakeBoxMesh() {
     return Mesh::Build(grid);
 }
 
-Mesh MakeDegenerateMesh() {
-    Mesh mesh;
-    mesh.vertices = {
-        Vec3f{0.0f, 0.0f, 0.0f},
-        Vec3f{1.0f, 0.0f, 0.0f},
-        Vec3f{2.0f, 0.0f, 0.0f},
-    };
-    mesh.indices = {
-        Vec3i{0, 1, 2},
-    };
-    return mesh;
-}
-
 } // namespace
 
 TEST(SlicerPreset, FindPresetFileFindsExisting) {
@@ -376,7 +363,7 @@ TEST(SlicerPreset, ExplicitSlotsMappingSurvivesDroppedMesh) {
     if (!PresetFileExists()) { GTEST_SKIP() << "Preset file not found"; }
     SlicerPreset preset = MakeTestPreset();
 
-    std::vector<Mesh> meshes       = {MakeBoxMesh(), MakeDegenerateMesh(), MakeBoxMesh()};
+    std::vector<Mesh> meshes       = {MakeBoxMesh(), Mesh{}, MakeBoxMesh()};
     std::vector<std::string> names = {"ObjA", "ObjDeg", "ObjC"};
     std::vector<int> slots         = {1, 8, 2};
 
@@ -448,7 +435,7 @@ TEST(SlicerPreset, FaceDownRotatesMeshesAroundGlobalBounds) {
         Vec3f{1.0f, 0.0f, 0.0f},
         Vec3f{0.0f, 0.0f, 1.0f},
     };
-    mesh_a.indices = {Vec3i{0, 1, 2}};
+    mesh_a.indices = {Vec3u{0, 1, 2}};
 
     Mesh mesh_b;
     mesh_b.vertices = {
@@ -456,7 +443,7 @@ TEST(SlicerPreset, FaceDownRotatesMeshesAroundGlobalBounds) {
         Vec3f{12.0f, 0.0f, 5.0f},
         Vec3f{10.0f, 0.0f, 7.0f},
     };
-    mesh_b.indices = {Vec3i{0, 1, 2}};
+    mesh_b.indices = {Vec3u{0, 1, 2}};
 
     std::vector<Mesh> meshes     = {mesh_a, mesh_b};
     std::vector<Channel> palette = {{"Red", "PLA"}, {"Blue", "PLA"}};

--- a/core/tests/test_vector_mesh.cpp
+++ b/core/tests/test_vector_mesh.cpp
@@ -104,9 +104,8 @@ MeshTopologyMetrics AnalyzeMesh(const Mesh& mesh) {
 
     const uint32_t max_idx = static_cast<uint32_t>(mesh.vertices.size());
     for (const Vec3u& tri : mesh.indices) {
-        if (tri.x >= max_idx || tri.y >= max_idx || tri.z >= max_idx ||
-            tri.x == tri.y || tri.y == tri.z || tri.x == tri.z ||
-            IsDegenerateByArea(mesh, tri)) {
+        if (tri.x >= max_idx || tri.y >= max_idx || tri.z >= max_idx || tri.x == tri.y ||
+            tri.y == tri.z || tri.x == tri.z || IsDegenerateByArea(mesh, tri)) {
             ++m.degenerate_triangles;
             continue;
         }

--- a/core/tests/test_vector_mesh.cpp
+++ b/core/tests/test_vector_mesh.cpp
@@ -35,49 +35,49 @@ VectorRecipeMap BuildSingleChannelRecipeMap(int shape_count) {
 }
 
 struct EdgeKey {
-    int a = 0;
-    int b = 0;
+    uint32_t a = 0;
+    uint32_t b = 0;
 
     bool operator==(const EdgeKey& o) const { return a == o.a && b == o.b; }
 };
 
 struct EdgeKeyHash {
     size_t operator()(const EdgeKey& e) const {
-        size_t h = std::hash<int>{}(e.a);
-        h ^= std::hash<int>{}(e.b) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        size_t h = std::hash<uint32_t>{}(e.a);
+        h ^= std::hash<uint32_t>{}(e.b) + 0x9e3779b9 + (h << 6) + (h >> 2);
         return h;
     }
 };
 
 struct FaceKey {
-    int a = 0;
-    int b = 0;
-    int c = 0;
+    uint32_t a = 0;
+    uint32_t b = 0;
+    uint32_t c = 0;
 
     bool operator==(const FaceKey& o) const { return a == o.a && b == o.b && c == o.c; }
 };
 
 struct FaceKeyHash {
     size_t operator()(const FaceKey& f) const {
-        size_t h = std::hash<int>{}(f.a);
-        h ^= std::hash<int>{}(f.b) + 0x9e3779b9 + (h << 6) + (h >> 2);
-        h ^= std::hash<int>{}(f.c) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        size_t h = std::hash<uint32_t>{}(f.a);
+        h ^= std::hash<uint32_t>{}(f.b) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<uint32_t>{}(f.c) + 0x9e3779b9 + (h << 6) + (h >> 2);
         return h;
     }
 };
 
-EdgeKey MakeEdgeKey(int a, int b) {
+EdgeKey MakeEdgeKey(uint32_t a, uint32_t b) {
     if (b < a) std::swap(a, b);
     return {a, b};
 }
 
-FaceKey MakeFaceKey(int i0, int i1, int i2) {
-    std::array<int, 3> ids{i0, i1, i2};
+FaceKey MakeFaceKey(uint32_t i0, uint32_t i1, uint32_t i2) {
+    std::array<uint32_t, 3> ids{i0, i1, i2};
     std::sort(ids.begin(), ids.end());
     return {ids[0], ids[1], ids[2]};
 }
 
-bool IsDegenerateByArea(const Mesh& mesh, const Vec3i& tri) {
+bool IsDegenerateByArea(const Mesh& mesh, const Vec3u& tri) {
     const Vec3f& a = mesh.vertices[static_cast<size_t>(tri.x)];
     const Vec3f& b = mesh.vertices[static_cast<size_t>(tri.y)];
     const Vec3f& c = mesh.vertices[static_cast<size_t>(tri.z)];
@@ -102,10 +102,10 @@ MeshTopologyMetrics AnalyzeMesh(const Mesh& mesh) {
     edge_use.reserve(mesh.indices.size() * 3);
     faces.reserve(mesh.indices.size() * 2);
 
-    const int max_idx = static_cast<int>(mesh.vertices.size());
-    for (const Vec3i& tri : mesh.indices) {
-        if (tri.x < 0 || tri.y < 0 || tri.z < 0 || tri.x >= max_idx || tri.y >= max_idx ||
-            tri.z >= max_idx || tri.x == tri.y || tri.y == tri.z || tri.x == tri.z ||
+    const uint32_t max_idx = static_cast<uint32_t>(mesh.vertices.size());
+    for (const Vec3u& tri : mesh.indices) {
+        if (tri.x >= max_idx || tri.y >= max_idx || tri.z >= max_idx ||
+            tri.x == tri.y || tri.y == tri.z || tri.x == tri.z ||
             IsDegenerateByArea(mesh, tri)) {
             ++m.degenerate_triangles;
             continue;


### PR DESCRIPTION
## 变更类型

- [x] 重构 / 性能优化 (refactor / perf)
- [x] 文档 (docs)

## 变更说明

### 问题背景

ChromaPrint3D 的 3MF 导出链路在每次写盘前都会执行一次完整的网格拷贝：`ConvertMesh` 把 `Mesh::vertices`（`Vec3f`）逐元素压入 `neroued_3mf::Mesh::vertices`，并把 `Mesh::indices`（`Vec3i`）逐三角面 `static_cast` 成 `neroued_3mf::IndexTriangle`。对于大体素模型（>10MB 顶点缓冲）这个拷贝既占额外内存也拉长导出耗时；而 `neroued_3mf` 已经提供了基于 `std::span` 的 `MeshView` 零拷贝接口，等待上游对齐。

同时，原 `ConvertMesh` 内联了三种过滤逻辑（索引越界 → 抛错；索引重复 → 丢弃；面积退化 → 丢弃），这些工作与 `neroued_3mf::detail::ValidateDocument` / `Mesh::Validate()` / `Mesh::RemoveDegenerateTriangles()` 重复；并且按当前网格生成约束（贪心 meshing + Earcut + 自带 2D 退化过滤），上游已经保证不产生退化面，导出端再做一次只是无谓的开销。

### 解决方案

**1. 类型层对齐：`Vec3<T>` 模板 + `Vec3u` 别名**

把原来的 `Vec3i` 提升为 `template<typename T> struct Vec3`，保留 `using Vec3i = Vec3<int32_t>` 维持向后兼容，新增 `using Vec3u = Vec3<uint32_t>` 用于网格三角面索引。`Vec3u` 在 `vec3.h` 即用 `static_assert(sizeof(Vec3u) == 12)` 锁定布局；并实现了默认 `operator==`（C++20 `= default`），让 `std::unordered_map<Vec3u, ...>` 直接走 `std::equal_to` 路径。

**2. `Mesh::indices` / `TriangulatedRegion::triangles` 从 `Vec3i` 切换为 `Vec3u`**

- `core/include/chromaprint3d/mesh.h`、`core/src/vecgeo/triangulate.h` 同步换型。
- `core/src/geo/geo.cpp::Mesh::Build`、`core/src/vecgeo/vector_mesh_builder.cpp::ExtrudeSlab`、`core/src/vecgeo/triangulate.cpp::TriangulateMergedPaths` 内部新增 `CheckedU32Index` / `CheckedU32Coord` 守卫：把 `size_t → uint32_t` 的窄化包成显式越界检查，越界时抛 `InputError`，避免静默回绕。

**3. 零拷贝桥接：`core/src/geo/export_bridge.h::detail::MakeMeshView`**

在新文件中：
- 用 `static_assert(sizeof / alignof / offsetof / std::is_trivially_copyable_v)` 双向锁定 `Vec3f ↔ neroued_3mf::Vec3f` 与 `Vec3u ↔ neroued_3mf::IndexTriangle` 的布局兼容。
- 通过 `std::span` + `reinterpret_cast` 直接引用 `Mesh::vertices.data()` / `Mesh::indices.data()`，构造 `neroued_3mf::MeshView`，**零拷贝**。
- 在 `BuildStandardDocument` / `BuildBambuDocument` 内把 `ConvertMesh` 调用替换为 `MakeMeshView`，索引越界检查回退给 `neroued_3mf::detail::ValidateDocument`（在 `Build()` / `WriteToBuffer` / `WriteToFile` / `WriteToStream` 入口已自动调用）；对应的 `ConvertMesh` / `IsDegenerateTriangle`（3D 版）从 `export_3mf.cpp` 中移除。

**4. 死分支与冗余清理**

- 移除 `BuildStandardDocument` / `BuildBambuDocument` 内部 `view.triangles.empty()` 的兜底分支：上游 `BuildInputObjects` 已经过滤空 mesh，这里不可达。
- 移除 `Mesh::Build` 内的 `Vec3uEq` 工作区，由 `Vec3<T>::operator==` 提供。

**5. 测试与文档同步**

- `core/tests/test_3mf_writer.cpp`：清理无用的 `static_cast<uint32_t>(idx.x)`（`Vec3u` 字段已是 `uint32_t`）。
- `core/tests/test_mesh.cpp` / `test_vector_mesh.cpp`：移除无符号下永远不可能成立的 `tri.x < 0` 之类检查，把 `EdgeKey` / `FaceKey` 也切到 `uint32_t`。
- `core/tests/test_slicer_preset.cpp`：原 `MakeDegenerateMesh` 替换为 `Mesh{}`，仍覆盖"被丢弃 mesh 占位"的测试意图（即映射到 `palette` 槽位的稳定性）。
- `core/README.md` / `core/README.en.md` 第 141 行：把 "`Vec3i`：用于体素坐标 + 网格索引" 拆为 `Vec3<T>` 模板说明 + `Vec3i` / `Vec3u` 各自语义，并点明零拷贝兼容性。
- `vec3.h` 的 `\file` brief 与 `Vec3<T>` 模板各加 doxygen 注释说明语义。

### 影响范围

- [x] `core/` — C++ 核心算法（图像处理、配方匹配、体素/网格、3MF）

不涉及 `apps/` / `web/backend/` / `web/frontend/` / `modeling/` / 构建脚本。`Mesh` / `MeshView` 是内部类型，对外的 `Export3mf*` 接口签名未变。

## 验证记录

- [x] 已完成最小构建验证（`cmake --build build -j$(nproc)` 干净通过，无新告警）
- [x] 已验证关键功能路径（3MF 写出与 `MeshView` 零拷贝路径）
- [x] 已通过相关测试（`ctest --test-dir build --output-on-failure -j$(nproc)`：**194 / 194 passed**）

<details>
<summary>验证详情</summary>

```bash
# 全量构建
cmake --build build -j$(nproc)

# 全量测试
ctest --test-dir build --output-on-failure -j$(nproc)
# => 100% tests passed, 0 tests failed out of 194
# => Total Test time (real) = 30.05 sec

# 重点回归测试集（与第一次提交记录一致）
ctest --test-dir build --output-on-failure \
  -R '^(Mesh|VectorMesh|ThreeMf(Writer|Export))\.'
# => 28/28 passed
```

零拷贝桥接的布局正确性由 `core/src/geo/export_bridge.h` 中的 `static_assert` 编译期锁定，导出后的 3MF 二进制完整性通过既有 `ThreeMfExport.*` / `ThreeMfWriter.*` 用例覆盖（含 OPC/L2 watermark/SerializesUnitAndMetadata/WriteToFileMatchesWriteToBuffer 等）。

</details>

## 代码质量检查

- [x] C++ 修改文件由 `.cursor/hooks.json` 的 `format-cpp.sh` 钩子自动 `clang-format -i`
- [x] 未引入重复工具函数；`CheckedU32Index` 在 `geo.cpp` / `vector_mesh_builder.cpp` / `triangulate.cpp` 三处虽各有定义，但都在 anonymous namespace 内，逻辑保持单点理解；如后续需要可统一收敛到 `core/src/common/`
- [x] `.cpp` 文件结构清晰（工具函数 → 核心流程 → 对外接口）
- [x] 无平台相关硬编码

## 文档与协作同步

- [x] 模块入口或职责边界变化 → 已更新 `core/README.md` / `core/README.en.md`（`Vec3i` / `Vec3u` 段落）
- [x] `vec3.h` doxygen 已同步描述 `Vec3<T>` 模板 + 别名语义
- [x] 不涉及 API / CLI / 构建 / 部署 / 前端用户行为

## 端到端联动检查

不涉及（纯 core 内部类型与导出实现重构，HTTP API / 文件下载 / 缓存策略均未触及）。

## 风险与回滚

**风险点：**

- **严格别名**：`MakeMeshView` 通过 `reinterpret_cast<const neroued_3mf::Vec3f*>` / `reinterpret_cast<const neroued_3mf::IndexTriangle*>` 让 `neroued_3mf::MeshView` 直接引用 `Mesh` 内部缓冲。两侧类型在 `export_bridge.h` 中已有完整 `sizeof / alignof / offsetof / is_trivially_copyable_v` 静态校验，且都是 POD 风格 trivially-copyable struct；但严格意义上仍属 strict-aliasing UB。当前选择保留该做法，等待 `neroued_3mf` 后续可能提供 typed `from_external<T>` / `BitCastSpan<T>` 之类的 API 后再切换。所有平台的 GCC/Clang/MSVC 在 -O2 下均能正确编译并通过测试。
- **退化三角面不再过滤**：从 `ConvertMesh` 中下沉的"重复索引 / 零面积"过滤逻辑已被永久删除——这是预期行为。`Mesh::Build` 与 `BuildVectorMeshes` 上游已经保证不产生此类三角面（贪心 meshing 本身不会，Earcut 路径走 `IsDegenerateTriangle2D` 提前过滤）。如果未来引入新的 mesh 来源（例如外部导入），应在源端补齐校验或调用 `neroued_3mf::Mesh::RemoveDegenerateTriangles()`。
- **错误信息变化**：原 `ConvertMesh` 抛 `"Mesh index out of range"`；新链路在 `neroued_3mf::detail::ValidateDocument` 中抛 `"Object \"...\" triangle N has out-of-range vertex index"`。已全仓搜索，无任何代码 / 测试 / 文档断言旧文案。

**回滚方案：**

`git revert 8fd5a97 c4964b3` 即可。两个 commit 自包含、无下游依赖（外部 API 与磁盘格式未变）。
