### PR TITLE
fix(docker): copy data/preset_bases/ into runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY data/dbs/        /app/data/dbs/
 COPY data/recipes/    /app/data/recipes/
 COPY data/models/     /app/data/models/
 COPY data/presets/    /app/data/presets/
+COPY data/preset_bases/ /app/data/preset_bases/
 COPY data/model_packs/ /app/data/model_packs/
 
 RUN chown -R chromaprint3d:chromaprint3d /app


### PR DESCRIPTION
## Problem

PR #98 introduced `data/preset_bases/` (26 pre-generated machine preset bases) but the `Dockerfile` was not updated to `COPY` them into the runtime image. As a result, on container startup the official image (e.g. v1.3.3-rc.2 preview) logs:

```
[warning] ServerFacade: BambuPresetCatalog unavailable
  (preset_bases directory not found at /app/data/preset_bases);
  3MF export will fall back to standard mode
```

Multi-machine 3MF export silently degrades to standard mode in every Dockerized deployment.

## Fix

Add the missing `COPY data/preset_bases/ /app/data/preset_bases/` next to the other `data/*` directives. One-line change, no code or data churn.

## Verification

- Locally confirmed the warning originates from `@core/src/geo/bambu_preset_catalog.cpp:185` (raises `IOError` if the directory is missing).
- After this change, future image builds will include the 26 base JSONs and `BambuPresetCatalog` will load on startup.

## Followups

- Existing v1.3.3-rc.1 / v1.3.3-rc.2 images already published to Docker Hub still miss the directory; preview deployment needs a temporary bind-mount workaround until a new tag is built (handled out-of-band).
- No need to bump version for this fix alone — it will ride along whenever the next `preview/v...` or `release/v...` PR is cut.

## Checklist

- [x] Code change is minimal (1-line COPY)
- [x] No behavior change beyond image packaging
- [x] No new test added (Dockerfile-only)
- [x] Documentation untouched (no API/CLI change)