### PR TITLE
Recover calibration locate when board outline contrast is weak

### DIFF
--- a/core/src/calib/loc.cpp
+++ b/core/src/calib/loc.cpp
@@ -232,6 +232,24 @@ static std::vector<cv::Point2f> OrderCorners(const std::vector<cv::Point2f>& pts
     return {tl, tr, br, bl};
 }
 
+static std::vector<cv::Point2f> OrderByImagePosition(const std::vector<cv::Point2f>& pts) {
+    if (pts.size() != 4) { throw InputError("OrderByImagePosition expects 4 points"); }
+    cv::Point2f tl, tr, br, bl;
+    double min_sum  = std::numeric_limits<double>::infinity();
+    double max_sum  = -std::numeric_limits<double>::infinity();
+    double min_diff = std::numeric_limits<double>::infinity();
+    double max_diff = -std::numeric_limits<double>::infinity();
+    for (const auto& p : pts) {
+        double sum  = p.x + p.y;
+        double diff = p.x - p.y;
+        if (sum < min_sum) { min_sum = sum, tl = p; }
+        if (sum > max_sum) { max_sum = sum, br = p; }
+        if (diff < min_diff) { min_diff = diff, bl = p; }
+        if (diff > max_diff) { max_diff = diff, tr = p; }
+    }
+    return {tl, tr, br, bl};
+}
+
 static std::vector<cv::Point2f> CoarseLocateBoard(const cv::Mat& bgr, double& scale_out) {
     const int width  = bgr.cols;
     const int height = bgr.rows;
@@ -494,9 +512,173 @@ static BoardGeometry ComputeBoardGeometry(const CalibrationBoardMeta& meta) {
     return g;
 }
 
+static float Distance(const cv::Point2f& a, const cv::Point2f& b) {
+    const cv::Point2f d = a - b;
+    return std::sqrt(d.x * d.x + d.y * d.y);
+}
+
+static std::vector<cv::Point2f> RotateCornerOrder(const std::vector<cv::Point2f>& corners,
+                                                  int offset) {
+    if (corners.size() != 4) { throw InputError("RotateCornerOrder expects 4 points"); }
+    std::vector<cv::Point2f> rotated(4);
+    for (int i = 0; i < 4; ++i) { rotated[static_cast<size_t>(i)] = corners[(offset + i) % 4]; }
+    return rotated;
+}
+
+static double AspectPenaltyForCanonicalOrder(const std::vector<cv::Point2f>& corners,
+                                             double expected_aspect) {
+    const float top     = Distance(corners[0], corners[1]);
+    const float right   = Distance(corners[1], corners[2]);
+    const float bottom  = Distance(corners[3], corners[2]);
+    const float left    = Distance(corners[0], corners[3]);
+    const double avg_w  = (static_cast<double>(top) + bottom) * 0.5;
+    const double avg_h  = (static_cast<double>(left) + right) * 0.5;
+    const double aspect = avg_h > 1e-3 ? avg_w / avg_h : 0.0;
+    return std::abs(std::log(std::max(1e-3, aspect / expected_aspect)));
+}
+
+static std::vector<cv::Point2f> InferBoardCornersFromGlobalFiducials(const cv::Mat& bgr,
+                                                                     const BoardGeometry& geom) {
+    cv::Mat gray;
+    cv::cvtColor(bgr, gray, cv::COLOR_BGR2GRAY);
+    cv::medianBlur(gray, gray, 5);
+
+    const int max_dim   = std::max(bgr.cols, bgr.rows);
+    const int board_dim = std::max(geom.board_w, geom.board_h);
+    const float nominal_radius =
+        board_dim > 0 ? (static_cast<float>(max_dim) * geom.main_r / static_cast<float>(board_dim))
+                      : 0.0f;
+    const int min_radius =
+        std::max(3, static_cast<int>(std::floor(std::max(2.0f, nominal_radius * 0.25f))));
+    const int max_radius = std::max(
+        min_radius + 2, static_cast<int>(std::ceil(std::max(8.0f, nominal_radius * 2.5f))));
+
+    std::vector<cv::Vec3f> circles;
+    cv::HoughCircles(gray, circles, cv::HOUGH_GRADIENT, 1.2,
+                     std::max(12.0, static_cast<double>(max_dim) * 0.04), 100.0, 25.0, min_radius,
+                     max_radius);
+    if (circles.size() < 4) {
+        throw InputError("Failed to detect calibration board fiducial holes");
+    }
+
+    struct Candidate {
+        cv::Point2f center;
+        float radius = 0.0f;
+        float score  = 0.0f;
+    };
+
+    const cv::Point2f image_center(static_cast<float>(bgr.cols) * 0.5f,
+                                   static_cast<float>(bgr.rows) * 0.5f);
+    std::vector<Candidate> candidates;
+    candidates.reserve(circles.size());
+    for (const auto& c : circles) {
+        Candidate candidate;
+        candidate.center = cv::Point2f(c[0], c[1]);
+        candidate.radius = c[2];
+        candidate.score  = Distance(candidate.center, image_center);
+        if (nominal_radius > 1.0f) {
+            candidate.score -= std::abs(candidate.radius - nominal_radius) * 4.0f;
+        }
+        candidates.push_back(candidate);
+    }
+    std::sort(candidates.begin(), candidates.end(),
+              [](const Candidate& a, const Candidate& b) { return a.score > b.score; });
+    if (candidates.size() > 120) { candidates.resize(120); }
+
+    const double image_area = static_cast<double>(bgr.cols) * static_cast<double>(bgr.rows);
+    const double expected_aspect =
+        geom.board_h > 0 ? static_cast<double>(geom.board_w) / static_cast<double>(geom.board_h)
+                         : 1.0;
+
+    double best_score = -1.0;
+    std::vector<cv::Point2f> best_quad;
+    const int n = static_cast<int>(candidates.size());
+    for (int a = 0; a < n; ++a) {
+        for (int b = a + 1; b < n; ++b) {
+            for (int c = b + 1; c < n; ++c) {
+                for (int d = c + 1; d < n; ++d) {
+                    std::vector<cv::Point2f> quad = OrderByImagePosition({
+                        candidates[static_cast<size_t>(a)].center,
+                        candidates[static_cast<size_t>(b)].center,
+                        candidates[static_cast<size_t>(c)].center,
+                        candidates[static_cast<size_t>(d)].center,
+                    });
+
+                    bool unique = true;
+                    for (int i = 0; i < 4; ++i) {
+                        for (int j = i + 1; j < 4; ++j) {
+                            if (Distance(quad[static_cast<size_t>(i)],
+                                         quad[static_cast<size_t>(j)]) < 20.0f) {
+                                unique = false;
+                            }
+                        }
+                    }
+                    if (!unique) { continue; }
+
+                    const float top      = Distance(quad[0], quad[1]);
+                    const float right    = Distance(quad[1], quad[2]);
+                    const float bottom   = Distance(quad[3], quad[2]);
+                    const float left     = Distance(quad[0], quad[3]);
+                    const float min_side = std::min({top, right, bottom, left});
+                    if (min_side < static_cast<float>(std::min(bgr.cols, bgr.rows)) * 0.20f) {
+                        continue;
+                    }
+
+                    const double area = std::abs(cv::contourArea(quad));
+                    if (area < image_area * 0.12) { continue; }
+
+                    const double image_avg_w    = (static_cast<double>(top) + bottom) * 0.5;
+                    const double image_avg_h    = (static_cast<double>(left) + right) * 0.5;
+                    const double rectangularity = (image_avg_w > 1e-3 && image_avg_h > 1e-3)
+                                                      ? area / (image_avg_w * image_avg_h)
+                                                      : 0.0;
+                    if (rectangularity < 0.45) { continue; }
+
+                    const double shape_score = area * std::min(1.0, rectangularity);
+                    for (int offset = 0; offset < 4; ++offset) {
+                        std::vector<cv::Point2f> oriented_quad = RotateCornerOrder(quad, offset);
+                        const double aspect_penalty =
+                            AspectPenaltyForCanonicalOrder(oriented_quad, expected_aspect);
+                        const double score = shape_score / (1.0 + aspect_penalty);
+                        if (score > best_score) {
+                            best_score = score;
+                            best_quad  = std::move(oriented_quad);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (best_quad.size() != 4) {
+        throw InputError("Failed to infer calibration board corners from fiducial holes");
+    }
+
+    std::vector<cv::Point2f> board_corners = {
+        cv::Point2f(0.0f, 0.0f),
+        cv::Point2f(static_cast<float>(geom.board_w - 1), 0.0f),
+        cv::Point2f(static_cast<float>(geom.board_w - 1), static_cast<float>(geom.board_h - 1)),
+        cv::Point2f(0.0f, static_cast<float>(geom.board_h - 1)),
+    };
+    cv::Mat H_main_to_img = cv::getPerspectiveTransform(geom.canonical_main, best_quad);
+    std::vector<cv::Point2f> inferred_board_corners;
+    cv::perspectiveTransform(board_corners, inferred_board_corners, H_main_to_img);
+
+    spdlog::info(
+        "Coarse board outline fallback: inferred board corners from global fiducial holes");
+    return inferred_board_corners;
+}
+
 static std::vector<cv::Point2f> DetectFiducials(const cv::Mat& bgr, const BoardGeometry& geom) {
-    double coarse_scale                     = 1.0;
-    std::vector<cv::Point2f> coarse_corners = CoarseLocateBoard(bgr, coarse_scale);
+    double coarse_scale = 1.0;
+    std::vector<cv::Point2f> coarse_corners;
+    try {
+        coarse_corners = CoarseLocateBoard(bgr, coarse_scale);
+    } catch (const InputError& e) {
+        spdlog::warn("Coarse board outline locate failed: {}; trying fiducial-hole fallback",
+                     e.what());
+        coarse_corners = InferBoardCornersFromGlobalFiducials(bgr, geom);
+    }
 
     std::vector<cv::Point2f> board_corners = {
         cv::Point2f(0.0f, 0.0f),

--- a/web/backend/src/application/calibration_service.cpp
+++ b/web/backend/src/application/calibration_service.cpp
@@ -294,6 +294,7 @@ ServiceResult CalibrationService::LocateBoard(const std::vector<uint8_t>& image,
         out["image_height"] = result.image_height;
         return ServiceResult::Success(200, std::move(out));
     } catch (const std::exception& e) {
+        spdlog::warn("LocateBoard failed: {}", e.what());
         return ServiceResult::Error(422, "locate_failed", e.what());
     }
 }


### PR DESCRIPTION
## 变更类型

- [ ] 新功能 (feature)
- [x] 缺陷修复 (bugfix)
- [ ] 重构 / 性能优化 (refactor / perf)
- [ ] 构建 / 部署 / CI (build / deploy / ci)
- [ ] 文档 (docs)
- [ ] 其他:

## 变更说明

### 问题背景

校准板自动定位当前先依赖整块板子的外轮廓。实际拍摄时，如果白色校准板放在浅色桌面、木纹背景或其他低对比环境里，Canny/轮廓检测很容易找不到可靠的板外框。此时照片里四个主定位孔和方向小孔仍然清晰可见，但流程会提前返回：

```text
Failed to locate calibration board outline in the image...
```

结果是用户明明拍到了完整校准板，也必须重新拍摄或手动拖拽角点，降低了 ColorDB 构建链路的成功率。

Closes #

### 解决方案

本次修复保留原有外轮廓定位作为主路径，只在外轮廓粗定位抛出 `InputError` 时启用兜底路径：

1. 全图转灰度并做中值滤波，降低噪声和纹理干扰。
2. 使用 `HoughCircles` 在全图搜索圆形候选，半径范围根据 meta 中的定位孔尺寸和图像尺寸估算。
3. 对候选圆按“远离图像中心”和“接近预期半径”排序，保留较可信候选，避免组合数量失控。
4. 枚举候选圆四元组，按图像位置组成四边形，并过滤重复点、过小边长、过小面积和低矩形度候选。
5. 根据 meta 中校准板的宽高比，对四种旋转顺序打分，选择最符合真实板几何的主定位孔组合。
6. 用 meta 里的 canonical fiducial 坐标和检测到的四个主孔计算透视变换，反推出板外角。
7. 后续仍进入原有精细定位流程：在预测 ROI 内重新检测四个主孔和方向小孔，由方向小孔决定返回角点顺序。

这样做的好处是：

- 不放宽原有外轮廓阈值，避免把背景矩形误判为校准板。
- 不改变 `/api/v1/calibration/locate` 的响应结构、错误码或前端交互。
- 兜底路径只在主路径失败时运行，对正常高对比照片的性能和行为影响很小。
- 返回角点仍由原有方向小孔逻辑统一排序，保证第 1 个角点贴近方向小孔，并按物理板顺时针排列。

后端同时在 `LocateBoard` 捕获异常时写入 warning 日志，线上定位失败时可以从服务日志直接看到真实失败原因，而不只依赖前端错误提示。

### 影响范围

- [x] `core/` — C++ 核心算法（校准板定位）
- [ ] `apps/` — CLI 工具
- [x] `web/backend/` — Drogon HTTP API（仅增加失败日志，不改变接口契约）
- [ ] `web/frontend/` — Vue3 前端
- [ ] `modeling/` — Python 建模与拟合流水线
- [ ] `docs/` — 文档
- [ ] 构建 / CI / 部署脚本

## 验证记录

- [x] 已完成最小构建验证（`cmake --build` 或对应模块构建通过）
- [x] 已验证关键功能路径（命令、接口或页面）
- [ ] 已通过相关测试（单元测试 / 集成测试）

<details>
<summary>验证详情</summary>

```bash
cmake --build build --target chromaprint3d chromaprint3d_backend -j"$(nproc)"
```

结果：通过，重新编译并链接 `core/libchromaprint3d.a` 和 `web/backend/libchromaprint3d_backend.a`。

```bash
./build/bin/build_colordb \
  --image .omx/artifacts/upload-photo-from-screenshot.png \
  --meta .omx/artifacts/board-meta.json \
  --out /tmp/chromaprint3d_pr_colordb.json
```

验证样本是低对比背景导致外轮廓定位失败的复现图。运行日志显示：

```text
Coarse board outline locate failed: ... trying fiducial-hole fallback
Coarse board outline fallback: inferred board corners from global fiducial holes
ColorDB saved: name=CalibrationBoard_4ch, entries=1024
```

并验证输出：

```bash
jq '.entries | length' /tmp/chromaprint3d_pr_colordb.json
# 1024
```

```bash
git diff --check
```

结果：通过，无空白错误。

</details>

## 代码质量检查

- [x] C++ 修改文件已执行 `clang-format-18 -i <modified-files>`
- [x] 未引入重复工具函数（复用现有 OpenCV / meta 几何流程）
- [x] `.cpp` 文件结构清晰（工具函数 -> 核心流程 -> 对外接口）
- [x] 无平台相关硬编码（路径、系统 API、脚本依赖）

说明：已安装并执行 `clang-format-18 -i core/src/calib/loc.cpp web/backend/src/application/calibration_service.cpp`，并通过 `clang-format-18 --dry-run --Werror` 与 `git diff --check`。

## 文档与协作同步

- [ ] 若涉及 API / 参数 / 错误码变化 -> 已同步 `README.md`、`docs/development.md`、`docs/agents/web/backend/`
- [ ] 若涉及 CLI 参数或默认值变化 -> 已同步 `README.md`、`docs/development.md`、`docs/agents/apps/`
- [ ] 若涉及构建 / 部署流程变化 -> 已同步 `README.md`、`docs/deployment.md`
- [ ] 若涉及前端用户可见行为变化 -> 已同步 `README.md`、`docs/agents/web/frontend/`
- [ ] 若涉及机型 / 预设 / `data/preset_bases/` 变化 -> 已同步 `docs/agents/tasks/extend_machine_support.md`、`docs/development.md`
- [ ] 若模块入口或职责边界变化 -> 已更新 `AGENTS.md` 与对应模块索引
- [ ] 若属于高频改动场景 -> 已更新对应任务手册 `docs/agents/tasks/`
- [x] 以上均不涉及

## 端到端联动检查

<details>
<summary>联动检查</summary>

- [x] 已画出完整链路：上传照片 + meta -> `/api/v1/calibration/locate` / CLI ColorDB 构建 -> 核心定位 -> 颜色区域矫正 -> ColorDB 输出
- [x] 已全量检索同类路径（定位与 ColorDB 构建共用 `DetectFiducials`）
- [x] `content-type`、文件名、错误码、fallback 策略已对齐
- [x] 部署约束已校验（无新增可写路径、无新增依赖）
- [x] 已覆盖至少 1 条主链路 + 1 条分支链路的端到端验证

**覆盖链路：**

- `build_colordb` CLI 使用复现图片和 meta 成功生成 1024 条 ColorDB entries。
- 复现样本明确触发“外轮廓失败 -> fiducial-hole fallback -> 精细孔定位 -> ColorDB 输出”分支。

**未覆盖风险：**

- 当前构建目录 `ctest -N` 显示 0 个注册测试，未能运行自动化单元测试。
- 还缺少更大规模真实照片集验证，尤其是强反光、极端透视、部分遮挡、复杂圆形背景干扰等场景。

</details>

## 风险与回滚

**风险点：**

- 低对比失败场景下会额外执行一次全图 Hough 圆检测，单次定位耗时可能增加。
- 如果背景存在大量圆形图案，兜底路径可能选中错误候选；为降低风险，代码加入了面积、边长、矩形度、半径、宽高比等过滤，并且后续仍要通过主孔与方向小孔的精细检测。

**回滚方案：**

回退本次提交即可。主路径和 API 契约没有迁移或数据格式变更。

## 截图 / 演示

无 UI 变更。
