### PR TITLE
fix: hide SVG strokes in upload preview

### DIFF
--- a/web/frontend/src/components/ImageUpload.vue
+++ b/web/frontend/src/components/ImageUpload.vue
@@ -14,6 +14,7 @@ import {
   readRasterImageDimensions,
   validateImageUploadFile,
 } from '../domain/upload/imageUploadValidation'
+import { createSvgPreviewWithoutStroke } from '../domain/upload/svgPreview'
 import { getUploadMaxMb, getUploadMaxPixels } from '../runtime/env'
 import { useI18n } from 'vue-i18n'
 import { trackEvent } from '../services/analytics'
@@ -103,6 +104,14 @@ async function syncImageDimensions(file: File) {
   appStore.setImageDimensions(dims)
 }
 
+async function syncSvgPreview(file: File) {
+  const currentVersion = dimensionsTaskVersion
+  const previewBlob = await createSvgPreviewWithoutStroke(file).catch(() => file)
+  if (currentVersion !== dimensionsTaskVersion || selectedFile.value !== file) return
+  revokeUrl(previewUrl.value)
+  previewUrl.value = createUrl(previewBlob)
+}
+
 watch(
   () => selectedFile.value,
   (newFile) => {
@@ -116,12 +125,13 @@ watch(
       detectedType.value = type
       appStore.setInputType(type)
 
-      previewUrl.value = createUrl(newFile)
       if (type === 'raster') {
+        previewUrl.value = createUrl(newFile)
         void syncImageDimensions(newFile)
       } else {
         dimensions.value = null
         appStore.setImageDimensions(null)
+        void syncSvgPreview(newFile)
       }
     } else {
       fileList.value = []

--- a/web/frontend/src/domain/upload/svgPreview.test.ts
+++ b/web/frontend/src/domain/upload/svgPreview.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createSvgPreviewWithoutStroke } from './svgPreview'
+
+class MockElement {
+  localName: string
+  textContent: string | null = null
+  firstChild: MockElement | null = null
+  private attributes: Record<string, string> = {}
+
+  constructor(localName: string) {
+    this.localName = localName
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes[name] = value
+  }
+
+  insertBefore(child: MockElement) {
+    this.firstChild = child
+  }
+
+  serialize(): string {
+    const attrs = Object.entries(this.attributes)
+      .map(([key, value]) => `${key}="${value}"`)
+      .join(' ')
+    return `<${this.localName}${attrs ? ` ${attrs}` : ''}>${this.textContent ?? ''}</${
+      this.localName
+    }>`
+  }
+}
+
+class MockDocument {
+  readonly documentElement: MockElement
+  readonly source: string
+  private readonly parserError: boolean
+
+  constructor(source: string, parserError = false) {
+    this.source = source
+    this.parserError = parserError
+    this.documentElement = new MockElement(parserError ? 'parsererror' : 'svg')
+  }
+
+  getElementsByTagName(name: string): MockElement[] {
+    return this.parserError && name === 'parsererror' ? [this.documentElement] : []
+  }
+
+  createElementNS(_namespace: string, name: string): MockElement {
+    return new MockElement(name)
+  }
+}
+
+const originalDomParser = globalThis.DOMParser
+const originalXmlSerializer = globalThis.XMLSerializer
+
+describe('svgPreview', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'DOMParser', {
+      configurable: true,
+      writable: true,
+      value: class {
+        parseFromString(text: string): MockDocument {
+          return new MockDocument(text, !text.trim().startsWith('<svg'))
+        }
+      },
+    })
+    Object.defineProperty(globalThis, 'XMLSerializer', {
+      configurable: true,
+      writable: true,
+      value: class {
+        serializeToString(doc: MockDocument): string {
+          const injected = doc.documentElement.firstChild?.serialize() ?? ''
+          return doc.source.replace(/<svg([^>]*)>/, `<svg$1>${injected}`)
+        }
+      },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'DOMParser', {
+      configurable: true,
+      writable: true,
+      value: originalDomParser,
+    })
+    Object.defineProperty(globalThis, 'XMLSerializer', {
+      configurable: true,
+      writable: true,
+      value: originalXmlSerializer,
+    })
+  })
+
+  it('为 SVG 预览插入去描边样式', async () => {
+    const input = new Blob(
+      [
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path fill="#fff" stroke="#000" stroke-width="1" d="M0 0h10v10H0z"/></svg>',
+      ],
+      { type: 'image/svg+xml' },
+    )
+
+    const output = await createSvgPreviewWithoutStroke(input)
+    const text = await output.text()
+
+    expect(output).not.toBe(input)
+    expect(text).toContain('data-chromaprint3d-preview="hide-stroke"')
+    expect(text).toContain('stroke: none !important')
+    expect(text).toContain('stroke-width: 0 !important')
+    expect(text).toContain('stroke="#000"')
+  })
+
+  it('解析失败时回退原始 Blob', async () => {
+    const input = new Blob(['not svg'], { type: 'image/svg+xml' })
+
+    const output = await createSvgPreviewWithoutStroke(input)
+
+    expect(output).toBe(input)
+  })
+})

--- a/web/frontend/src/domain/upload/svgPreview.ts
+++ b/web/frontend/src/domain/upload/svgPreview.ts
@@ -1,0 +1,34 @@
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
+
+const PREVIEW_STROKE_OVERRIDE = `
+svg, svg * {
+  stroke: none !important;
+  stroke-width: 0 !important;
+}
+`
+
+function hasParserError(doc: Document): boolean {
+  return doc.getElementsByTagName('parsererror').length > 0
+}
+
+function createStrokeOverrideStyle(doc: Document): Element {
+  const style = doc.createElementNS(SVG_NAMESPACE, 'style')
+  style.setAttribute('data-chromaprint3d-preview', 'hide-stroke')
+  style.textContent = PREVIEW_STROKE_OVERRIDE
+  return style
+}
+
+export async function createSvgPreviewWithoutStroke(svg: Blob): Promise<Blob> {
+  const text = await svg.text()
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(text, 'image/svg+xml')
+  const root = doc.documentElement
+
+  if (!root || root.localName.toLowerCase() !== 'svg' || hasParserError(doc)) {
+    return svg
+  }
+
+  root.insertBefore(createStrokeOverrideStyle(doc), root.firstChild)
+  const serialized = new XMLSerializer().serializeToString(doc)
+  return new Blob([serialized], { type: 'image/svg+xml' })
+}


### PR DESCRIPTION
## 变更类型

- [ ] 新功能 (feature)
- [x] 缺陷修复 (bugfix)
- [ ] 重构 / 性能优化 (refactor / perf)
- [ ] 构建 / 部署 / CI (build / deploy / ci)
- [ ] 文档 (docs)
- [ ] 其他:

## 变更说明

### 问题背景

叠色模型生成面板上传用户 SVG 后，前端预览直接使用原始 SVG object URL 渲染。如果源 SVG 中包含区域描边，预览会显示色块之间的 stroke，观感较差。

无关联 Issue。

### 解决方案

新增 `createSvgPreviewWithoutStroke()`，仅为预览用 Blob 注入隐藏 `stroke` / `stroke-width` 的样式。`ImageUpload.vue` 在检测到 SVG 输入时使用该预览 Blob；原始 SVG 文件仍保留在 store 中并原样提交给后端，不改变转换行为。

### 影响范围

- [ ] `core/` — C++ 核心算法（图像处理、配方匹配、体素/网格、3MF）
- [ ] `apps/` — CLI 工具
- [ ] `web/backend/` — Drogon HTTP API
- [x] `web/frontend/` — Vue3 前端
- [ ] `modeling/` — Python 建模与拟合流水线
- [ ] `docs/` — 文档
- [ ] 构建 / CI / 部署脚本

## 验证记录

- [x] 已完成最小构建验证（`npm run typecheck` 通过）
- [x] 已验证关键功能路径（SVG 预览 Blob helper 单测覆盖）
- [x] 已通过相关测试（新增单元测试通过）

<details>
<summary>验证详情（可选，展开填写）</summary>

```bash
cd web/frontend
npx vitest run src/domain/upload/svgPreview.test.ts
# PASS: 2 tests

npm run typecheck
# PASS

npm run lint:eslint
# PASS

npm run format:check
# PASS

npm run test
# FAIL before running most tests: existing jsdom dependency startup issue,
# html-encoding-sniffer requires ESM @exodus/bytes/encoding-lite.js.
# The new node-environment svgPreview test still passes in this run.
```

</details>

## 代码质量检查

- [ ] C++ 修改文件已执行 `clang-format -i <modified-files>`
- [x] 未引入重复工具函数（改动集中在上传预览域 helper）
- [ ] `.cpp` 文件结构清晰（工具函数 → 核心流程 → 对外接口）
- [x] 无平台相关硬编码（路径、系统 API、脚本依赖）

## 文档与协作同步

- [ ] 若涉及 API / 参数 / 错误码变化 → 已同步 `README.md`、`docs/development.md`、`docs/agents/web/backend/`
- [ ] 若涉及 CLI 参数或默认值变化 → 已同步 `README.md`、`docs/development.md`、`docs/agents/apps/`
- [ ] 若涉及构建 / 部署流程变化 → 已同步 `README.md`、`docs/deployment.md`
- [ ] 若涉及前端用户可见行为变化 → 已同步 `README.md`、`docs/agents/web/frontend/`
- [ ] 若涉及机型 / 预设 / `data/preset_bases/` 变化 → 已同步 `docs/agents/tasks/extend_machine_support.md`、`docs/development.md`
- [ ] 若模块入口或职责边界变化 → 已更新 `AGENTS.md` 与对应模块索引
- [ ] 若属于高频改动场景 → 已更新对应任务手册 `docs/agents/tasks/`
- [ ] 以上均不涉及

说明：本次按要求不更新文档；行为变化仅限 SVG 上传预览渲染，不影响 API/参数/后端转换链路。

## 端到端联动检查

<details>
<summary>联动检查（如不涉及可跳过，展开填写）</summary>

不涉及后端 API、运行时缓存、下载链路或文件落盘。

</details>

## 风险与回滚

**风险点：**

仅影响 SVG 上传预览。若 SVG 解析失败，会回退到原始 SVG Blob 进行预览。

**回滚方案：**

回退本次提交即可。

## 截图 / 演示

未附。
