### PR TITLE
fix(geo): center 3MF on machine-specific bed via printable_area

### DIFF
--- a/core/include/chromaprint3d/bambu_preset_catalog.h
+++ b/core/include/chromaprint3d/bambu_preset_catalog.h
@@ -42,6 +42,15 @@ struct MachineSpec {
     /// Path to `data/preset_bases/<slug>_<lh>_<nozzle>.json`.
     std::filesystem::path preset_base_path;
 
+    /// Physical print bed size in millimetres, parsed from the base preset's
+    /// `printable_area` field (axis-aligned rectangle whose third corner is
+    /// `"<W>x<H>"`). Used by 3MF export to centre the model on the machine's
+    /// actual bed instead of a hardcoded 256x256.
+    /// Falls back to 256x256 if `printable_area` is missing or unparseable
+    /// (logged as a warning at catalog load time).
+    float bed_size_x_mm = 256.0f;
+    float bed_size_y_mm = 256.0f;
+
     /// Shared (cheap) snapshot of the catalog's patch overlay; populated by
     /// `BambuPresetCatalog::Resolve`. Held by `shared_ptr` so we avoid copying
     /// the (small but non-trivial) ChromaPrintPatches per MachineSpec while
@@ -139,12 +148,22 @@ private:
         std::make_shared<const ChromaPrintPatches>()};
     std::string default_machine_;
 
-    /// Cache of `printer_model` keyed by base filename stem `<slug>_<lh>mm_<nozzle>`
-    /// (e.g. `bambu_p2s_0.08mm_n04`). Populated once at LoadFromDir; consumed
-    /// by Resolve to avoid re-parsing base JSON on every export call.
-    /// Reads from `_chromaprint3d_meta.printer_model` first, falling back to
-    /// the top-level `printer_model` field.
-    std::unordered_map<std::string, std::string> base_printer_model_cache_;
+    /// Fields read from a `<slug>_<lh>mm_<nozzle>.json` base file at
+    /// LoadFromDir time. Cached here so Resolve does not re-parse the JSON on
+    /// every export call.
+    struct BasePresetMeta {
+        /// `_chromaprint3d_meta.printer_model` (preferred) or top-level
+        /// `printer_model`. May be empty if neither is present.
+        std::string printer_model;
+        /// Parsed from `printable_area[2]` ("<W>x<H>"). Falls back to 256x256
+        /// when the field is missing or cannot be parsed.
+        float bed_size_x_mm = 256.0f;
+        float bed_size_y_mm = 256.0f;
+    };
+
+    /// Cache keyed by base filename stem `<slug>_<lh>mm_<nozzle>`
+    /// (e.g. `bambu_p2s_0.08mm_n04`). Populated once at LoadFromDir.
+    std::unordered_map<std::string, BasePresetMeta> base_meta_cache_;
 };
 
 } // namespace ChromaPrint3D

--- a/core/src/geo/bambu_preset_catalog.cpp
+++ b/core/src/geo/bambu_preset_catalog.cpp
@@ -5,12 +5,15 @@
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <map>
+#include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 namespace ChromaPrint3D {
 
@@ -53,6 +56,41 @@ ChromaPrintPatches::JsonSection LoadSection(const nlohmann::json& obj) {
         out.emplace(it.key(), EncodeJsonValue(it.value()));
     }
     return out;
+}
+
+/// Parse a base preset's `printable_area[2]` ("<W>x<H>") to (width, height) in
+/// millimetres. The third corner of the axis-aligned rectangle defined by
+/// `printable_area = ["0x0", "Wx0", "WxH", "0xH"]` directly carries the bed
+/// dimensions. Returns std::nullopt if the field is missing, malformed, or
+/// non-positive. Tolerates trailing whitespace (some upstream BambuStudio
+/// printer profiles ship `"0x256 "` for X2D).
+std::optional<std::pair<float, float>> ParsePrintableAreaSize(const nlohmann::json& base) {
+    if (!base.contains("printable_area")) return std::nullopt;
+    const auto& pa = base["printable_area"];
+    if (!pa.is_array() || pa.size() < 3) return std::nullopt;
+    if (!pa[2].is_string()) return std::nullopt;
+
+    std::string s = pa[2].get<std::string>();
+    auto is_space = [](char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+    };
+    while (!s.empty() && is_space(s.front())) s.erase(s.begin());
+    while (!s.empty() && is_space(s.back())) s.pop_back();
+    if (s.empty()) return std::nullopt;
+
+    const auto x_pos = s.find('x');
+    if (x_pos == std::string::npos || x_pos == 0 || x_pos + 1 >= s.size()) {
+        return std::nullopt;
+    }
+
+    try {
+        const float w = std::stof(s.substr(0, x_pos));
+        const float h = std::stof(s.substr(x_pos + 1));
+        if (!std::isfinite(w) || !std::isfinite(h) || w <= 0.0f || h <= 0.0f) {
+            return std::nullopt;
+        }
+        return std::make_pair(w, h);
+    } catch (const std::exception&) { return std::nullopt; }
 }
 
 } // namespace
@@ -186,9 +224,11 @@ BambuPresetCatalog BambuPresetCatalog::LoadFromDir(const std::filesystem::path& 
         throw IOError("preset_bases directory not found at " + bases_dir.string());
     }
 
-    // One-shot scan of base files to populate the printer_model cache.
-    // Reads `_chromaprint3d_meta.printer_model` first, falling back to top-level
-    // `printer_model` field. Avoids re-parsing on every Resolve call.
+    // One-shot scan of base files to populate the per-base meta cache
+    // (printer_model + bed size). Avoids re-parsing JSON on every Resolve call.
+    // Reads printer_model from `_chromaprint3d_meta.printer_model` first,
+    // falling back to top-level `printer_model`. Reads bed size from
+    // `printable_area[2]` ("<W>x<H>"); falls back to 256x256 when missing.
     std::size_t cache_misses = 0;
     for (const auto& entry : std::filesystem::directory_iterator(bases_dir)) {
         if (!entry.is_regular_file()) continue;
@@ -202,23 +242,35 @@ BambuPresetCatalog BambuPresetCatalog::LoadFromDir(const std::filesystem::path& 
         }
         try {
             nlohmann::json bd = nlohmann::json::parse(bif);
-            std::string pm;
+            BasePresetMeta meta;
+
             if (bd.contains("_chromaprint3d_meta") && bd["_chromaprint3d_meta"].is_object()) {
-                const auto& meta = bd["_chromaprint3d_meta"];
-                if (meta.contains("printer_model") && meta["printer_model"].is_string()) {
-                    pm = meta["printer_model"].get<std::string>();
+                const auto& m = bd["_chromaprint3d_meta"];
+                if (m.contains("printer_model") && m["printer_model"].is_string()) {
+                    meta.printer_model = m["printer_model"].get<std::string>();
                 }
             }
-            if (pm.empty() && bd.contains("printer_model") && bd["printer_model"].is_string()) {
-                pm = bd["printer_model"].get<std::string>();
+            if (meta.printer_model.empty() && bd.contains("printer_model") &&
+                bd["printer_model"].is_string()) {
+                meta.printer_model = bd["printer_model"].get<std::string>();
             }
-            if (!pm.empty()) {
-                cat.base_printer_model_cache_.emplace(stem, std::move(pm));
+
+            if (auto bed = ParsePrintableAreaSize(bd); bed) {
+                meta.bed_size_x_mm = bed->first;
+                meta.bed_size_y_mm = bed->second;
             } else {
+                spdlog::warn("BambuPresetCatalog: base file {} has missing or unparseable "
+                             "printable_area; falling back to 256x256",
+                             path.string());
+            }
+
+            if (meta.printer_model.empty()) {
                 ++cache_misses;
                 spdlog::warn("BambuPresetCatalog: base file {} has no printer_model",
                              path.string());
             }
+
+            cat.base_meta_cache_.emplace(stem, std::move(meta));
         } catch (const std::exception& e) {
             ++cache_misses;
             spdlog::warn("BambuPresetCatalog: failed to parse base file {}: {}", path.string(),
@@ -227,8 +279,8 @@ BambuPresetCatalog BambuPresetCatalog::LoadFromDir(const std::filesystem::path& 
     }
 
     spdlog::info("BambuPresetCatalog loaded: {} machines, default = {}, cached {} base "
-                 "printer_model entries ({} misses)",
-                 cat.machines_.size(), cat.default_machine_, cat.base_printer_model_cache_.size(),
+                 "meta entries ({} misses)",
+                 cat.machines_.size(), cat.default_machine_, cat.base_meta_cache_.size(),
                  cache_misses);
     return cat;
 }
@@ -299,11 +351,16 @@ std::optional<MachineSpec> BambuPresetCatalog::Resolve(std::string_view machine_
     // Share the catalog's patches with this MachineSpec (shared_ptr aliasing).
     spec.patches = patches_;
 
-    // printer_model: pull from the cache populated at LoadFromDir time.
-    auto cit = base_printer_model_cache_.find(stem);
-    if (cit != base_printer_model_cache_.end()) { spec.printer_model = cit->second; }
-    // (cache miss is non-fatal; spec.printer_model stays empty and downstream
-    //  metadata writers omit the printer_model_id plate annotation.)
+    // printer_model + bed size: pull from the cache populated at LoadFromDir time.
+    auto cit = base_meta_cache_.find(stem);
+    if (cit != base_meta_cache_.end()) {
+        spec.printer_model = cit->second.printer_model;
+        spec.bed_size_x_mm = cit->second.bed_size_x_mm;
+        spec.bed_size_y_mm = cit->second.bed_size_y_mm;
+    }
+    // (cache miss is non-fatal; spec.printer_model stays empty and bed size
+    //  retains its 256x256 default. Downstream metadata writers omit the
+    //  printer_model_id plate annotation when printer_model is empty.)
 
     return spec;
 }
@@ -323,13 +380,15 @@ BambuPresetCatalog::GetMachineSummary(std::string_view machine_name) const {
 
     // Best-effort printer_model lookup: the cache key is `<slug>_<lh>mm_<nozzle>`,
     // and we don't know which layer-height/nozzle the catalog actually shipped a
-    // base file for, so accept the first stem starting with `<slug>_`. Order is
-    // unordered_map iteration order; consistency is fine since all base files
-    // for a given slug carry the same printer_model (sanity-checked at load).
+    // base file for, so accept the first stem starting with `<slug>_` whose
+    // entry has a non-empty printer_model. Order is unordered_map iteration
+    // order; consistency is fine since all base files for a given slug carry
+    // the same printer_model (sanity-checked at load).
     const std::string slug_prefix = rec.slug + "_";
-    for (const auto& [stem, model] : base_printer_model_cache_) {
-        if (stem.compare(0, slug_prefix.size(), slug_prefix) == 0) {
-            summary.printer_model = model;
+    for (const auto& [stem, meta] : base_meta_cache_) {
+        if (stem.compare(0, slug_prefix.size(), slug_prefix) == 0 &&
+            !meta.printer_model.empty()) {
+            summary.printer_model = meta.printer_model;
             break;
         }
     }

--- a/core/src/geo/bambu_preset_catalog.cpp
+++ b/core/src/geo/bambu_preset_catalog.cpp
@@ -71,17 +71,13 @@ std::optional<std::pair<float, float>> ParsePrintableAreaSize(const nlohmann::js
     if (!pa[2].is_string()) return std::nullopt;
 
     std::string s = pa[2].get<std::string>();
-    auto is_space = [](char c) {
-        return c == ' ' || c == '\t' || c == '\n' || c == '\r';
-    };
+    auto is_space = [](char c) { return c == ' ' || c == '\t' || c == '\n' || c == '\r'; };
     while (!s.empty() && is_space(s.front())) s.erase(s.begin());
     while (!s.empty() && is_space(s.back())) s.pop_back();
     if (s.empty()) return std::nullopt;
 
     const auto x_pos = s.find('x');
-    if (x_pos == std::string::npos || x_pos == 0 || x_pos + 1 >= s.size()) {
-        return std::nullopt;
-    }
+    if (x_pos == std::string::npos || x_pos == 0 || x_pos + 1 >= s.size()) { return std::nullopt; }
 
     try {
         const float w = std::stof(s.substr(0, x_pos));
@@ -386,8 +382,7 @@ BambuPresetCatalog::GetMachineSummary(std::string_view machine_name) const {
     // the same printer_model (sanity-checked at load).
     const std::string slug_prefix = rec.slug + "_";
     for (const auto& [stem, meta] : base_meta_cache_) {
-        if (stem.compare(0, slug_prefix.size(), slug_prefix) == 0 &&
-            !meta.printer_model.empty()) {
+        if (stem.compare(0, slug_prefix.size(), slug_prefix) == 0 && !meta.printer_model.empty()) {
             summary.printer_model = meta.printer_model;
             break;
         }

--- a/core/src/geo/export_3mf.cpp
+++ b/core/src/geo/export_3mf.cpp
@@ -248,7 +248,9 @@ neroued_3mf::Document BuildBambuDocument(const std::vector<InputObject>& objects
     builder.AddMetadata("BambuStudio:3mfVersion", "1");
     builder.AddNamespace("BambuStudio", "http://schemas.bambulab.com/package/2021");
 
-    // Compute bed centering transform before enabling production
+    // Compute bed centering transform before enabling production. Bed size is
+    // taken from the resolved MachineSpec (parsed from the base preset's
+    // `printable_area`); falls back to 256x256 when the field is missing.
     float min_x = std::numeric_limits<float>::infinity();
     float max_x = -std::numeric_limits<float>::infinity();
     float min_y = std::numeric_limits<float>::infinity();
@@ -262,14 +264,14 @@ neroued_3mf::Document BuildBambuDocument(const std::vector<InputObject>& objects
             if (v.y > max_y) max_y = v.y;
         }
     }
-    constexpr float kBedCenterX = 128.0f;
-    constexpr float kBedCenterY = 128.0f;
-    float center_tx             = 0.0f;
-    float center_ty             = 0.0f;
+    const float bed_center_x = preset.machine.bed_size_x_mm * 0.5f;
+    const float bed_center_y = preset.machine.bed_size_y_mm * 0.5f;
+    float center_tx          = 0.0f;
+    float center_ty          = 0.0f;
     if (std::isfinite(min_x) && std::isfinite(max_x) && std::isfinite(min_y) &&
         std::isfinite(max_y)) {
-        center_tx = kBedCenterX - (min_x + max_x) * 0.5f;
-        center_ty = kBedCenterY - (min_y + max_y) * 0.5f;
+        center_tx = bed_center_x - (min_x + max_x) * 0.5f;
+        center_ty = bed_center_y - (min_y + max_y) * 0.5f;
     }
 
     builder.EnableProduction(neroued_3mf::Transform::Translation(center_tx, center_ty, 0));

--- a/core/tests/test_slicer_preset.cpp
+++ b/core/tests/test_slicer_preset.cpp
@@ -349,6 +349,54 @@ TEST(SlicerPreset, CatalogReturnsNulloptForMissingNozzle) {
     EXPECT_FALSE(spec.has_value());
 }
 
+// ===========================================================================
+// Bed size parsed from preset_base printable_area; consumed by
+// `BuildBambuDocument` to centre the model on each machine's actual print bed
+// (was previously hardcoded to 256x256, mis-centering A1 mini / H2x machines).
+// ===========================================================================
+
+TEST(BedSize, P2sIsDefault256x256) {
+    auto catalog = LoadCatalogOrNull();
+    if (!catalog) GTEST_SKIP() << "BambuPresetCatalog not available";
+    auto spec = catalog->Resolve("Bambu Lab P2S", NozzleSize::N04, 0.08f);
+    ASSERT_TRUE(spec.has_value());
+    EXPECT_FLOAT_EQ(spec->bed_size_x_mm, 256.0f);
+    EXPECT_FLOAT_EQ(spec->bed_size_y_mm, 256.0f);
+}
+
+TEST(BedSize, A1MiniIs180x180) {
+    auto catalog = LoadCatalogOrNull();
+    if (!catalog) GTEST_SKIP() << "BambuPresetCatalog not available";
+    // A1 mini's bed is 180x180; the previous hardcoded 128x128 centre would
+    // push the model 38mm past the bed edge.
+    auto spec = catalog->Resolve("Bambu Lab A1 mini", NozzleSize::N04, 0.08f);
+    ASSERT_TRUE(spec.has_value());
+    EXPECT_FLOAT_EQ(spec->bed_size_x_mm, 180.0f);
+    EXPECT_FLOAT_EQ(spec->bed_size_y_mm, 180.0f);
+}
+
+TEST(BedSize, H2dIsRectangular350x320) {
+    auto catalog = LoadCatalogOrNull();
+    if (!catalog) GTEST_SKIP() << "BambuPresetCatalog not available";
+    // H2D / H2D Pro have a non-square 350x320 bed.
+    auto spec = catalog->Resolve("Bambu Lab H2D", NozzleSize::N04, 0.08f);
+    ASSERT_TRUE(spec.has_value());
+    EXPECT_FLOAT_EQ(spec->bed_size_x_mm, 350.0f);
+    EXPECT_FLOAT_EQ(spec->bed_size_y_mm, 320.0f);
+}
+
+TEST(BedSize, X2dToleratesTrailingSpaceInPrintableArea) {
+    auto catalog = LoadCatalogOrNull();
+    if (!catalog) GTEST_SKIP() << "BambuPresetCatalog not available";
+    // X2D's printable_area ships as ["0x0","256x0","256x256","0x256 "] from
+    // upstream BambuStudio (note trailing space on the last corner). The
+    // parser must still extract 256x256 from the third corner.
+    auto spec = catalog->Resolve("Bambu Lab X2D", NozzleSize::N04, 0.08f);
+    ASSERT_TRUE(spec.has_value());
+    EXPECT_FLOAT_EQ(spec->bed_size_x_mm, 256.0f);
+    EXPECT_FLOAT_EQ(spec->bed_size_y_mm, 256.0f);
+}
+
 TEST(SlicerPreset, DoubleSidedForcesFaceDownPresetSelection) {
     auto catalog = LoadCatalogOrNull();
     if (!catalog) GTEST_SKIP() << "BambuPresetCatalog not available";

--- a/docs/agents/core/README.md
+++ b/docs/agents/core/README.md
@@ -36,11 +36,11 @@
 
 ## Bambu Studio 预设体系
 
-`core/include/chromaprint3d/common.h` 定义了 `NozzleSize`（N02/N04）和 `FaceOrientation`（FaceUp/FaceDown）枚举。`PrintProfile` 携带这两个字段。多机型预设体系由 `BambuPresetCatalog`（`core/include/chromaprint3d/bambu_preset_catalog.h`）统一管理：从 `data/presets/machines.json` + `data/presets/chromaprint_patches.json` + `data/preset_bases/*.json` 加载，`SlicerPreset::FromProfile(catalog, profile, target_machine, ...)` 依据机型名、喷嘴、层高解析出 `MachineSpec`，其中 `compatible_printers` 会列出同拓扑同 nozzle 的全部机型，Bambu Studio 切换机型时可保留切片参数（`is_compatible_with_printer` 返回 true 不替换 process preset）。`face_orientation` 也会联动 3MF 导出几何：`FaceDown` 时模型整体绕 Y 轴旋转 180°，`FaceUp` 保持原方向。
+`core/include/chromaprint3d/common.h` 定义了 `NozzleSize`（N02/N04）和 `FaceOrientation`（FaceUp/FaceDown）枚举。`PrintProfile` 携带这两个字段。多机型预设体系由 `BambuPresetCatalog`（`core/include/chromaprint3d/bambu_preset_catalog.h`）统一管理：从 `data/presets/machines.json` + `data/presets/chromaprint_patches.json` + `data/preset_bases/*.json` 加载，`SlicerPreset::FromProfile(catalog, profile, target_machine, ...)` 依据机型名、喷嘴、层高解析出 `MachineSpec`，其中 `compatible_printers` 会列出同拓扑同 nozzle 的全部机型，Bambu Studio 切换机型时可保留切片参数（`is_compatible_with_printer` 返回 true 不替换 process preset）。`MachineSpec.bed_size_x_mm / bed_size_y_mm` 由 catalog 在加载 base preset 时从 `printable_area` 字段解析得到（缺失或解析失败时 fallback 到 256×256 + `spdlog::warn`），`BuildBambuDocument` 据此把模型居中到目标机型的实际打印板中心，避免在 A1 mini（180×180）/ H2x（330–350×320）等非 256² 板上偏离板中心。`face_orientation` 也会联动 3MF 导出几何：`FaceDown` 时模型整体绕 Y 轴旋转 180°，`FaceUp` 保持原方向。
 
 `SlicerPreset::FromProfile` 在机型未注册或 base file 缺失时**不**抛错，仅 `spdlog::warn` 并返回 `machine_resolved() == false` 的 preset；调用方（pipeline / 后端 / apps）需以 `machine_resolved()` 为门控决定是否走 Bambu 增强 3MF 路径，否则退化到标准 3MF。若把未解析 preset 直接传给 `BuildProjectSettings` 或 `Export3mf*(..., preset, ...)`，下游会作为防御网兜抛 `IOError`。
 
-UI 列举机型走 `BambuPresetCatalog::GetMachineSummary()`（layer-height 无关），从 `MachineRecord` 直接读 topology / nozzles + 从 `base_printer_model_cache_` 取一个 `<slug>_*` 命中。`Resolve` 仍是导出/构建链路的入口（需要具体 base file 路径）。
+UI 列举机型走 `BambuPresetCatalog::GetMachineSummary()`（layer-height 无关），从 `MachineRecord` 直接读 topology / nozzles + 从 `base_meta_cache_` 取一个 `<slug>_*` 的 `BasePresetMeta`（含 `printer_model` + `bed_size_x/y_mm`）命中。`Resolve` 仍是导出/构建链路的入口（需要具体 base file 路径）。
 
 颜色匹配逻辑在 `bambu_metadata.cpp` 中：`MatchColorToSlot` 基于 RGB 欧氏距离将每个 mesh 颜色匹配到预设 `filament_colour` 数组中最近的槽位。`BuildProjectSettings` 运行时叠加 `chromaprint_patches.json`（含 `$variant_indexed` 多变体項）、按 N×K_process 扩展 filament 数组、生成 BambuStudio 必填的 3 个 variant 元字段（`extruder_variant_list`/`filament_extruder_variant`/`filament_self_index`）。导出翻转逻辑位于 `export_3mf.cpp`，与 `flip_y`（坐标系适配）解耦。
 

--- a/docs/agents/tasks/extend_machine_support.md
+++ b/docs/agents/tasks/extend_machine_support.md
@@ -224,6 +224,15 @@ python3 -m pytest scripts/tests/test_chromaprint_patches_schema.py -v
 2. 确认目标机型 `<machine> <nozzle> nozzle` 在数组中。
 3. 如果不在：检查 `machines.json` 中两台机型的 `extruder_topology` 是否一致（catalog 仅在同 topology 内联合）。
 
+### 问题：3MF 在切片器中模型偏离打印板中心 / 启动日志出现 `printable_area` warning
+
+**原因**：`MachineSpec.bed_size_x_mm / bed_size_y_mm` 来自 base preset JSON 的 `printable_area[2]`（如 `"256x256"`、`"350x320"`）。字段缺失或解析失败时 `BambuPresetCatalog` 会 fallback 到 256×256 并 `spdlog::warn`，不致命但模型会按 256² 居中，对实际板尺寸 ≠ 256² 的机型（A1 mini=180²、H2x=330–350×320）会偏。
+
+**排查**：
+1. 检查 `data/preset_bases/<slug>_*.json` 是否含 `printable_area`（应是 `["0x0", "Wx0", "WxH", "0xH"]` 4 元素数组）。
+2. 若上游 BambuStudio 字段消失或格式变更，重新跑 `scripts/build_preset_bases.py` 重新合并继承链；上游 `"0x256 "` 类的尾随空格已由 catalog parser 容错。
+3. 若需要新增非矩形板的机型（含 `bed_exclude_area` 大区域排除），目前 catalog 只读 `printable_area`，几何中心仍用 `(W/2, H/2)`；如需更精细中心计算需扩展 `BambuPresetCatalog::Resolve` + `BuildBambuDocument`。
+
 ### 已解决：H2D × TPU 精度问题
 
 **背景**：早期担心 H2D `filament_max_volumetric_speed` 在 DD TPU HF slot 用 i%2 fallback 到 DD Std 值，可能不准（non-divisor pattern fallback）。
@@ -238,6 +247,6 @@ python3 -m pytest scripts/tests/test_chromaprint_patches_schema.py -v
 - `scripts/build_preset_bases.py`：base 文件生成脚本
 - `scripts/tests/test_build_preset_bases.py`：base 生成与 schema 单测
 - `scripts/tests/test_chromaprint_patches_schema.py`：patch JSON schema 单测
-- `core/src/geo/bambu_preset_catalog.cpp`：catalog 加载实现（`LoadFromDir` 一次性扫描 base 缓存 `printer_model`）
+- `core/src/geo/bambu_preset_catalog.cpp`：catalog 加载实现（`LoadFromDir` 一次性扫描 base 缓存 `BasePresetMeta` = `printer_model` + `bed_size_x/y_mm`）
 - `core/src/geo/bambu_metadata.cpp`：BuildProjectSettings + 字段集合常量
 - `core/include/chromaprint3d/bambu_preset_catalog.h`：公开 API

--- a/docs/development.md
+++ b/docs/development.md
@@ -272,7 +272,7 @@ npm run dev
 | `transparent_layer_mm` | float | `0` | `0`, `0.04`, `0.08` | 透明镀层厚度（mm）。仅在 `face_orientation=facedown` 且 `double_sided=false` 时可用。启用后在打印模型最底层追加一层透明材料网格 |
 | `gradient_pixel_mm` | float | `0` | `>=0` | 渐变色区域栅格化分辨率（mm/px）。`0`=自动（3×`tessellation_tolerance_mm`）。SVG 中的渐变填充会被栅格化并拆分为纯色子区域参与颜色匹配与 3MF 生成 |
 
-组合后由 `BambuPresetCatalog` 从 `data/presets/machines.json` + `data/preset_bases/<slug>_<lh>_<nozzle>.json` 解析出实际预设。`target_machine` 参数（可选，默认=catalog 默认机型）决定选哪台机型；catalog 并会在 `print_compatible_printers` 列出同拓扑同 nozzle 的全部机型，Bambu Studio 切换机型时可保留切片参数（`is_compatible_with_printer` 返回 true 不替换预设）。`data/presets/chromaprint_patches.json` 指定 ChromaPrint3D 需要覆盖的字段（`$variant_indexed` 合并多变体）。模型颜色自动匹配到预设中最接近的耗材丝槽位（RGB 欧氏距离）。此外，`face_orientation=facedown` 会在导出阶段将模型几何整体绕 Y 轴旋转 180°，`faceup` 则保持原方向。后端同时还提供 `GET /api/v1/machines` 返回 catalog 清单（机型名、拓扑、可用 nozzle）供前端下拉使用。
+组合后由 `BambuPresetCatalog` 从 `data/presets/machines.json` + `data/preset_bases/<slug>_<lh>_<nozzle>.json` 解析出实际预设。`target_machine` 参数（可选，默认=catalog 默认机型）决定选哪台机型；catalog 并会在 `print_compatible_printers` 列出同拓扑同 nozzle 的全部机型，Bambu Studio 切换机型时可保留切片参数（`is_compatible_with_printer` 返回 true 不替换预设）。`data/presets/chromaprint_patches.json` 指定 ChromaPrint3D 需要覆盖的字段（`$variant_indexed` 合并多变体）。模型颜色自动匹配到预设中最接近的耗材丝槽位（RGB 欧氏距离）。此外，`face_orientation=facedown` 会在导出阶段将模型几何整体绕 Y 轴旋转 180°，`faceup` 则保持原方向。导出 3MF 时模型按目标机型的实际打印板尺寸自动居中：catalog 在加载 base preset 时从 `printable_area` 字段解析 `bed_size_x_mm / bed_size_y_mm`（缺失或解析失败 fallback 到 256×256），`BuildBambuDocument` 据此把模型几何中心对齐到 `(W/2, H/2)`，避免在 A1 mini（180²）/ H2x（330–350×320）等非 256² 板上偏离板中心。后端同时还提供 `GET /api/v1/machines` 返回 catalog 清单（机型名、拓扑、可用 nozzle）供前端下拉使用。
 
 注意：`face_orientation` 与 `flip_y` 语义不同。`flip_y` 用于图像/坐标系方向适配（预处理与体素构建阶段），`face_orientation` 用于最终导出几何朝向控制。
 


### PR DESCRIPTION
## Problem

`BuildBambuDocument` (the Bambu-mode 3MF exporter) hardcoded the bed centre to `(128, 128)`, equivalent to assuming every Bambu Lab printer has a 256×256 build plate. Only 8 of the 13 catalog machines actually do; the other 5 are silently mis-centered:

| Machine | Bed (mm) | True centre | Hardcoded (128,128) offset |
|---|---|---|---|
| P2S / P1P / P1S / X1 / X1C / X1E / A1 / X2D | 256×256 | (128, 128) | OK |
| **A1 mini** | **180×180** | **(90, 90)** | **−38, −38** (off the plate) |
| H2S | 340×320 | (170, 160) | +42, +32 |
| H2C | 330×320 | (165, 160) | +37, +32 |
| H2D / H2D Pro | 350×320 | (175, 160) | +47, +32 |

Each `preset_bases/<slug>_<lh>_<nozzle>.json` already carries the bed dimensions in `printable_area` (axis-aligned rectangle whose third corner is literally `"<W>x<H>"`).

## Fix

- `MachineSpec` gains `bed_size_x_mm` / `bed_size_y_mm` (default 256×256 to keep historical behaviour on cache miss).
- `BambuPresetCatalog`'s private cache is upgraded from `unordered_map<string, string>` (printer_model only) to `unordered_map<string, BasePresetMeta> { printer_model, bed_size_x_mm, bed_size_y_mm }`. Populated in the same one-shot `LoadFromDir` scan, no extra IO.
- New `ParsePrintableAreaSize` helper tolerates the trailing whitespace upstream BambuStudio ships in X2D's `"0x256 "` corner.
- `Resolve` / `GetMachineSummary` updated for the new cache shape. Missing / unparseable `printable_area` logs a single `spdlog::warn` and falls back to 256×256, matching the documented contract.
- `BuildBambuDocument` swaps the `kBedCenterX/Y` constants for `preset.machine.bed_size_*_mm * 0.5f`.

`BuildStandardDocument` (no machine resolved) does not centre, so it is unaffected.

## Tests

- 4 new `TEST(BedSize, ...)` cases in `core/tests/test_slicer_preset.cpp` covering P2S (sanity), A1 mini (the worst-case regression), H2D (non-square), X2D (trailing-space tolerance).
- `cmake --build build -j$(nproc)` clean.
- `ctest --test-dir build -j$(nproc)` -> **302/302 passed**, no regressions in the existing catalog / 3mf-writer / variant test groups.

## Docs

- `docs/development.md` — multi-machine paragraph notes per-machine centering and the `printable_area` -> `bed_size_*_mm` flow.
- `docs/agents/core/README.md` — `MachineSpec.bed_size_*_mm` + new cache layout (`BasePresetMeta`).
- `docs/agents/tasks/extend_machine_support.md` — new troubleshooting entry for off-center 3MF / `printable_area` warnings, plus updated cache description.

## Out of scope

- Calibration / 8-color board fitting onto smaller plates (e.g. A1 mini's 180²) — separate issue.
- `bed_exclude_area` (X1C ships a non-empty value but only for corners; the geometric centre is still `(W/2, H/2)`).
- The upstream BambuStudio `"0x256 "` trailing-whitespace bug — kept tolerant on the parser side rather than mutating data.

## Plan

`.windsurf/plans/bambu-bed-center-from-printable-area-d8ce1f.md`

## Checklist

- [x] Tests added (4 BedSize cases) and passing
- [x] No existing test loosened or skipped
- [x] No public ABI break (`MachineSpec` field additions are POD-default)
- [x] Documentation synced (development.md / agents/core / extend_machine_support troubleshooting)
- [x] No data file changes; only parser & exporter consume an existing field