### PR TITLE
fix(recipe-editor): 预览图改用 object-fit: fill，修复大图点击选区坐标偏移

### DIFF
--- a/web/frontend/src/components/common/ZoomableImageViewport.vue
+++ b/web/frontend/src/components/common/ZoomableImageViewport.vue
@@ -96,7 +96,7 @@ const imgStyle = computed(() => {
   if (useExplicitFit.value) {
     base.width = `${props.contentWidth}px`
     base.height = `${props.contentHeight}px`
-    base.objectFit = 'none'
+    base.objectFit = 'fill'
   }
   return base
 })


### PR DESCRIPTION
## 变更类型

- [ ] 新功能 (feature)
- [x] 缺陷修复 (bugfix)
- [ ] 重构 / 性能优化 (refactor / perf)
- [ ] 构建 / 部署 / CI (build / deploy / ci)
- [ ] 文档 (docs)
- [ ] 其他:

## 变更说明

### 问题背景

`ResizeForPreview` 在光栅 recipe map 最长边超过 `kPreviewMaxDim (2048)` 时会下采样预览 PNG，使其分辨率小于 `summary.width/height`。而 `ZoomableImageViewport` 的 `<img>` 盒子按 `contentWidth/contentHeight`（= summary 全分辨率）设置，却使用 `object-fit: none`，导致预览图按自身较小尺寸居中绘制，与叠加层 canvas、点击坐标映射（都基于 summary 全分辨率坐标系）错位。

表现：当输出像素长边超过 2048 时，在配方编辑器点击色块，高亮选区与实际位置偏移。

复现：`p0.png`（804×1200），目标高度设为 240mm（参数面板提示“输出约 1608×2400 像素”），长边 2400 > 2048，进入配方编辑器点击色块即偏移；目标高度 ≤ ~205mm（输出 ≤ 2048px）时预览图不被下采样，不触发。

### 解决方案

将 `imgStyle` 中的 `object-fit: none` 改为 `fill`，让预览图铺满 summary 坐标盒子，从而与叠加层和点击映射对齐。

与 #83 的关系：
- 同一根因（预览图分辨率与 summary 坐标系不一致 + `object-fit: none` 按图片自身尺寸绘制）。
- #83 只修了**上采样**方向（小图 `min_dim` 默认 512 造成放大的回归）。
- 本 PR 修**下采样**方向（最长边 > 2048 被缩小），该路径 #83 未覆盖。
- `ResizeForPreview` 为等比缩放，盒子长宽比与预览图一致，`fill` 不产生可见变形；未触发 resize 时 `none`/`fill` 效果相同，无回归。两个 resize 方向（含 #83 的上采样场景）一并覆盖。

### 影响范围

- [ ] `core/` — C++ 核心算法（图像处理、配方匹配、体素/网格、3MF）
- [ ] `apps/` — CLI 工具
- [ ] `web/backend/` — Drogon HTTP API
- [x] `web/frontend/` — Vue3 前端
- [ ] `modeling/` — Python 建模与拟合流水线
- [ ] `docs/` — 文档
- [ ] 构建 / CI / 部署脚本

## 验证记录

- [x] 已完成最小构建验证（前端 `npm run build`：typecheck + vite build 通过）
- [x] 已验证关键功能路径（配方编辑器用 >2048px 光栅图点击选区，修复后高亮与实际位置一致，见下方截图）
- [ ] 已通过相关测试（本次无针对性单测）

<details>
<summary>验证详情（可选，展开填写）</summary>

前端构建（electron 目标）通过：

    cd web/frontend
    CHROMAPRINT3D_FRONTEND_TARGET=electron npm run build
    # vue-tsc typecheck 通过；vite build 成功，无错误

手动复现与验证：`p0.png` 804×1200，目标高度 240mm（输出约 1608×2400 像素）。修复前点击色块选区偏移，修复后选区与点击位置一致。

</details>

## 代码质量检查

- [x] C++ 修改文件已执行 `clang-format -i <modified-files>`（本次无 C++ 改动，N/A）
- [x] 未引入重复工具函数（仅改一处样式值，无新增函数）
- [x] `.cpp` 文件结构清晰（本次无 `.cpp` 改动，N/A）
- [x] 无平台相关硬编码（路径、系统 API、脚本依赖）

## 文档与协作同步

- [ ] 若涉及 API / 参数 / 错误码变化 → 已同步 `README.md`、`docs/development.md`、`docs/agents/web/backend/`
- [ ] 若涉及 CLI 参数或默认值变化 → 已同步 `README.md`、`docs/development.md`、`docs/agents/apps/`
- [ ] 若涉及构建 / 部署流程变化 → 已同步 `README.md`、`docs/deployment.md`
- [ ] 若涉及前端用户可见行为变化 → 已同步 `README.md`、`docs/agents/web/frontend/`
- [ ] 若涉及机型 / 预设 / `data/preset_bases/` 变化 → 已同步 `docs/agents/tasks/extend_machine_support.md`、`docs/development.md`
- [ ] 若模块入口或职责边界变化 → 已更新 `AGENTS.md` 与对应模块索引
- [ ] 若属于高频改动场景 → 已更新对应任务手册 `docs/agents/tasks/`
- [x] 以上均不涉及（纯缺陷修复，恢复既有正确行为，无 API/CLI/文档化行为变化）

## 端到端联动检查

<details>
<summary>联动检查（如不涉及可跳过，展开填写）</summary>

本次为纯前端渲染样式修复，不涉及 API / runtime / cache / 下载链路 / 文件落盘，故不适用。

</details>

## 风险与回滚

**风险点：** 低。改动仅影响配方编辑器预览图的 CSS `object-fit`。预览图未触发 resize 时 `fill` 与 `none` 效果一致；触发时因等比缩放，`fill` 仅将预览图拉伸铺满原本就等比的盒子，无可见变形，且与坐标系对齐。

**回滚方案：** 回退本次提交即可（单文件一行改动）。

## 截图 / 演示

修复前：
<img width="948" height="837" alt="Snipaste_2026-09-06_06-12-36" src="https://github.com/user-attachments/assets/1613e636-8d29-4b9e-bc1a-110442830d36" />
修复后：
<img width="929" height="949" alt="Snipaste_2026-09-06_06-13-52" src="https://github.com/user-attachments/assets/6c8b07ce-d9e9-4841-89df-6f0dd19c9a0f" />